### PR TITLE
docs: make the quickstart platform-aware (add Proxmox path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ not a feature toggle, and it's the project's one hard rule.
 
 ## Quickstart (5 minutes)
 
-Requires Docker with Compose on the machine that will host the dashboard.
+Trove is a **server** (the dashboard + API) plus one **agent per platform** you
+want to watch. The server is the same everywhere; only the agent differs. Start
+with the compose file that matches what you're watching — each one stands up the
+server *and* the right agent together. Requires Docker with Compose on the
+machine that will host the dashboard.
+
+**Docker host** — server + an agent watching this box's containers:
 
 ```sh
 mkdir trove && cd trove
@@ -51,9 +57,28 @@ export TROVE_TOKEN=trove_$(openssl rand -hex 24)
 docker compose up -d
 ```
 
-Open <http://localhost:8080>. This host's containers appear within ~30
-seconds. That's the whole install: a server plus a Docker agent watching the
-same machine.
+**Proxmox VE** — server + an agent watching your cluster's VMs and LXCs. First
+create a read-only API token (the [Proxmox guide](docs/agents/proxmox.md) has
+the exact `pveum` commands), then:
+
+```sh
+mkdir trove && cd trove
+curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker-compose.proxmox.yml
+
+export TROVE_TOKEN=trove_$(openssl rand -hex 24)
+export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
+export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+docker compose -f docker-compose.proxmox.yml up -d
+```
+
+**Kubernetes** or **bare-metal Linux** — the agent doesn't run in Compose
+(the K8s agent runs in-cluster as a Deployment; the bare-metal agent runs as a
+systemd unit). Stand up the server with either compose file above, then deploy
+the agent from the [Kubernetes](docs/agents/kubernetes.md) or
+[bare-metal](docs/agents/local.md) guide.
+
+Open <http://localhost:8080>. Your services appear within ~30 seconds. If an
+agent doesn't show up, watch it connect with `docker compose logs -f agent`.
 
 > ⚠️ The dashboard has **no authentication yet** — keep it on a trusted
 > network (LAN/VPN/tailnet) or behind an authenticating reverse proxy. See

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,17 @@
-# CONTRIBUTOR dev stack: builds server + agent from this checkout.
+# ==========================================================================
+#  CONTRIBUTOR DEV STACK — builds from source. This is NOT how you run Trove.
 #
-# Just want to RUN Trove? Use examples/docker-compose.yml instead — it pulls
-# the published images and needs no clone or toolchain.
+#  Just want to RUN Trove?  Use the published-image quickstart compose files,
+#  which need no clone, no build, no Go toolchain (see the README Quickstart):
+#      examples/docker-compose.yml           -> Docker host
+#      examples/docker-compose.proxmox.yml   -> Proxmox cluster
+#
+#  This file exists only for hacking on Trove itself. It builds the DOCKER
+#  agent (Dockerfile.agent); pointing its env at another platform (Proxmox/K8s)
+#  will NOT work — those agents are separate binaries/images. To watch Proxmox
+#  or Kubernetes, use the quickstart above or the per-platform guides in
+#  docs/agents/ — don't edit this dev stack.
+# ==========================================================================
 #
 # `docker compose up --build` and open http://localhost:8080.
 #

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -53,6 +53,27 @@ docker run -d --name trove-agent-proxmox --restart unless-stopped \
 `TROVE_PROXMOX_INSECURE=true` skips TLS verification — needed for Proxmox's
 default self-signed certificate. Drop it if your PVE API has a real cert.
 
+### Or with Docker Compose (server + agent together)
+
+If you don't already have a Trove server running, the quickstart compose file
+stands up both at once — no cloning or building:
+
+```sh
+curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker-compose.proxmox.yml
+
+export TROVE_TOKEN=trove_$(openssl rand -hex 24)
+export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
+export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+docker compose -f docker-compose.proxmox.yml up -d
+docker compose -f docker-compose.proxmox.yml logs -f agent   # watch it connect
+```
+
+> The agent image is `trove-agent-proxmox` — **not** `trove-agent-docker`. The
+> Docker agent ignores the `TROVE_PROXMOX_*` variables and reads the Docker
+> socket instead, so it will connect and look healthy while never contacting
+> Proxmox. If you're adapting your own compose file, make sure the agent uses
+> the Proxmox image (and it needs no `/var/run/docker.sock` mount).
+
 ## Configuration
 
 | Variable                 | Default      | Purpose                                          |

--- a/examples/docker-compose.proxmox.yml
+++ b/examples/docker-compose.proxmox.yml
@@ -1,0 +1,52 @@
+# Trove quickstart for Proxmox — the server plus a Proxmox agent that watches
+# your PVE cluster, using the published images. No cloning or building required.
+#
+#   1. Create a read-only Proxmox API token (PVEAuditor role). See:
+#        https://github.com/techdox/trove/blob/main/docs/agents/proxmox.md
+#   2. Set a Trove token and your Proxmox connection details:
+#        export TROVE_TOKEN=trove_$(openssl rand -hex 24)
+#        export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
+#        export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+#   3. Start the stack:
+#        docker compose -f docker-compose.proxmox.yml up -d
+#   4. Open http://localhost:8080 — your VMs and LXCs appear within ~30s.
+#      Watch the agent while it connects:  docker compose logs -f agent
+#
+# To watch OTHER hosts/platforms too, mint each its own token on the server
+# and add its agent (see the per-platform guides):
+#        docker compose exec server trove-server agent create <name>
+#
+# ⚠ The dashboard has no authentication yet — keep port 8080 on a trusted
+#   network (LAN/VPN) or behind an authenticating reverse proxy.
+
+services:
+  server:
+    image: ghcr.io/techdox/trove-server:latest
+    environment:
+      TROVE_BOOTSTRAP_AGENT: "proxmox"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  export TROVE_TOKEN=trove_$(openssl rand -hex 24)}"
+    ports:
+      - "8080:8080"
+    volumes:
+      - trove-data:/data
+    restart: unless-stopped
+
+  agent:
+    # The Proxmox agent — NOT trove-agent-docker. It reads the PVE API only;
+    # it needs no Docker socket.
+    image: ghcr.io/techdox/trove-agent-proxmox:latest
+    environment:
+      TROVE_SERVER_URL: "http://server:8080"
+      TROVE_TOKEN: "${TROVE_TOKEN}"
+      TROVE_PROXMOX_URL: "${TROVE_PROXMOX_URL:?set your Proxmox API URL, e.g. https://192.168.1.10:8006}"
+      TROVE_PROXMOX_TOKEN: "${TROVE_PROXMOX_TOKEN:?set your Proxmox API token in the form USER@REALM!TOKENID=SECRET}"
+      # Proxmox ships a self-signed cert by default; "true" accepts it. Set to
+      # "false" (or remove) once your PVE API has a trusted certificate.
+      TROVE_PROXMOX_INSECURE: "true"
+    depends_on:
+      server:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  trove-data:


### PR DESCRIPTION
## Why
A homelab user following the quickstart to set up **Proxmox** hit a silent failure: they adapted the bundled compose to point at Proxmox but kept the Docker agent image. `trove-agent-docker` ignores every `TROVE_PROXMOX_*` var, reads the Docker socket, and connects looking healthy — while never once contacting Proxmox. No error, no data.

Root cause is framing: the quickstart fuses the (platform-agnostic) server with a Docker agent into one file, so non-Docker users read the Docker agent as "the agent" and try to mutate it into theirs.

## Changes
- **New `examples/docker-compose.proxmox.yml`** — server + `trove-agent-proxmox`, published images, connection vars guarded with `:?` so a missing setting fails loudly.
- **README quickstart** reframed around "the server is the same everywhere; only the agent differs," with a first-class path per platform. Docker inline, Proxmox via its compose, K8s/bare-metal pointed at their actual deploy methods (those agents don't run in Compose — K8s is in-cluster, bare-metal is systemd).
- **docs/agents/proxmox.md** — adds the compose path plus an explicit "use `trove-agent-proxmox`, not `trove-agent-docker`" warning.
- **docker-compose.yml** — louder banner that it's the contributor build-from-source dev stack, and that editing it to target other platforms won't work (this is the file the user actually grabbed).

## Verification
- `docker compose config` validates both example files and the dev stack
- Confirmed the Proxmox agent resolves to the correct image with **no** docker.sock mount
- Confirmed `:?` guards fire with helpful messages when required vars are unset
- All README internal links resolve to real files

Docs-only; no code paths touched.