### PR TITLE
fix: warn when an agent collects zero hosts

### DIFF
--- a/internal/agentkit/agentkit.go
+++ b/internal/agentkit/agentkit.go
@@ -128,6 +128,19 @@ func runOnce(ctx context.Context, envelope model.ReportAgent, c Collector, p *pu
 		log.Error("collect failed", "err", err)
 		return
 	}
+	if len(snaps) == 0 {
+		// Collect succeeded but returned nothing to report. This is almost
+		// always a misconfiguration that would otherwise fail silently — the
+		// agent connects, looks healthy, and the dashboard just stays empty.
+		// The usual cause is a platform credential that authenticates but
+		// lacks read permission (e.g. a Proxmox API token without the
+		// PVEAuditor role, where the API answers 200 with an empty list), or
+		// the agent pointed at the wrong target. Surface it loudly.
+		log.Warn("collected 0 hosts — the agent reached its platform but found nothing to report; " +
+			"this is usually a credential/permission problem (for Proxmox, a token missing the PVEAuditor role) " +
+			"or the wrong target. Nothing will appear on the dashboard until this is resolved")
+		return
+	}
 	total := 0
 	for i := range snaps {
 		report := &model.Report{Agent: envelope, Host: snaps[i].Host, Services: snaps[i].Services}

--- a/internal/agentkit/agentkit_test.go
+++ b/internal/agentkit/agentkit_test.go
@@ -1,0 +1,76 @@
+package agentkit
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+type stubCollector struct {
+	snaps []HostSnapshot
+	err   error
+}
+
+func (s stubCollector) Collect(context.Context) ([]HostSnapshot, error) {
+	return s.snaps, s.err
+}
+
+func newTestLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), &buf
+}
+
+// A collector that reaches its platform but finds nothing (e.g. a Proxmox
+// token without read permission) must warn loudly rather than silently push
+// nothing — otherwise the agent looks healthy while the dashboard stays empty.
+func TestRunOnceWarnsWhenNothingCollected(t *testing.T) {
+	log, buf := newTestLogger()
+	p := &pusher{http: http.DefaultClient, serverURL: "http://127.0.0.1:0", token: "t"}
+
+	runOnce(context.Background(), model.ReportAgent{Name: "x"}, stubCollector{snaps: nil}, p, log)
+
+	out := buf.String()
+	if !strings.Contains(out, "collected 0 hosts") {
+		t.Fatalf("expected a zero-hosts warning, got:\n%s", out)
+	}
+	if strings.Contains(out, "report pushed") {
+		t.Fatalf("must not log 'report pushed' when nothing was collected:\n%s", out)
+	}
+}
+
+// When there is at least one host, no warning fires and the report is pushed.
+func TestRunOncePushesWhenHostsPresent(t *testing.T) {
+	var pushes int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&pushes, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	log, buf := newTestLogger()
+	p := &pusher{http: srv.Client(), serverURL: srv.URL, token: "t"}
+	snaps := []HostSnapshot{{
+		Host:     model.ReportHost{Hostname: "h1"},
+		Services: []model.ReportService{{ExternalID: "c1", Name: "svc", State: "running"}},
+	}}
+
+	runOnce(context.Background(), model.ReportAgent{Name: "x"}, stubCollector{snaps: snaps}, p, log)
+
+	out := buf.String()
+	if strings.Contains(out, "collected 0 hosts") {
+		t.Fatalf("unexpected zero-hosts warning when a host was present:\n%s", out)
+	}
+	if !strings.Contains(out, "report pushed") {
+		t.Fatalf("expected a 'report pushed' log:\n%s", out)
+	}
+	if n := atomic.LoadInt32(&pushes); n != 1 {
+		t.Fatalf("expected exactly 1 push to the server, got %d", n)
+	}
+}


### PR DESCRIPTION
## Why
The most common way a fresh Trove install fails is *silently*: an agent authenticates to its platform but gets nothing back, logs `report pushed hosts=0 services=0` at info, and the dashboard just stays empty with no clue why. The canonical case (found while reviewing a real Proxmox onboarding failure): a Proxmox API token that authenticates but lacks the `PVEAuditor` role — Proxmox answers `200` with an empty list, so `Collect()` succeeds with zero nodes.

## Change
`runOnce` now emits a `WARN` when a successful collect returns zero hosts, naming the likely causes (permission-less credential / wrong target). 

Chosen condition is `len(snaps) == 0`, which is unambiguous:
- Proxmox builds one snapshot per node, so a permission-less empty `/nodes` yields zero snapshots → warns.
- The Docker collector always returns exactly one host snapshot, so a legitimately idle host (0 containers) is 1 host / 0 services → does **not** warn (no false positive).

## Tests
- `TestRunOnceWarnsWhenNothingCollected` — zero hosts → warning fires, no "report pushed".
- `TestRunOncePushesWhenHostsPresent` — a host present → no warning, report is pushed to the server exactly once.

Part of the docs/onboarding hardening pass; the doc-side fixes follow in a separate PR.