### PR TITLE
fix: bundle systemd unit in the trove-server release archive

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,7 +52,10 @@ archives:
     ids: [trove-server]
     name_template: "trove-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats: [tar.gz]
-    files: [LICENSE, README.md]
+    # Ship the systemd unit alongside the binary so the bare-metal install in
+    # docs/README ("cp deploy/systemd/trove-server.service ...") works from the
+    # extracted archive — same as the trove-agent-local archive below.
+    files: [LICENSE, README.md, deploy/systemd/trove-server.service]
   - id: trove-agent-docker
     ids: [trove-agent-docker]
     name_template: "trove-agent-docker_{{ .Version }}_{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
## Why
The bare-metal server install (README "Server install options" and the unit's own header) tells users to `sudo cp deploy/systemd/trove-server.service /etc/systemd/system/` from the extracted release archive — but the `trove-server` archive only packed `[LICENSE, README.md]`, so that file wasn't in it and the step failed with "No such file or directory." The all-binary server path was broken as written.

The `trove-agent-local` archive already bundles its unit; this brings the server archive to parity.

## Change
Add `deploy/systemd/trove-server.service` to the `trove-server` archive's `files:` list in `.goreleaser.yaml`.

## Verification
- YAML parses; the server archive `files:` now lists the unit.
- Referenced file exists at `deploy/systemd/trove-server.service`.
- Full effect (the file appearing in the tarball) is validated by goreleaser at the next release; CI doesn't run goreleaser.