### PR TITLE
docs: onboarding overhaul — kill the silent-failure traps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ machine that will host the dashboard.
 mkdir trove && cd trove
 curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker-compose.yml
 
-export TROVE_TOKEN=trove_$(openssl rand -hex 24)
+# Save the agent's token to .env — Compose loads it automatically and it
+# survives restarts and upgrades. (Don't just `export` it: a new shell would
+# lose it, and re-running with a fresh token silently breaks the agent.)
+echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
 docker compose up -d
 ```
 
@@ -65,20 +68,33 @@ the exact `pveum` commands), then:
 mkdir trove && cd trove
 curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker-compose.proxmox.yml
 
-export TROVE_TOKEN=trove_$(openssl rand -hex 24)
-export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
-export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+# Save settings to .env (Compose loads it automatically; it persists across
+# restarts). TROVE_TOKEN is Trove's own agent token; TROVE_PROXMOX_TOKEN is
+# your Proxmox API token — two different credentials.
+{
+  echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
+  echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
+  echo "TROVE_PROXMOX_TOKEN=trove@pve!trove-agent=YOUR-TOKEN-SECRET"
+} > .env
+# now edit .env to fill in your real PVE host and API token, then:
 docker compose -f docker-compose.proxmox.yml up -d
 ```
 
 **Kubernetes** or **bare-metal Linux** — the agent doesn't run in Compose
 (the K8s agent runs in-cluster as a Deployment; the bare-metal agent runs as a
-systemd unit). Stand up the server with either compose file above, then deploy
-the agent from the [Kubernetes](docs/agents/kubernetes.md) or
-[bare-metal](docs/agents/local.md) guide.
+systemd unit). Stand up just the server —
+[`docker-compose.server.yml`](examples/docker-compose.server.yml) runs the
+server with no bundled agent — then deploy the agent from the
+[Kubernetes](docs/agents/kubernetes.md) or [bare-metal](docs/agents/local.md)
+guide.
+
+The compose files auto-register this first agent from `TROVE_TOKEN` (via
+`TROVE_BOOTSTRAP_*`), so you don't run `agent create` for it — every
+*additional* host gets its own token ([below](#adding-more-hosts-and-platforms)).
 
 Open <http://localhost:8080>. Your services appear within ~30 seconds. If an
-agent doesn't show up, watch it connect with `docker compose logs -f agent`.
+agent doesn't show up, watch it connect with `docker compose logs -f agent`
+(add `-f docker-compose.proxmox.yml` if you used the Proxmox file).
 
 > ⚠️ The dashboard has **no authentication yet** — keep it on a trusted
 > network (LAN/VPN/tailnet) or behind an authenticating reverse proxy. See
@@ -86,11 +102,23 @@ agent doesn't show up, watch it connect with `docker compose logs -f agent`.
 
 ## Adding more hosts and platforms
 
-Every agent needs its own token, minted on the server:
+Each host or platform you watch runs its **own agent** — a separate process or
+container, with its own image and its own token. You don't repoint an existing
+agent at a new platform; you run another one. (Setting `TROVE_PROXMOX_*` on the
+Docker agent, for example, does nothing — it's a different agent image; it will
+connect, look healthy, and never report your Proxmox guests.)
+
+Mint a token per agent, on the server:
 
 ```sh
+# server running via Docker Compose (the quickstart):
 docker compose exec server trove-server agent create <name>
-# e.g.: agent create docker-nas, agent create k8s-homelab, agent create proxmox
+
+# server running as a bare-metal binary — point at the SAME database the server
+# uses, or the token lands in a throwaway ./trove.db and the agent can't auth
+# (the systemd unit sets TROVE_DB=/var/lib/trove/trove.db):
+sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create <name>
+# e.g. <name> = docker-nas, k8s-homelab, proxmox
 ```
 
 Then follow the guide for the platform:
@@ -124,25 +152,42 @@ Static binaries for everything (including the bare-metal agent) are on the
                   └─────────────────────────────┘
 ```
 
+- **Agents, hosts, services**: an *agent* is one connection to the server (one
+  token). It reports one or more *hosts* — a Docker host, each Proxmox node, a
+  whole cluster — and each host has *services* (containers, VMs/LXCs, pods,
+  systemd units). A Docker agent reports one host; one Proxmox agent reports
+  every node in its cluster. On the dashboard, services are grouped by host.
 - **Push model**: agents POST full-state snapshots on an interval. The server
   never reaches into your infrastructure — homelab/NAT friendly.
 - **Heartbeats**: miss 3 intervals → agent (and its services) marked *stale*;
   miss 10 → *offline*. Thresholds scale with each agent's own interval.
 - **Full-state reports** are idempotent and tolerate lost pushes. Services
-  that disappear are soft-removed and pruned after 24h.
+  that disappear are soft-removed and pruned after 24h (configurable,
+  `TROVE_REMOVED_RETENTION`).
 
 ## Server install options
 
 **Docker Compose** — the quickstart above; data lives in the `trove-data` volume.
 
-**Bare metal** — grab `trove-server` from a release archive and use
-[deploy/systemd/trove-server.service](deploy/systemd/trove-server.service):
+**Bare metal** — download the `trove-server` archive for your arch from the
+[latest release](https://github.com/techdox/trove/releases/latest) (the
+`trove-server.service` unit is bundled inside it):
 
 ```sh
+# pick the URL for your arch off the releases page, e.g.:
+VERSION=0.4.0        # the release you're installing
+curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
+tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
+
 sudo install -m 0755 trove-server /usr/local/bin/
 sudo cp deploy/systemd/trove-server.service /etc/systemd/system/
 sudo systemctl enable --now trove-server
 ```
+
+The server listens on `:8080` and stores its database at
+`/var/lib/trove/trove.db` (the unit creates that directory via
+`StateDirectory`). Mint agent tokens against that same DB — see
+[Adding more hosts](#adding-more-hosts-and-platforms).
 
 **Go install** (needs Go 1.26+):
 
@@ -162,7 +207,7 @@ go install github.com/techdox/trove/cmd/trove-server@latest
 | `TROVE_FRESHNESS_INTERVAL` | `5m`       | How often to scan for images due a check.                              |
 | `TROVE_FRESHNESS_TTL`      | `6h`       | How long a resolved digest counts as fresh before rechecking.          |
 | `TROVE_REGISTRY_AUTHS`     | _(unset)_  | Credentials for private registries — see below.                        |
-| `TROVE_EVENT_RETENTION`    | `720h`     | How long events (activity feed / alert stream) are kept.               |
+| `TROVE_EVENT_RETENTION`    | `720h` (30d) | How long events (activity feed / alert stream) are kept.             |
 | `TROVE_REMOVED_RETENTION`  | `24h`      | How long removed services linger before being purged.                  |
 | `TROVE_ALERT_*` / `TROVE_SMTP_*` | _(unset)_ | Notification channels & SMTP — see [docs/alerts.md](docs/alerts.md). |
 | `TROVE_DIGEST`             | `daily@08:00`* | Digest schedule; *only takes effect once `TROVE_SMTP_*` is set — see [docs/alerts.md](docs/alerts.md). |
@@ -197,8 +242,13 @@ each [agent guide](docs/agents/).
 trove-server agent create <name>    # mint a token (shown once, stored hashed)
 trove-server agent list             # names, platform, status, last seen
 trove-server agent delete <name>    # remove an agent and all its data
-trove-server alert test             # push a test notification through configured channels
+trove-server alert test             # test every configured channel + send a sample digest
 ```
+
+On a Docker Compose server, run these inside the container, e.g.
+`docker compose exec server trove-server agent create <name>`. On a bare-metal
+server, set `TROVE_DB` to the server's database path (see
+[Adding more hosts](#adding-more-hosts-and-platforms)).
 
 ## API
 

--- a/deploy/systemd/trove-server.service
+++ b/deploy/systemd/trove-server.service
@@ -2,9 +2,11 @@
 #
 # Install:
 #   sudo cp trove-server /usr/local/bin/            # from the release archive
-#   sudo mkdir -p /var/lib/trove
 #   sudo cp deploy/systemd/trove-server.service /etc/systemd/system/
 #   sudo systemctl enable --now trove-server
+#
+# StateDirectory=trove creates and owns /var/lib/trove automatically — no
+# manual mkdir needed (and a manual one can mis-own it against DynamicUser).
 #
 # Override settings via a drop-in (systemctl edit trove-server) or
 # /etc/trove-server.env. The dashboard has no auth — bind to a trusted

--- a/docs/agents/docker.md
+++ b/docs/agents/docker.md
@@ -22,14 +22,16 @@ Copy the `trove_...` token — it is shown once.
 
 ```sh
 docker run -d --name trove-agent --restart unless-stopped \
-  -e TROVE_SERVER_URL=http://trove.lan:8080 \
+  -e TROVE_SERVER_URL=http://YOUR-SERVER:8080 \
   -e TROVE_TOKEN=trove_xxxxxxxx \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   ghcr.io/techdox/trove-agent-docker:latest
 ```
 
-The host and its containers appear on the dashboard within one push interval
-(30s by default).
+Replace `YOUR-SERVER` with your Trove server's address as reachable from this
+host (a LAN IP or hostname; `localhost` only if the server runs on this same
+box). The host and its containers appear on the dashboard within one push
+interval (30s by default).
 
 ## Configuration
 

--- a/docs/agents/kubernetes.md
+++ b/docs/agents/kubernetes.md
@@ -6,10 +6,22 @@ dashboard). Read-only: the agent's RBAC grants only `get`/`list`/`watch`.
 
 Run **one agent per cluster**. It runs in-cluster as a Deployment.
 
+**Where things run:** you need a Trove **server** running somewhere first (see
+the [Quickstart](../../README.md#quickstart-5-minutes)) — typically *outside*
+the cluster, on your LAN. The agent runs *inside* the cluster and pushes out to
+that server; nothing ever reaches into the cluster. If you only have a cluster
+and no server yet, stand one up with
+[`examples/docker-compose.server.yml`](../../examples/docker-compose.server.yml)
+on a box on your network.
+
 ## 1. Mint a token
 
+On the server (not in the cluster):
+
 ```sh
-trove-server agent create k8s-homelab
+# Docker Compose server:
+docker compose exec server trove-server agent create k8s-homelab
+# bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create k8s-homelab
 ```
 
 ## 2. Create the namespace + token secret
@@ -17,7 +29,7 @@ trove-server agent create k8s-homelab
 ```sh
 kubectl create namespace trove
 kubectl -n trove create secret generic trove-agent \
-  --from-literal=token='trove_xxxxxxxx'
+  --from-literal=token='trove_xxxxxxxx'   # the token printed by step 1
 ```
 
 ## 3. Apply the manifest
@@ -25,8 +37,11 @@ kubectl -n trove create secret generic trove-agent \
 Download [`deploy/kubernetes/trove-agent.yaml`](../../deploy/kubernetes/trove-agent.yaml),
 set two values in the Deployment's env:
 
-- `TROVE_SERVER_URL` — where your Trove server lives (the agent pushes out;
-  the server never needs to reach into the cluster)
+- `TROVE_SERVER_URL` — where your Trove server lives, as reachable **from your
+  cluster nodes**: a LAN IP or DNS name like `http://192.168.1.50:8080`. **Not**
+  `localhost` (inside a pod that's the pod itself) and **not** the Compose alias
+  `http://server:8080` (that only resolves inside Compose). Getting this wrong
+  is the #1 reason the cluster never appears — with no error.
 - `TROVE_CLUSTER_NAME` — the host name this cluster appears under (e.g. `homelab`)
 
 ```sh
@@ -36,7 +51,22 @@ kubectl apply -f trove-agent.yaml
 The manifest contains the ServiceAccount, a read-only ClusterRole
 (deployments/statefulsets/daemonsets/replicasets/pods; get/list/watch only),
 the binding, and the Deployment running
-`ghcr.io/techdox/trove-agent-k8s` as nonroot with a read-only filesystem.
+`ghcr.io/techdox/trove-agent-k8s` as nonroot with a read-only filesystem. It
+also declares the `trove` namespace (harmless that step 2 created it too — we
+create it first so the Secret has somewhere to live).
+
+## 4. Verify
+
+```sh
+kubectl -n trove logs deploy/trove-agent -f
+```
+
+A healthy agent logs `report pushed hosts=1 services=…` each interval, and the
+cluster appears on the dashboard within ~30s. A `connection refused`/timeout
+means `TROVE_SERVER_URL` is wrong or unreachable from the cluster (see above); a
+`401` means the token in the Secret doesn't match the one minted in step 1.
+
+To upgrade the agent later: `kubectl -n trove rollout restart deploy/trove-agent`.
 
 ## Configuration
 

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -7,31 +7,43 @@ running Docker or Kubernetes but still matters. Read-only: it only ever runs
 Runs directly on the host (not in a container), since it needs the host's
 systemd. Ships as a static binary in the release archives.
 
+**Where things run:** you need a Trove **server** running and reachable first
+(see the [Quickstart](../../README.md#quickstart-5-minutes)). This agent runs on
+the host you want to watch and pushes to that server.
+
 ## 1. Mint a token
 
+On the server (this must run against the server's database):
+
 ```sh
-trove-server agent create nas01
+# Docker Compose server:
+docker compose exec server trove-server agent create nas01
+# bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create nas01
 ```
 
 ## 2. Install the binary + unit
 
 ```sh
-# grab the archive for your arch from the latest release
-curl -LO https://github.com/techdox/trove/releases/latest/download/trove-agent-local_<version>_linux_amd64.tar.gz
-tar xzf trove-agent-local_*_linux_amd64.tar.gz
+# grab the archive for your arch from the latest release. Set VERSION to the
+# release you're installing (see https://github.com/techdox/trove/releases).
+VERSION=0.4.0
+curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-agent-local_${VERSION}_linux_amd64.tar.gz"
+tar xzf trove-agent-local_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-agent-local /usr/local/bin/
 
-sudo cp deploy/systemd/trove-agent-local.service /etc/systemd/system/ 2>/dev/null \
-  || sudo cp trove-agent-local.service /etc/systemd/system/   # unit is bundled in the archive
+# the systemd unit is bundled in the archive under deploy/systemd/
+sudo cp deploy/systemd/trove-agent-local.service /etc/systemd/system/
 
-# configure
+# configure — TROVE_SERVER_URL is your server's address as seen from THIS host
+# (use http://localhost:8080 only if the server also runs on this box)
 sudo tee /etc/trove-agent-local.env >/dev/null <<EOF
-TROVE_SERVER_URL=http://trove.lan:8080
+TROVE_SERVER_URL=http://YOUR-SERVER:8080
 TROVE_TOKEN=trove_xxxxxxxx
 EOF
 sudo chmod 600 /etc/trove-agent-local.env
 
 sudo systemctl enable --now trove-agent-local
+journalctl -u trove-agent-local -f   # watch it connect
 ```
 
 ## Configuration

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -7,9 +7,16 @@ with an API token that has only the `PVEAuditor` role and issues only `GET`s.
 Run **one agent per cluster** (it discovers all nodes through any one API
 endpoint).
 
+**Where things run:** you need a Trove **server** running somewhere first (see
+the [Quickstart](../../README.md#quickstart-5-minutes)). The Proxmox **agent**
+runs wherever the server does — a NAS, a small VM, any Linux box or container —
+**not** on a PVE node. `TROVE_PROXMOX_URL` is your PVE cluster's API address as
+seen from wherever the agent runs.
+
 ## 1. Create a read-only API token in Proxmox
 
-On any PVE node's shell (or via the web UI under Datacenter → Permissions):
+Run these as root on any PVE node's shell (or use the web UI under Datacenter →
+Permissions):
 
 ```sh
 # a dedicated user for trove
@@ -23,47 +30,64 @@ pveum aclmod / --users trove@pve --roles PVEAuditor
 pveum user token add trove@pve trove-agent --privsep 0
 ```
 
-The output shows the token secret once. Your token string for Trove is:
+> **`--privsep 0` is required.** A privilege-separated token — the default for
+> both `pveum` and the web UI (where "Privilege Separation" is a checked box) —
+> starts with **no** permissions of its own. Such a token still *authenticates*,
+> so the agent connects and looks healthy, but every Proxmox query comes back
+> empty and **no guests ever appear on the dashboard, with no error.** If you
+> use the web UI, uncheck "Privilege Separation."
+
+The `pveum user token add` output is a table with two fields you must combine.
+Glue the `full-tokenid` (e.g. `trove@pve!trove-agent`) and the `value` (a UUID)
+with an `=` — that whole string is your `TROVE_PROXMOX_TOKEN`:
 
 ```
 trove@pve!trove-agent=<the-secret-uuid>
 ```
 
-## 2. Mint a Trove token
+**Verify the token before going further** — this catches the empty-permissions
+trap above in seconds (run it from wherever the agent will run):
 
 ```sh
-trove-server agent create proxmox-cluster
+curl -sk -H "Authorization: PVEAPIToken=trove@pve!trove-agent=<secret>" \
+  https://YOUR-PVE-HOST:8006/api2/json/nodes
+```
+
+You should get a JSON list of your nodes. `{"data":[]}` means the token
+authenticated but has no permission — recheck the `aclmod` and `--privsep 0`
+steps.
+
+## 2. Get a Trove agent token
+
+**Using the Compose file in step 3?** It generates and seeds this token for you
+from `TROVE_TOKEN` — skip to step 3.
+
+**Running the container by hand (server already exists)?** Mint one on the
+server:
+
+```sh
+# Docker Compose server:
+docker compose exec server trove-server agent create proxmox
+# bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create proxmox
 ```
 
 ## 3. Run the agent
 
-Anywhere that can reach both the Proxmox API and the Trove server — commonly
-as a container on the same box as the Trove server:
+### With Docker Compose (server + agent together)
 
-```sh
-docker run -d --name trove-agent-proxmox --restart unless-stopped \
-  -e TROVE_SERVER_URL=http://trove.lan:8080 \
-  -e TROVE_TOKEN=trove_xxxxxxxx \
-  -e TROVE_PROXMOX_URL=https://pve.lan:8006 \
-  -e TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
-  -e TROVE_PROXMOX_INSECURE=true \
-  ghcr.io/techdox/trove-agent-proxmox:latest
-```
-
-`TROVE_PROXMOX_INSECURE=true` skips TLS verification — needed for Proxmox's
-default self-signed certificate. Drop it if your PVE API has a real cert.
-
-### Or with Docker Compose (server + agent together)
-
-If you don't already have a Trove server running, the quickstart compose file
-stands up both at once — no cloning or building:
+If you don't already have a Trove server, the quickstart Compose file stands up
+both at once — no cloning or building:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker-compose.proxmox.yml
 
-export TROVE_TOKEN=trove_$(openssl rand -hex 24)
-export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
-export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+# Save settings to .env (Compose loads it automatically; it persists across
+# restarts). Then edit .env to fill in your real PVE host and API token.
+{
+  echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
+  echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
+  echo "TROVE_PROXMOX_TOKEN=trove@pve!trove-agent=YOUR-TOKEN-SECRET"
+} > .env
 docker compose -f docker-compose.proxmox.yml up -d
 docker compose -f docker-compose.proxmox.yml logs -f agent   # watch it connect
 ```
@@ -71,15 +95,37 @@ docker compose -f docker-compose.proxmox.yml logs -f agent   # watch it connect
 > The agent image is `trove-agent-proxmox` — **not** `trove-agent-docker`. The
 > Docker agent ignores the `TROVE_PROXMOX_*` variables and reads the Docker
 > socket instead, so it will connect and look healthy while never contacting
-> Proxmox. If you're adapting your own compose file, make sure the agent uses
-> the Proxmox image (and it needs no `/var/run/docker.sock` mount).
+> Proxmox. If you adapt your own compose file, make sure the agent uses the
+> Proxmox image (and it needs no `/var/run/docker.sock` mount).
+
+### Against an existing server (`docker run`)
+
+```sh
+docker run -d --name trove-agent-proxmox --restart unless-stopped \
+  -e TROVE_SERVER_URL=http://YOUR-SERVER:8080 \
+  -e TROVE_TOKEN=trove_xxxxxxxx \
+  -e TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006 \
+  -e TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
+  -e TROVE_PROXMOX_INSECURE=true \
+  ghcr.io/techdox/trove-agent-proxmox:latest
+```
+
+> **Two different tokens, don't mix them up.** `TROVE_TOKEN` is Trove's own
+> agent token (format `trove_…`, from step 2). `TROVE_PROXMOX_TOKEN` is your
+> Proxmox API token (format `user@realm!tokenid=secret`, from step 1).
+
+`TROVE_PROXMOX_INSECURE=true` skips TLS verification — needed for Proxmox's
+default self-signed certificate. Drop it if your PVE API has a real cert.
+
+Replace `YOUR-SERVER` and `YOUR-PVE-HOST` with addresses reachable from where
+the agent runs (not `localhost` unless the agent shares that host).
 
 ## Configuration
 
 | Variable                 | Default      | Purpose                                          |
 | ------------------------ | ------------ | ------------------------------------------------ |
 | `TROVE_SERVER_URL`       | _(required)_ | Base URL of the Trove server.                    |
-| `TROVE_TOKEN`            | _(required)_ | Token from `agent create`.                       |
+| `TROVE_TOKEN`            | _(required)_ | Trove agent token (`trove_…`), from step 2.      |
 | `TROVE_PROXMOX_URL`      | _(required)_ | PVE API base, e.g. `https://pve.lan:8006`.       |
 | `TROVE_PROXMOX_TOKEN`    | _(required)_ | `USER@REALM!TOKENID=SECRET` from step 1.         |
 | `TROVE_PROXMOX_INSECURE` | `false`      | `true` to accept self-signed certificates.       |
@@ -94,3 +140,22 @@ reported by Proxmox config (`ostype`) where available — for example `Windows
 it does not require the QEMU guest agent. Proxmox has no app-level healthcheck,
 so health shows `unknown` — the state badge carries the up/down signal, and
 Trove's agent heartbeat covers "is the cluster still reporting at all."
+
+## Nothing showing up?
+
+Watch the agent's logs (`docker compose -f docker-compose.proxmox.yml logs -f
+agent`, or `docker logs trove-agent-proxmox`):
+
+- **`collect failed` with an auth/connection error** — the agent can't reach or
+  authenticate to the PVE API. Check `TROVE_PROXMOX_URL` is reachable from the
+  agent's host and `TROVE_PROXMOX_TOKEN` is correct (and `TROVE_PROXMOX_INSECURE=true`
+  for a self-signed cert).
+- **`collected 0 hosts …` warning** — the token authenticated but returned no
+  nodes: it's missing the `PVEAuditor` role or was created with privilege
+  separation. Re-run the step-1 `aclmod` / `--privsep 0` commands, or use the
+  curl pre-flight test above.
+- **`push failed … 401`** — `TROVE_TOKEN` doesn't match a Trove agent on the
+  server (e.g. you pasted the Proxmox token here by mistake, or minted the
+  token against a different database).
+- **The agent shows on the dashboard but has no guests** — same as the
+  `collected 0 hosts` case above.

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -6,12 +6,32 @@ email digest summarizing the fleet. Everything is configured with environment
 variables on **the server** (agents are not involved), and none of it changes
 anything: notifications are outbound-only.
 
+> **Where these variables go.** They must reach the *server process* — setting
+> them in your shell with `export` does nothing. For a Docker Compose server,
+> add them under the `server` service's `environment:` and re-run
+> `docker compose up -d`. For a bare-metal server, put them in
+> `/etc/trove-server.env` (the systemd unit reads it via `EnvironmentFile`) and
+> `systemctl restart trove-server`.
+
 Verify any setup with one command:
 
 ```sh
 trove-server alert test
 # compose: docker compose exec server trove-server alert test
 ```
+
+It POSTs a test notification through every configured instant channel and, if
+SMTP is set, sends a sample digest — printing one line per channel:
+
+```
+  webhook  ok
+  discord  ok
+  digest   ok
+```
+
+`ok` means the channel accepted the request (so also check that the message
+actually arrived on your phone/Discord). If you see `no instant channels
+configured`, the variables didn't reach the server — see the note above.
 
 ## Instant channels
 
@@ -109,6 +129,11 @@ TROVE_SMTP_FROM=trove@example.com
 TROVE_SMTP_TO=nick@example.com   # comma-separated for multiple
 TROVE_DIGEST=daily@08:00         # or weekly@mon:08:00, or off
 ```
+
+`TROVE_SMTP_HOST`, `TROVE_SMTP_FROM`, and `TROVE_SMTP_TO` are the required trio
+(username/password are optional, for open relays). If any of the three is
+missing the digest silently stays off — `alert test` will report `email digest
+not configured`.
 
 Gmail: use an [app password](https://myaccount.google.com/apppasswords) with
 `TROVE_SMTP_HOST=smtp.gmail.com`, port 587.

--- a/examples/docker-compose.proxmox.yml
+++ b/examples/docker-compose.proxmox.yml
@@ -3,10 +3,16 @@
 #
 #   1. Create a read-only Proxmox API token (PVEAuditor role). See:
 #        https://github.com/techdox/trove/blob/main/docs/agents/proxmox.md
-#   2. Set a Trove token and your Proxmox connection details:
-#        export TROVE_TOKEN=trove_$(openssl rand -hex 24)
-#        export TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006
-#        export TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=YOUR-TOKEN-SECRET'
+#   2. Save a Trove token and your Proxmox connection details to .env (Compose
+#      loads .env automatically and it persists across restarts/upgrades):
+#        {
+#          echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
+#          echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
+#          echo "TROVE_PROXMOX_TOKEN=trove@pve!trove-agent=YOUR-TOKEN-SECRET"
+#        } > .env
+#      then edit .env to fill in your real PVE host and API token.
+#      Note: TROVE_TOKEN (Trove's own agent token) and TROVE_PROXMOX_TOKEN
+#      (your Proxmox API token) are two different credentials.
 #   3. Start the stack:
 #        docker compose -f docker-compose.proxmox.yml up -d
 #   4. Open http://localhost:8080 — your VMs and LXCs appear within ~30s.
@@ -24,7 +30,7 @@ services:
     image: ghcr.io/techdox/trove-server:latest
     environment:
       TROVE_BOOTSTRAP_AGENT: "proxmox"
-      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  export TROVE_TOKEN=trove_$(openssl rand -hex 24)}"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
     ports:
       - "8080:8080"
     volumes:

--- a/examples/docker-compose.server.yml
+++ b/examples/docker-compose.server.yml
@@ -1,0 +1,37 @@
+# Trove server only — no bundled agent. Use this when the thing you want to
+# watch runs its agent elsewhere: a Kubernetes cluster (in-cluster Deployment)
+# or a bare-metal host (systemd unit). Uses the published image; no build.
+#
+#   1. Save a token for your first agent to .env (Compose loads it automatically
+#      and it persists across restarts/upgrades):
+#        echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
+#   2. Start the server:
+#        docker compose -f docker-compose.server.yml up -d
+#   3. Open http://localhost:8080 (empty until an agent connects).
+#   4. Deploy the agent per its guide, pointing TROVE_SERVER_URL at THIS host's
+#      LAN address (e.g. http://192.168.1.50:8080) — not localhost, which from
+#      inside a pod or another box means "myself":
+#        docs/agents/kubernetes.md   or   docs/agents/local.md
+#
+# The TROVE_BOOTSTRAP_* pair seeds that first agent from TROVE_TOKEN, so you
+# don't run `agent create` for it. Additional agents each get their own token:
+#        docker compose -f docker-compose.server.yml exec server \
+#          trove-server agent create <name>
+#
+# ⚠ The dashboard has no authentication yet — keep port 8080 on a trusted
+#   network (LAN/VPN) or behind an authenticating reverse proxy.
+
+services:
+  server:
+    image: ghcr.io/techdox/trove-server:latest
+    environment:
+      TROVE_BOOTSTRAP_AGENT: "first-agent"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
+    ports:
+      - "8080:8080"
+    volumes:
+      - trove-data:/data
+    restart: unless-stopped
+
+volumes:
+  trove-data:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,8 +1,10 @@
 # Trove quickstart — server + a Docker agent watching this host, using the
 # published images. No cloning or building required.
 #
-#   1. Generate a token for this host's agent:
-#        export TROVE_TOKEN=trove_$(openssl rand -hex 24)
+#   1. Generate a token for this host's agent and save it to .env (Compose
+#      loads .env automatically, and it survives restarts/upgrades — an
+#      `export` would be lost in a new shell):
+#        echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
 #   2. Start the stack:
 #        docker compose up -d
 #   3. Open http://localhost:8080 — your containers appear within ~30s.
@@ -20,7 +22,7 @@ services:
     image: ghcr.io/techdox/trove-server:latest
     environment:
       TROVE_BOOTSTRAP_AGENT: "docker-local"
-      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  export TROVE_TOKEN=trove_$(openssl rand -hex 24)}"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Why
A five-journey cold-read (each journey read as a naive first-time user, prompted by a real Proxmox onboarding failure) found one dominant root cause: **every install path can reach "connected, healthy-looking, no data, no error"**, and the docs never say how to diagnose it. This PR is the docs/examples half of the fix. (The code half — an agent warning on zero-collect, #6, and the server-archive systemd unit, #7 — already merged.)

## Blocker/correctness fixes
- **Quickstart persists `TROVE_TOKEN` to `.env`** (not `export`), so the documented upgrade no longer hard-aborts or silently 401s.
- **Bare-metal agent download** uses a real resolvable version + `curl -f` (the literal `<version>` 404'd and saved the error page to disk).
- **Token minting** shows both the Compose (`docker compose exec`) and bare-metal (`TROVE_DB=…`) forms in every guide — the bare command doesn't exist for Compose users and writes the wrong DB on bare metal.
- **Proxmox**: privsep/`PVEAuditor` pitfall (authenticates but returns nothing), token-string assembly, a `curl` pre-flight test, `TROVE_TOKEN` vs `TROVE_PROXMOX_TOKEN` disambiguation, and a "Nothing showing up?" troubleshooting section.
- **Alerts**: `TROVE_ALERT_*`/`TROVE_SMTP_*` must reach the server process (Compose `environment:` / systemd `EnvironmentFile`), not a shell `export`; documented `alert test` output (verified against the code) and the required SMTP trio.

## Orientation / clarity
- "Where things run" preamble in every non-Docker guide; reachable-URL guidance (not `localhost`), with explicit LAN-IP wording + a Verify step for K8s.
- README: agent/host/service explainer; each platform is its own agent with its own image (the wrong-image trap, surfaced on the "adding more hosts" path people actually arrive by).

## New
- **`examples/docker-compose.server.yml`** — server only, for K8s/bare-metal users previously sent to a compose file that bundled an unwanted agent.

## Verification
- `docker compose config` validates all three example files (and the `:?` guards still fire with a clear message when a var is unset).
- All README internal anchors + referenced files resolve; `gofmt`/`go test` clean (no code changed here).