### PR TITLE
ci: mark the release PR autorelease:tagged after tagging

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -78,3 +78,30 @@ jobs:
           git push "https://x-access-token:${RELEASE_PLEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${tag}"
 
           echo "Created ${tag} at ${GITHUB_SHA}. The Release workflow will publish artifacts from this tag."
+
+      - name: Mark the merged release PR as tagged
+        if: steps.changed.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # release-please refuses to open the NEXT release PR while a merged
+          # one is still labelled "autorelease: pending" ("untagged, merged
+          # release PRs outstanding"). With skip-github-release it never flips
+          # that label itself — it expects whatever tags the release to do it.
+          # Since we just created the tag above, close the loop here. Without
+          # this, every release gets stuck after the first.
+          gh label create "autorelease: tagged" --color 00FF00 \
+            --description "release-please: this release PR has been tagged/released" 2>/dev/null || true
+
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state merged \
+            --label "autorelease: pending" --json number --jq '.[].number')
+          if [ -z "$prs" ]; then
+            echo "No merged release PR labelled 'autorelease: pending'; nothing to relabel."
+          fi
+          for pr in $prs; do
+            echo "Marking PR #${pr} as autorelease: tagged"
+            gh pr edit "$pr" --repo "$GITHUB_REPOSITORY" \
+              --add-label "autorelease: tagged" --remove-label "autorelease: pending" || true
+          done


### PR DESCRIPTION
## Why
Found while shipping the docs/onboarding fixes: after two `fix:` commits merged, release-please **refused to open the 0.4.1 release PR**, aborting with "There are untagged, merged release PRs outstanding." 

Root cause: release-please tracks whether a merged release PR has shipped via its label (`autorelease: pending` → `autorelease: tagged`). Under `skip-github-release: true` it never flips that label itself — it expects whatever creates the tag to do so. `release-tag.yml` only created the tag, so the release PR stayed `pending` forever, and release-please blocked all subsequent release PRs. It only worked the first time (0.4.0) because the next merges had no releasable commits and short-circuited before the guard.

I unstuck 0.4.1 by relabeling PR #3 by hand; this prevents recurrence.

## Change
After `release-tag.yml` creates the tag, it now relabels any merged release PR from `autorelease: pending` to `autorelease: tagged` (best-effort — labeling never fails the tag/release). Authenticated with the existing `RELEASE_PLEASE_TOKEN` (has pull-requests: write).

## Verification
- YAML parses.
- Manual proof of the mechanism: relabeling PR #3 immediately let release-please create PR #9 ("chore(main): release 0.4.1").
- Full effect validated on the next real release merge.