### PR TITLE
docs: add an upgrade & rollback guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,13 +282,16 @@ interface; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Upgrades & backup
 
-- **Upgrade**: pull the new image (or binary) and restart. Schema migrations
-  run automatically on startup; agents and server tolerate version skew within
-  a minor version.
-- **Backup**: everything is one SQLite file (`trove.db` / the `trove-data`
-  volume). Copy it while the server is stopped, or use `sqlite3 ... ".backup"`
-  live. Trove state is rebuildable anyway — agents repopulate the catalog
-  within one interval; you'd lose only event history.
+Upgrades are a `pull` (or binary swap) and restart away: schema migrations apply
+automatically on startup and are additive, and the server and agents tolerate
+version skew within a minor version. Everything is one SQLite file (`trove.db` /
+the `trove-data` volume) — back it up by copying it with the server stopped or
+via `sqlite3 ... ".backup"`; state is rebuildable anyway, since agents repopulate
+the catalog within one interval (a lost database costs only event history).
+
+See **[docs/upgrades.md](docs/upgrades.md)** for per-method upgrade steps (Docker
+Compose, bare metal, `go install`, agents), version pinning, backup commands,
+and how to roll back.
 
 ## Building from source
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,0 +1,108 @@
+# Upgrading Trove
+
+Upgrades are meant to be boring. All state is one SQLite file; schema migrations
+apply automatically on startup and are additive; and the server and agents
+tolerate version skew **within a minor version**, so you don't have to upgrade
+everything in lockstep. Pick the section that matches how you run the server.
+
+## Before you upgrade
+
+- Skim the [release notes](https://github.com/techdox/trove/releases) /
+  `CHANGELOG.md` for the version you're moving to.
+- **Back up the database** (see [Backup](#backup)). Migrations only ever move
+  forward, so a backup is your rollback path.
+- In anything you care about, pin a specific version (e.g. `0.6.0`) rather than
+  `latest`, so upgrades are a deliberate change you control.
+
+## Docker Compose
+
+From the directory holding your compose file and `.env`:
+
+```sh
+docker compose pull
+docker compose up -d
+docker compose logs -f       # watch it come back
+```
+
+If you started from a named file, pass it: `docker compose -f docker-compose.server.yml pull`
+then `... up -d`. The database lives in the `trove-data` volume and survives the
+recreate; your `.env` (agent token) is reused.
+
+**Pin a version:** set the image tag in the compose file
+(`ghcr.io/techdox/trove-server:0.6.0` instead of `:latest`), then `pull` / `up -d`.
+
+## Bare metal (systemd)
+
+Download the release archive for the version you want and swap the binary in
+place — the database at `/var/lib/trove/trove.db` is untouched:
+
+```sh
+VERSION=0.6.0
+curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
+tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
+sudo install -m 0755 trove-server /usr/local/bin/
+sudo systemctl restart trove-server
+```
+
+Confirm it's healthy: `systemctl status trove-server` and
+`journalctl -u trove-server -e`. The bare-metal agent (`trove-agent-local`)
+upgrades the same way with its own archive, then `sudo systemctl restart trove-agent-local`.
+
+## go install
+
+```sh
+go install github.com/techdox/trove/cmd/trove-server@v0.6.0   # or @latest
+```
+
+Then restart however you run it. (A `go install` build reports its version as
+`dev` — that's expected and harmless; the real module version is still what you
+installed.)
+
+## Agents
+
+Agents and the server tolerate version skew within a minor version, so upgrade
+agents whenever convenient — they don't have to move in lockstep with the server.
+
+- **Docker agent (compose):** `docker compose pull && docker compose up -d`.
+- **Docker agent (`docker run`):** `docker pull ghcr.io/techdox/trove-agent-docker:latest`, then recreate the container.
+- **Kubernetes agent:** `kubectl -n trove rollout restart deploy/trove-agent` (bump the image tag first if you pin one).
+- **Bare-metal agent:** see [Bare metal](#bare-metal-systemd) above.
+
+## Backup
+
+Everything Trove knows is in one SQLite file:
+
+- **Docker:** the `trove-data` volume → `/data/trove.db` in the container.
+- **Bare metal:** `/var/lib/trove/trove.db`.
+
+Copy it with the server stopped:
+
+```sh
+sudo systemctl stop trove-server
+sudo cp /var/lib/trove/trove.db "/var/backups/trove-$(date +%F).db"
+sudo systemctl start trove-server
+```
+
+Or take a consistent hot backup without stopping:
+
+```sh
+sqlite3 /var/lib/trove/trove.db ".backup '/var/backups/trove.db'"
+```
+
+For Docker: `docker compose cp server:/data/trove.db ./trove-backup.db`.
+
+Trove state is rebuildable anyway — agents repopulate the catalog within one
+push interval, so a lost database costs you only event history.
+
+## Rolling back
+
+Migrations are forward-only; Trove never auto-downgrades the schema. To go back
+to an older version after a newer one has run a migration:
+
+1. Stop the server.
+2. Restore the database backup you took **before** the upgrade.
+3. Start the older binary / image.
+
+If no new migration ran between the two versions, you can downgrade without
+restoring. When unsure, restore the backup — an older binary may not understand
+a newer schema.


### PR DESCRIPTION
## Why
Upgrade guidance was a single two-line bullet in the README. New (and existing) users have asked how to upgrade safely — this fills that gap for the currently-shipping install methods.

## What
- **New `docs/upgrades.md`** covering, for what's on `main` today:
  - Per-method upgrade steps: Docker Compose, bare-metal/systemd, `go install`, and agents.
  - "Before you upgrade" (back up first; migrations are forward-only).
  - Version pinning vs `:latest`.
  - Backup commands (stopped copy + `sqlite3 .backup`; Docker `compose cp`).
  - A rollback procedure (restore the pre-upgrade DB backup; why downgrading across a migration needs it).
- README "Upgrades & backup" now summarizes and links the guide.

Scoped to current functionality only — Helm and auth are Phase 5 and will get their own upgrade notes when they ship.

## Verification
- No Helm/auth references (confirmed against `main`).
- Referenced paths (`CHANGELOG.md`, releases) exist; internal anchors resolve.