### PR TITLE
feat: dashboard legibility + surface why a service is unhealthy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # Build artifacts
 /bin/
 /dist/
+# stray binaries from `go build ./cmd/<x>` in the repo root
+/trove-server
+/trove-agent-docker
+/trove-agent-k8s
+/trove-agent-proxmox
+/trove-agent-local
 
 # Local SQLite database (+ WAL sidecars)
 *.db

--- a/cmd/trove-agent-docker/collect.go
+++ b/cmd/trove-agent-docker/collect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/techdox/trove/internal/agentkit"
@@ -39,16 +40,18 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 			c.log.Debug("inspect container failed", "id", short(ct.ID), "err", err)
 		}
 
+		health := mapHealth(ct.State, insp)
 		services = append(services, model.ReportService{
-			ExternalID:  ct.ID,
-			Name:        containerName(ct.Names),
-			Kind:        model.KindContainer,
-			Image:       ct.Image,
-			ImageDigest: c.resolveDigest(ctx, ct.ImageID, digestCache),
-			State:       ct.State,
-			Health:      mapHealth(ct.State, insp),
-			Ports:       mapPorts(ct.Ports),
-			Labels:      ct.Labels,
+			ExternalID:   ct.ID,
+			Name:         containerName(ct.Names),
+			Kind:         model.KindContainer,
+			Image:        ct.Image,
+			ImageDigest:  c.resolveDigest(ctx, ct.ImageID, digestCache),
+			State:        ct.State,
+			Health:       health,
+			HealthDetail: healthDetail(ct.State, insp, health),
+			Ports:        mapPorts(ct.Ports),
+			Labels:       ct.Labels,
 		})
 	}
 
@@ -131,6 +134,46 @@ func mapHealth(state string, insp dockerInspect) model.Health {
 		return model.HealthUnknown
 	}
 }
+
+// healthDetail explains WHY a container is unhealthy, so the dashboard can show
+// more than a red badge. It prefers the failing healthcheck's last output;
+// failing that (a stopped container that was meant to stay up), it reports the
+// exit code and any daemon error. Empty for healthy/unknown states.
+func healthDetail(state string, insp dockerInspect, health model.Health) string {
+	if health != model.HealthUnhealthy {
+		return ""
+	}
+	const maxLen = 300
+	if h := insp.State.Health; h != nil && len(h.Log) > 0 {
+		last := h.Log[len(h.Log)-1]
+		out := collapseWS(last.Output)
+		if len(out) > maxLen {
+			out = out[:maxLen] + "…"
+		}
+		if out != "" {
+			return "healthcheck failing (exit " + itoa(last.ExitCode) + "): " + out
+		}
+		return "healthcheck failing (exit " + itoa(last.ExitCode) + ", " + itoa(h.FailingStreak) + " in a row)"
+	}
+	if state == "exited" || state == "dead" {
+		d := "container " + state + " (exit " + itoa(insp.State.ExitCode) + ")"
+		if insp.State.Error != "" {
+			if e := collapseWS(insp.State.Error); e != "" {
+				d += ": " + e
+			}
+		}
+		return d
+	}
+	return ""
+}
+
+// collapseWS trims and collapses all runs of whitespace (including the newlines
+// Docker healthcheck output usually carries) into single spaces.
+func collapseWS(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
 
 // mapPorts converts Docker port entries to model ports, de-duplicating the
 // IPv4/IPv6 pairs Docker reports for a single published mapping.

--- a/cmd/trove-agent-docker/collect_test.go
+++ b/cmd/trove-agent-docker/collect_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+func inspectFromJSON(t *testing.T, s string) dockerInspect {
+	t.Helper()
+	var insp dockerInspect
+	if err := json.Unmarshal([]byte(s), &insp); err != nil {
+		t.Fatalf("unmarshal inspect: %v", err)
+	}
+	return insp
+}
+
+func TestHealthDetail(t *testing.T) {
+	t.Run("healthy has no detail", func(t *testing.T) {
+		insp := inspectFromJSON(t, `{"State":{"Health":{"Status":"healthy"}}}`)
+		if d := healthDetail("running", insp, model.HealthHealthy); d != "" {
+			t.Fatalf("healthy detail = %q, want empty", d)
+		}
+	})
+
+	t.Run("failing healthcheck reports exit code + collapsed output", func(t *testing.T) {
+		insp := inspectFromJSON(t, `{"State":{"Health":{"Status":"unhealthy","FailingStreak":3,
+			"Log":[{"ExitCode":0,"Output":"ok"},{"ExitCode":1,"Output":"curl: (7)\n  connection refused\n"}]}}}`)
+		d := healthDetail("running", insp, model.HealthUnhealthy)
+		if !strings.Contains(d, "exit 1") || !strings.Contains(d, "curl: (7) connection refused") {
+			t.Fatalf("healthcheck detail = %q", d)
+		}
+		if strings.Contains(d, "\n") {
+			t.Fatalf("detail should be single-line, got %q", d)
+		}
+	})
+
+	t.Run("stopped-but-should-run reports exit code + error", func(t *testing.T) {
+		insp := inspectFromJSON(t, `{"State":{"ExitCode":137,"Error":"OOMKilled"},
+			"HostConfig":{"RestartPolicy":{"Name":"always"}}}`)
+		d := healthDetail("exited", insp, model.HealthUnhealthy)
+		if !strings.Contains(d, "exited") || !strings.Contains(d, "137") || !strings.Contains(d, "OOMKilled") {
+			t.Fatalf("stopped detail = %q", d)
+		}
+	})
+
+	t.Run("long output is truncated", func(t *testing.T) {
+		long := strings.Repeat("x", 500)
+		insp := inspectFromJSON(t, `{"State":{"Health":{"Status":"unhealthy","Log":[{"ExitCode":1,"Output":"`+long+`"}]}}}`)
+		d := healthDetail("running", insp, model.HealthUnhealthy)
+		if len(d) > 360 { // 300 cap + prefix + ellipsis
+			t.Fatalf("detail not truncated: len %d", len(d))
+		}
+		if !strings.HasSuffix(d, "…") {
+			t.Fatalf("truncated detail should end with ellipsis: %q", d)
+		}
+	})
+}

--- a/cmd/trove-agent-docker/docker.go
+++ b/cmd/trove-agent-docker/docker.go
@@ -104,8 +104,16 @@ type dockerContainer struct {
 
 type dockerInspect struct {
 	State struct {
-		Health   *struct{ Status string } `json:"Health"`
-		ExitCode int                      `json:"ExitCode"`
+		Health *struct {
+			Status        string `json:"Status"`
+			FailingStreak int    `json:"FailingStreak"`
+			Log           []struct {
+				ExitCode int    `json:"ExitCode"`
+				Output   string `json:"Output"`
+			} `json:"Log"`
+		} `json:"Health"`
+		ExitCode int    `json:"ExitCode"`
+		Error    string `json:"Error"`
 	} `json:"State"`
 	HostConfig struct {
 		RestartPolicy struct {

--- a/cmd/trove-agent-k8s/collect.go
+++ b/cmd/trove-agent-k8s/collect.go
@@ -108,6 +108,7 @@ func podService(p *pod, rsOwner map[string]string) model.ReportService {
 	} else if len(p.Spec.Containers) > 0 {
 		image = p.Spec.Containers[0].Image
 	}
+	health := podHealth(p)
 	return model.ReportService{
 		ExternalID:       extID("pod", p.Metadata.Namespace, p.Metadata.Name),
 		ParentExternalID: podParent(p, rsOwner),
@@ -116,9 +117,55 @@ func podService(p *pod, rsOwner map[string]string) model.ReportService {
 		Image:            image,
 		ImageDigest:      digest,
 		State:            strings.ToLower(p.Status.Phase),
-		Health:           podHealth(p),
+		Health:           health,
+		HealthDetail:     podDetail(p, health),
 		Labels:           map[string]string{"namespace": p.Metadata.Namespace, "node": p.Spec.NodeName},
 	}
+}
+
+// podDetail explains why a pod is unhealthy: the first not-ready container's
+// waiting reason (CrashLoopBackOff, ImagePullBackOff, …) or termination reason
+// (OOMKilled, Error + exit code), falling back to the pod-level reason
+// (Evicted, …). Empty for healthy/unknown pods.
+func podDetail(p *pod, health model.Health) string {
+	if health != model.HealthUnhealthy {
+		return ""
+	}
+	for _, cs := range p.Status.ContainerStatuses {
+		if cs.Ready {
+			continue
+		}
+		if w := cs.State.Waiting; w != nil && w.Reason != "" {
+			return joinReason(cs.Name, w.Reason, w.Message)
+		}
+		if t := cs.State.Terminated; t != nil && (t.Reason != "" || t.ExitCode != 0) {
+			reason := t.Reason
+			if reason == "" {
+				reason = "Terminated"
+			}
+			return joinReason(cs.Name, fmt.Sprintf("%s (exit %d)", reason, t.ExitCode), t.Message)
+		}
+	}
+	if p.Status.Reason != "" {
+		return joinReason("", p.Status.Reason, p.Status.Message)
+	}
+	return ""
+}
+
+// joinReason formats "<container>: <reason> — <message>", trimming and capping
+// the free-form message.
+func joinReason(container, reason, message string) string {
+	s := reason
+	if container != "" {
+		s = container + ": " + reason
+	}
+	if msg := strings.Join(strings.Fields(message), " "); msg != "" {
+		if len(msg) > 240 {
+			msg = msg[:240] + "…"
+		}
+		s += " — " + msg
+	}
+	return s
 }
 
 func podParent(p *pod, rsOwner map[string]string) string {

--- a/cmd/trove-agent-k8s/collect_test.go
+++ b/cmd/trove-agent-k8s/collect_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+func podFromJSON(t *testing.T, s string) pod {
+	t.Helper()
+	var p pod
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		t.Fatalf("unmarshal pod: %v", err)
+	}
+	return p
+}
+
+func TestPodDetail(t *testing.T) {
+	t.Run("healthy has no detail", func(t *testing.T) {
+		p := podFromJSON(t, `{"status":{"phase":"Running","containerStatuses":[{"name":"web","ready":true}]}}`)
+		if d := podDetail(&p, model.HealthHealthy); d != "" {
+			t.Fatalf("healthy detail = %q, want empty", d)
+		}
+	})
+
+	t.Run("waiting reason (CrashLoopBackOff)", func(t *testing.T) {
+		p := podFromJSON(t, `{"status":{"phase":"Running","containerStatuses":[
+			{"name":"web","ready":false,"state":{"waiting":{"reason":"CrashLoopBackOff","message":"back-off restarting failed container"}}}]}}`)
+		d := podDetail(&p, model.HealthUnhealthy)
+		if !strings.Contains(d, "web:") || !strings.Contains(d, "CrashLoopBackOff") || !strings.Contains(d, "back-off restarting") {
+			t.Fatalf("waiting detail = %q", d)
+		}
+	})
+
+	t.Run("terminated reason with exit code", func(t *testing.T) {
+		p := podFromJSON(t, `{"status":{"phase":"Failed","containerStatuses":[
+			{"name":"job","ready":false,"state":{"terminated":{"reason":"OOMKilled","exitCode":137}}}]}}`)
+		d := podDetail(&p, model.HealthUnhealthy)
+		if !strings.Contains(d, "job:") || !strings.Contains(d, "OOMKilled") || !strings.Contains(d, "137") {
+			t.Fatalf("terminated detail = %q", d)
+		}
+	})
+
+	t.Run("pod-level reason falls back", func(t *testing.T) {
+		p := podFromJSON(t, `{"status":{"phase":"Failed","reason":"Evicted","message":"The node was low on resource: memory."}}`)
+		d := podDetail(&p, model.HealthUnhealthy)
+		if !strings.Contains(d, "Evicted") || !strings.Contains(d, "low on resource") {
+			t.Fatalf("pod-level detail = %q", d)
+		}
+	})
+}

--- a/cmd/trove-agent-k8s/kube.go
+++ b/cmd/trove-agent-k8s/kube.go
@@ -186,14 +186,28 @@ type pod struct {
 	} `json:"spec"`
 	Status struct {
 		Phase      string `json:"phase"`
+		Reason     string `json:"reason"`  // pod-level, e.g. "Evicted"
+		Message    string `json:"message"` // pod-level detail
 		Conditions []struct {
 			Type   string `json:"type"`
 			Status string `json:"status"`
 		} `json:"conditions"`
 		ContainerStatuses []struct {
+			Name    string `json:"name"`
 			Image   string `json:"image"`
 			ImageID string `json:"imageID"`
 			Ready   bool   `json:"ready"`
+			State   struct {
+				Waiting *struct {
+					Reason  string `json:"reason"` // e.g. CrashLoopBackOff, ImagePullBackOff
+					Message string `json:"message"`
+				} `json:"waiting"`
+				Terminated *struct {
+					Reason   string `json:"reason"` // e.g. Error, OOMKilled
+					Message  string `json:"message"`
+					ExitCode int    `json:"exitCode"`
+				} `json:"terminated"`
+			} `json:"state"`
 		} `json:"containerStatuses"`
 	} `json:"status"`
 }

--- a/docs/agents/docker.md
+++ b/docs/agents/docker.md
@@ -52,6 +52,10 @@ the reported hostname comes from the Docker daemon.
 - Exited with restart policy `always`/`unless-stopped` → `unhealthy`
   (it was meant to stay up); otherwise `unknown`.
 
+When a container is unhealthy, click its row: the detail drawer shows **why** —
+the failing healthcheck's last output and exit code, or the exit code (and any
+daemon error) of a container that stopped when it was meant to stay up.
+
 ## Notes
 
 - Mounting the Docker socket is inherently sensitive. The agent's API usage is

--- a/docs/agents/kubernetes.md
+++ b/docs/agents/kubernetes.md
@@ -89,5 +89,8 @@ supported via `TROVE_KUBE_APISERVER`, `TROVE_KUBE_TOKEN`, `TROVE_KUBE_CA`, and
 - Pods appear nested under their workload (pod → ReplicaSet → Deployment
   ownership is resolved automatically), with per-pod phase and readiness.
 - Bare pods and Job pods (no workload owner) appear as top-level services.
+- An unhealthy pod's detail drawer shows **why** — the not-ready container's
+  waiting reason (`CrashLoopBackOff`, `ImagePullBackOff`, …) or termination
+  reason (`OOMKilled`, exit code), falling back to the pod-level reason.
 - Pod image digests are captured, so image freshness works for cluster
   workloads just like containers.

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -21,7 +21,8 @@ type serviceDTO struct {
 	ImageDigest      string          `json:"image_digest,omitempty"`
 	State            string          `json:"state"`
 	Health           string          `json:"health"`
-	Freshness        string          `json:"freshness"` // current | outdated | unknown
+	HealthDetail     string          `json:"health_detail,omitempty"` // why unhealthy, when known
+	Freshness        string          `json:"freshness"`               // current | outdated | unknown
 	LatestDigest     string          `json:"latest_digest,omitempty"`
 	Ports            json.RawMessage `json:"ports"`
 	Labels           json.RawMessage `json:"labels"`
@@ -117,6 +118,7 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 			ImageDigest:      row.ImageDigest,
 			State:            row.State,
 			Health:           row.Health,
+			HealthDetail:     row.HealthDetail,
 			Freshness:        freshness,
 			LatestDigest:     latestDigest,
 			Ports:            rawJSON(row.PortsJSON, "[]"),

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -118,10 +118,10 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 			if _, err := tx.ExecContext(ctx,
 				`UPDATE services
 				    SET name = ?, kind = ?, image = ?, image_digest = ?, state = ?, health = ?,
-				        ports_json = ?, labels_json = ?, last_seen_at = ?, updated_at = ?
+				        health_detail = ?, ports_json = ?, labels_json = ?, last_seen_at = ?, updated_at = ?
 				  WHERE id = ?`,
 				svc.Name, string(svc.Kind), svc.Image, svc.ImageDigest, svc.State, string(svc.Health),
-				portsJSON, labelsJSON, now, now, ex.id,
+				svc.HealthDetail, portsJSON, labelsJSON, now, now, ex.id,
 			); err != nil {
 				return fmt.Errorf("update service %q: %w", svc.ExternalID, err)
 			}
@@ -132,10 +132,10 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 		res, err := tx.ExecContext(ctx,
 			`INSERT INTO services
 			   (host_id, external_id, name, kind, image, image_digest, state, health,
-			    ports_json, labels_json, first_seen_at, last_seen_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			    health_detail, ports_json, labels_json, first_seen_at, last_seen_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			hostID, svc.ExternalID, svc.Name, string(svc.Kind), svc.Image, svc.ImageDigest,
-			svc.State, string(svc.Health), portsJSON, labelsJSON, now, now, now,
+			svc.State, string(svc.Health), svc.HealthDetail, portsJSON, labelsJSON, now, now, now,
 		)
 		if err != nil {
 			return fmt.Errorf("insert service %q: %w", svc.ExternalID, err)

--- a/internal/store/migrations/0006_health_detail.sql
+++ b/internal/store/migrations/0006_health_detail.sql
@@ -1,0 +1,5 @@
+-- Add a short, human-readable reason for a service's health — e.g. a failing
+-- Docker healthcheck's last output, or a Kubernetes pod's CrashLoopBackOff /
+-- termination reason. Purely supplementary display data: it is never on the
+-- state/health diff or event path, so ingest just overwrites it each report.
+ALTER TABLE services ADD COLUMN health_detail TEXT NOT NULL DEFAULT '';

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -10,19 +10,20 @@ import (
 // owning agent. The dashboard groups these by host; the API layer overlays
 // derived staleness using the agent heartbeat fields.
 type ServiceRow struct {
-	ID          int64
-	ExternalID  string
-	Name        string
-	Kind        string
-	Image       string
-	ImageDigest string
-	State       string
-	Health      string
-	PortsJSON   string
-	LabelsJSON  string
-	FirstSeenAt int64
-	LastSeenAt  int64
-	UpdatedAt   int64
+	ID           int64
+	ExternalID   string
+	Name         string
+	Kind         string
+	Image        string
+	ImageDigest  string
+	State        string
+	Health       string
+	HealthDetail string
+	PortsJSON    string
+	LabelsJSON   string
+	FirstSeenAt  int64
+	LastSeenAt   int64
+	UpdatedAt    int64
 
 	HostID       int64
 	Hostname     string
@@ -72,6 +73,7 @@ func (r *ServiceRow) FreshnessVerdict() string {
 func (s *Store) ListServices(ctx context.Context) ([]ServiceRow, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT s.id, s.external_id, s.name, s.kind, s.image, s.image_digest, s.state, s.health,
+		       s.health_detail,
 		       s.ports_json, s.labels_json, s.first_seen_at, s.last_seen_at, s.updated_at,
 		       h.id, h.hostname, h.platform_meta_json,
 		       a.id, a.name, a.platform, a.report_interval_seconds, a.last_seen_at,
@@ -93,6 +95,7 @@ func (s *Store) ListServices(ctx context.Context) ([]ServiceRow, error) {
 		var r ServiceRow
 		if err := rows.Scan(
 			&r.ID, &r.ExternalID, &r.Name, &r.Kind, &r.Image, &r.ImageDigest, &r.State, &r.Health,
+			&r.HealthDetail,
 			&r.PortsJSON, &r.LabelsJSON, &r.FirstSeenAt, &r.LastSeenAt, &r.UpdatedAt,
 			&r.HostID, &r.Hostname, &r.HostMetaJSON,
 			&r.AgentID, &r.AgentName, &r.AgentPlatform, &r.AgentIntervalSeconds, &r.AgentLastSeenAt,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -109,15 +109,19 @@ type ReportService struct {
 	// ParentExternalID, if set, is the ExternalID of this service's parent
 	// within the same report/host — e.g. a pod's owning Deployment. The server
 	// resolves it to an internal parent link. Empty for standalone services.
-	ParentExternalID string            `json:"parent_external_id,omitempty"`
-	Name             string            `json:"name"`
-	Kind             Kind              `json:"kind"`
-	Image            string            `json:"image"`
-	ImageDigest      string            `json:"image_digest,omitempty"`
-	State            string            `json:"state"`
-	Health           Health            `json:"health"`
-	Ports            []Port            `json:"ports,omitempty"`
-	Labels           map[string]string `json:"labels,omitempty"`
+	ParentExternalID string `json:"parent_external_id,omitempty"`
+	Name             string `json:"name"`
+	Kind             Kind   `json:"kind"`
+	Image            string `json:"image"`
+	ImageDigest      string `json:"image_digest,omitempty"`
+	State            string `json:"state"`
+	Health           Health `json:"health"`
+	// HealthDetail is an optional short, human-readable reason for the health
+	// state — e.g. a failing Docker healthcheck's last output, or a Kubernetes
+	// pod's waiting/termination reason. Empty when there's nothing to explain.
+	HealthDetail string            `json:"health_detail,omitempty"`
+	Ports        []Port            `json:"ports,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
 }
 
 // Port is a published port mapping.

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -471,6 +471,8 @@ function renderDrawer() {
       ${s.freshness === "outdated" ? badge("b-peach", "update available")
         : s.freshness === "current" ? badge("b-blue", "up to date") : ""}
     </div>
+    ${s.health === "unhealthy" && s.health_detail
+      ? `<div class="d-why"><span class="d-why-label">Why</span> ${esc(s.health_detail)}</div>` : ""}
     <div class="d-mono">
       <span class="lbl">host</span> ${esc(host.hostname)} · <span class="lbl">agent</span> ${esc(host.agent)} (${esc(host.platform || "—")})
     </div>

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -151,11 +151,11 @@ function portsHTML(ports) {
 function freshnessCell(s) {
   switch (s.freshness) {
     case "outdated":
-      return `<span class="badge b-peach" title="running: ${esc(s.image_digest || "?")}\nlatest:  ${esc(s.latest_digest || "?")}">update</span>`;
+      return `<span class="badge b-peach" title="A newer image is available for this tag.&#10;running: ${esc(s.image_digest || "?")}&#10;latest:  ${esc(s.latest_digest || "?")}">update</span>`;
     case "current":
       return '<span class="badge b-blue">up to date</span>';
     default:
-      return '<span class="muted">—</span>';
+      return '<span class="muted" title="Freshness not tracked — no image digest to compare (e.g. VMs/LXCs, or an image without a resolvable tag).">—</span>';
   }
 }
 
@@ -200,24 +200,37 @@ function computeCounts() {
 
 // ------------------------------------------------------------- summary ----
 
+// The summary is the at-a-glance answer: a health verdict + a read-only
+// overview. Filtering lives in the chip row below, so these are not clickable
+// (no duplicate controls).
 function renderSummary() {
   const c = computeCounts();
-  const agents = state.data.agents?.agents?.length ?? 0;
-  const stat = (n, label, cls, chip) => {
-    const active = chip && state.chips.has(chip) ? " active" : "";
-    return `<button class="stat ${cls}${active}" data-chip="${chip}"
-      aria-pressed="${!!active}" title="filter: ${label}"><b>${n}</b> ${label}</button>`;
-  };
-  $("summary").innerHTML = [
-    `<span class="stat"><b>${agents}</b> agent${agents === 1 ? "" : "s"}</span>`,
-    `<span class="stat"><b>${c.hosts}</b> host${c.hosts === 1 ? "" : "s"}</span>`,
-    `<span class="stat"><b>${c.services}</b> service${c.services === 1 ? "" : "s"}</span>`,
-    `<span class="sep">—</span>`,
-    stat(c.running, "running", "c-green", "running"),
-    stat(c.unhealthy, "unhealthy", "c-red", "unhealthy"),
-    stat(c.outdated, "outdated", "c-peach", "outdated"),
-    stat(c.stale, "stale", "c-gray", "stale"),
-  ].join("");
+  const agentList = state.data.agents?.agents || [];
+  const agents = agentList.length;
+  const agentsOffline = agentList.filter((a) => a.status === "offline").length;
+  const agentsStale = agentList.filter((a) => a.status === "stale").length;
+
+  // What "needs attention" — most urgent first.
+  const parts = [];
+  if (c.unhealthy) parts.push(`${c.unhealthy} unhealthy`);
+  if (agentsOffline) parts.push(`${agentsOffline} agent${agentsOffline === 1 ? "" : "s"} offline`);
+  if (c.stale) parts.push(`${c.stale} stale`);
+  if (agentsStale) parts.push(`${agentsStale} agent${agentsStale === 1 ? "" : "s"} not reporting`);
+  if (c.outdated) parts.push(`${c.outdated} outdated`);
+
+  const cls = parts.length === 0 ? "ok" : (c.unhealthy > 0 || agentsOffline > 0 ? "crit" : "warn");
+  const text = parts.length === 0 ? "All systems operational" : "Needs attention";
+  const overview =
+    `${agents} agent${agents === 1 ? "" : "s"} · ` +
+    `${c.hosts} host${c.hosts === 1 ? "" : "s"} · ` +
+    `${c.services} service${c.services === 1 ? "" : "s"}`;
+
+  $("summary").innerHTML =
+    `<div class="verdict verdict-${cls}"><span class="vdot"></span>` +
+    `<span class="vtext">${text}</span>` +
+    (parts.length ? `<span class="vbreak">${esc(parts.join(" · "))}</span>` : "") +
+    `</div>` +
+    `<span class="overview">${esc(overview)}</span>`;
 }
 
 function renderChips() {
@@ -232,6 +245,9 @@ function renderChips() {
   chips.push(`<button class="chip c-gray${remActive}" data-chip="removed"
     aria-pressed="${state.showRemoved}" title="show services no longer reported (kept 24h)">
     removed <span class="n">${c.removed}</span></button>`);
+  if (state.q.trim() !== "" || state.chips.size > 0 || state.showRemoved) {
+    chips.push(`<button class="chip chip-clear" data-clear="1" title="clear all filters (esc)">✕ clear</button>`);
+  }
   $("chips").innerHTML = chips.join("");
 }
 
@@ -576,7 +592,17 @@ function toggleChip(key) {
   render();
 }
 
+function clearFilters() {
+  state.q = "";
+  $("q").value = "";
+  state.chips.clear();
+  state.showRemoved = false;
+  render();
+}
+
 document.addEventListener("click", (e) => {
+  if (e.target.closest("[data-clear]")) { clearFilters(); return; }
+
   const chip = e.target.closest("[data-chip]");
   if (chip) { toggleChip(chip.dataset.chip); return; }
 
@@ -607,12 +633,7 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") {
     if (typing) { e.target.blur(); return; }
     if (state.drawerKey) { state.drawerKey = null; render(); return; }
-    if (state.q || state.chips.size > 0) {
-      state.q = "";
-      $("q").value = "";
-      state.chips.clear();
-      render();
-    }
+    if (state.q || state.chips.size > 0 || state.showRemoved) clearFilters();
     return;
   }
   if (typing) return;

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -47,8 +47,8 @@
 
     <footer>
       Trove &middot; read-only by design &middot; auto-refresh 10s &middot;
-      <kbd>/</kbd> filter &middot; <kbd>j</kbd>/<kbd>k</kbd> move &middot;
-      <kbd>enter</kbd> details &middot; <kbd>esc</kbd> close
+      click a row (or <kbd>enter</kbd>) for details &middot;
+      <kbd>/</kbd> filter &middot; <kbd>j</kbd>/<kbd>k</kbd> move &middot; <kbd>esc</kbd> close
     </footer>
   </div>
 

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -127,34 +127,24 @@ header h1 {
   align-items: center;
   margin: 22px 0 16px;
 }
-.summary .sep { color: var(--border-strong); padding: 0 2px; }
-.stat {
+/* health verdict — the at-a-glance answer */
+.verdict {
   display: inline-flex;
-  align-items: baseline;
-  gap: 7px;
-  padding: 7px 13px;
-  border: 1px solid var(--border);
+  align-items: center;
+  gap: 9px;
+  padding: 8px 15px;
   border-radius: 999px;
-  background: rgba(36, 34, 56, 0.55);
-  color: var(--muted);
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  cursor: default;
+  border: 1px solid transparent;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
 }
-.stat b { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
-button.stat { cursor: pointer; transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease; }
-button.stat:hover { transform: translateY(-1px); border-color: var(--border-strong); }
-.stat.c-green b  { color: var(--green); }
-.stat.c-red b    { color: var(--red); }
-.stat.c-yellow b { color: var(--amber); }
-.stat.c-peach b  { color: var(--amber); }
-.stat.c-gray b   { color: var(--subtle); }
-.stat.active { border-color: currentColor; background: rgba(36, 34, 56, 0.92); }
-.stat.c-green.active  { color: var(--green); }
-.stat.c-red.active    { color: var(--red); }
-.stat.c-yellow.active { color: var(--amber); }
-.stat.c-peach.active  { color: var(--amber); }
-.stat.c-gray.active   { color: var(--muted); }
+.verdict .vdot { width: 9px; height: 9px; border-radius: 50%; background: currentColor; flex: none; }
+.verdict .vbreak { font-family: var(--font-mono); font-weight: 500; font-size: 12px; opacity: 0.85; }
+.verdict-ok   { color: var(--green); background: rgba(155, 226, 143, 0.08); border-color: rgba(155, 226, 143, 0.3); }
+.verdict-warn { color: var(--amber); background: rgba(242, 166, 90, 0.08); border-color: rgba(242, 166, 90, 0.32); }
+.verdict-crit { color: var(--red);   background: rgba(255, 107, 122, 0.08); border-color: rgba(255, 107, 122, 0.34); }
+.overview { color: var(--subtle); font-family: var(--font-mono); font-size: 12.5px; }
 
 /* ---- filter bar ---- */
 .filterbar {
@@ -202,6 +192,8 @@ button.stat:hover { transform: translateY(-1px); border-color: var(--border-stro
 .chip.active.c-yellow { color: var(--amber);  border-color: var(--amber); }
 .chip.active.c-peach  { color: var(--amber);  border-color: var(--amber); }
 .chip.active.c-gray   { color: var(--muted); }
+.chip-clear { color: var(--subtle); border-style: dashed; }
+.chip-clear:hover { color: var(--text); border-color: var(--border-strong); }
 
 /* ---- section titles ---- */
 .section-title {
@@ -292,7 +284,7 @@ th.w-state   { width: 116px; }
 th.w-health  { width: 112px; }
 th.w-fresh   { width: 124px; }
 th.w-ports   { width: 15%; }
-th.w-seen    { width: 90px; }
+th.w-seen    { width: 108px; }
 /* image column takes the remainder */
 
 tbody td {
@@ -356,6 +348,10 @@ tbody tr.child .svc-name { color: var(--muted); font-family: var(--font-body); f
 .muted { color: var(--subtle); }
 .nowrap { white-space: nowrap; }
 td.seen { text-align: right; color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
+/* Persistent, subtle "open me" cue so clickable rows are discoverable without
+   having to hover first; brightens on hover. */
+tbody tr[data-ext] td.seen::after { content: "›"; margin-left: 9px; color: var(--border-strong); font-weight: 700; }
+tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
 
 /* ---- badges ---- */
 .badge {

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -445,6 +445,26 @@ tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
 }
 .d-close:hover { color: var(--text); border-color: var(--border-strong); }
 .d-badges { display: flex; flex-wrap: wrap; gap: 7px; margin-bottom: 4px; }
+.d-why {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 107, 122, 0.08);
+  border: 1px solid rgba(255, 107, 122, 0.3);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+.d-why-label {
+  color: var(--red);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  margin-right: 6px;
+}
 .d-sec {
   font-family: var(--font-mono);
   text-transform: uppercase;


### PR DESCRIPTION
From an adversarial non-technical UX review of the dashboard. Two things, bundled:

## 1. Dashboard legibility
- **Health verdict** replaces the clickable summary: green *All systems operational*, or amber/red *Needs attention* + breakdown (`2 unhealthy · 1 agent offline · 20 outdated`), plus a read-only agents/hosts/services line.
- **Chips are now the single filter control** (the summary stats used to duplicate them — both were wired to `toggleChip`), with a visible **✕ clear** when a filter/search is active.
- **Persistent `›` row cue** + footer hint "click a row (or enter) for details".
- Tooltips: freshness `—` → "not tracked"; `update` badge → "a newer image is available".

## 2. Surface *why* a service is unhealthy
Previously the drawer showed only a red `unhealthy` badge — the model discarded the reason. Now:
- Additive `HealthDetail` on `model.ReportService` (backward compatible).
- **Docker** agent captures the failing healthcheck's last output + exit code (or a stopped-should-be-running container's exit code + daemon error).
- **Kubernetes** agent captures the not-ready container's waiting/termination reason (CrashLoopBackOff, OOMKilled…), falling back to the pod-level reason.
- Migration `0006` adds `services.health_detail`; ingest writes it, the services API returns it (`omitempty`), and the drawer shows a **"Why"** callout for unhealthy services.

## Verification
- Unit tests for both extractors (`HealthDetail`, `podDetail`), JSON-driven.
- Server round-trip E2E: POST an unhealthy report with a reason → GET `/api/v1/services` returns `health_detail`; healthy service omits it; `health_detail` column present (migration applied).
- `gofmt`/`go vet`/`go test ./...` clean; `node --check` on app.js; assets build + serve.
- Client-side view changes best eyeballed on the running dashboard.