### PR TITLE
ci: require conventional pull request titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: PR Title
+
+# Squash-merges use the pull request title as the commit subject on main, and
+# release-please only cuts a release when that subject is a Conventional Commit
+# (feat:, fix:, …). A non-conventional title (e.g. an auto-generated
+# "Feat/branch name") is silently non-releasable, so guard the title here.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

Squash-merges use the **PR title** as the commit subject on `main`. release-please only cuts a release when that subject is a Conventional Commit (`feat:`, `fix:`, …).

PR #20 squash-merged as `Feat/platform observability (#20)` (auto-generated from the branch name) — not conventional — so release-please detected no releasable change and never opened a release PR. #19 hit the same trap silently.

## What

Adds a `PR Title` workflow using `amannn/action-semantic-pull-request` that fails when a PR title isn't a valid Conventional Commit. Least-privilege (`pull-requests: read`), matches the pinning style of the existing workflows.

Follow-up (once merged): add **PR Title / conventional-title** to the branch-protection required checks so a bad title can't be merged.