### PR TITLE
refactor(model): typed Platform enum + validate

### DIFF
--- a/cmd/trove-agent-k8s/collect.go
+++ b/cmd/trove-agent-k8s/collect.go
@@ -71,7 +71,7 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 	return []agentkit.HostSnapshot{{
 		Host: model.ReportHost{
 			Hostname: c.cfg.cluster,
-			Meta:     map[string]string{"platform": "kubernetes"},
+			Meta:     map[string]string{"platform": string(model.PlatformKubernetes)},
 		},
 		Services: services,
 	}}, nil

--- a/cmd/trove-agent-k8s/main.go
+++ b/cmd/trove-agent-k8s/main.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 
 	"github.com/techdox/trove/internal/agentkit"
+	"github.com/techdox/trove/pkg/model"
 )
 
 // version is stamped at build time via -ldflags "-X main.version=...".
@@ -47,5 +48,5 @@ func main() {
 	defer stop()
 
 	col := &collector{cli: cli, cfg: kcfg, log: log}
-	agentkit.Run(ctx, cfg, "kubernetes", version, col, log)
+	agentkit.Run(ctx, cfg, model.PlatformKubernetes, version, col, log)
 }

--- a/cmd/trove-agent-local/main.go
+++ b/cmd/trove-agent-local/main.go
@@ -84,7 +84,7 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 	}
 
 	return []agentkit.HostSnapshot{{
-		Host:     model.ReportHost{Hostname: c.hostname, Meta: map[string]string{"platform": "local"}},
+		Host:     model.ReportHost{Hostname: c.hostname, Meta: map[string]string{"platform": string(model.PlatformLocal)}},
 		Services: services,
 	}}, nil
 }
@@ -130,7 +130,7 @@ func main() {
 		includeAll: includeAll,
 		hostname:   hostname,
 	}
-	agentkit.Run(ctx, cfg, "local", version, col, log)
+	agentkit.Run(ctx, cfg, model.PlatformLocal, version, col, log)
 }
 
 func parseBool(s string) (bool, bool) {

--- a/cmd/trove-agent-proxmox/main.go
+++ b/cmd/trove-agent-proxmox/main.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"github.com/techdox/trove/internal/agentkit"
+	"github.com/techdox/trove/pkg/model"
 )
 
 // version is stamped at build time via -ldflags "-X main.version=...".
@@ -44,5 +45,5 @@ func main() {
 	defer stop()
 
 	col := &collector{cli: newProxmoxClient(pcfg), log: log}
-	agentkit.Run(ctx, cfg, "proxmox", version, col, log)
+	agentkit.Run(ctx, cfg, model.PlatformProxmox, version, col, log)
 }

--- a/internal/agentkit/agentkit.go
+++ b/internal/agentkit/agentkit.go
@@ -91,7 +91,7 @@ type Collector interface {
 // Run drives the collect-and-push loop until ctx is cancelled. It pushes once
 // immediately, then on every interval. Each HostSnapshot is sent as its own
 // full-state report sharing the agent envelope built from cfg/platform/version.
-func Run(ctx context.Context, cfg Config, platform, version string, c Collector, log *slog.Logger) {
+func Run(ctx context.Context, cfg Config, platform model.Platform, version string, c Collector, log *slog.Logger) {
 	p := &pusher{
 		http:      &http.Client{Timeout: 15 * time.Second},
 		serverURL: cfg.ServerURL,

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -60,10 +60,29 @@ func (k Kind) Valid() bool {
 	}
 }
 
-// Platform identifies the agent type. Only Docker exists in Phase 1.
+// Platform identifies the agent type. Every agent must report one of these
+// values; the server validates it on ingest. The typed enum prevents
+// silent typos at the call site (agents use the constants, turning a
+// misspelling into a compile error) and lets the server reject unknown
+// platforms with a 400 rather than storing a free-string.
+type Platform string
+
 const (
-	PlatformDocker = "docker"
+	PlatformDocker     Platform = "docker"
+	PlatformKubernetes Platform = "kubernetes"
+	PlatformProxmox    Platform = "proxmox"
+	PlatformLocal      Platform = "local"
 )
+
+// Valid reports whether p is a recognized platform value.
+func (p Platform) Valid() bool {
+	switch p {
+	case PlatformDocker, PlatformKubernetes, PlatformProxmox, PlatformLocal:
+		return true
+	default:
+		return false
+	}
+}
 
 // StateRemoved is the synthetic state the server assigns to a service that was
 // previously reported but is absent from the latest full-state report. Agents
@@ -82,9 +101,9 @@ type Report struct {
 
 // ReportAgent identifies the pushing agent.
 type ReportAgent struct {
-	Name     string `json:"name"`
-	Platform string `json:"platform"`
-	Version  string `json:"version"`
+	Name     string   `json:"name"`
+	Platform Platform `json:"platform"`
+	Version  string   `json:"version"`
 	// IntervalSeconds is the agent's configured push interval. The server
 	// stores it and derives staleness thresholds per-agent (stale/offline are
 	// multiples of this), so a slow-polling agent isn't falsely flagged. Zero
@@ -139,8 +158,11 @@ func (r *Report) Validate() error {
 	if strings.TrimSpace(r.Agent.Name) == "" {
 		return errors.New("agent.name is required")
 	}
-	if strings.TrimSpace(r.Agent.Platform) == "" {
+	if strings.TrimSpace(string(r.Agent.Platform)) == "" {
 		return errors.New("agent.platform is required")
+	}
+	if !r.Agent.Platform.Valid() {
+		return fmt.Errorf("agent.platform %q is not a recognized platform", r.Agent.Platform)
 	}
 	if strings.TrimSpace(r.Host.Hostname) == "" {
 		return errors.New("host.hostname is required")


### PR DESCRIPTION
Replace the untyped PlatformDocker string constant with a typed Platform enum covering all four agents that ship today (docker, kubernetes, proxmox, local). Add Platform.Valid() mirroring the existing Health and Kind patterns. Tighten Report.Validate() to reject unknown platform values with a 400 instead of accepting any non-empty string.

Swap the three free-string literals in the k8s, proxmox, and local agent mains to use the new constants, and update agentkit.Run to accept model.Platform. The host meta 'platform' keys in k8s and local collectors also use the constants via string() conversion.

The JSON wire value is unchanged ("docker", "kubernetes", etc.) so existing agents remain compatible. ReportAgent.Platform is now typed Platform instead of bare string, but Go's JSON marshaling handles string-based named types transparently.