### PR TITLE
ci: build branch-tagged preview images on feature pushes

### DIFF
--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -1,0 +1,73 @@
+name: Preview images
+
+# Builds and pushes branch-tagged Docker images to GHCR on every push to a
+# feature branch. This lets you test a PR build without merging to main:
+#
+#   docker pull ghcr.io/techdox/trove-server:feat-oidc-auth
+#
+# Only the server image is built (it's the one with dashboard/auth changes).
+# Agent images are unchanged by most feature work and can be tested with
+# the latest released image.
+#
+# Images are tagged with a sanitized branch name. On main, the tag is
+# "main" (overwritten on every push). Tags are never published to
+# "latest" — that stays on goreleaser's release flow.
+#
+# Package visibility note: the first push of a NEW package to GHCR
+# inherits the repo's visibility at push time. If the package doesn't
+# exist yet, it will be created automatically by this workflow. For a
+# public repo, the package should also be public — check:
+#   https://github.com/users/Techdox/packages/container/package/trove-server/settings
+
+on:
+  push:
+    branches:
+      - 'feat/**'
+      - 'fix/**'
+      - 'refactor/**'
+      - 'ci/**'
+      - 'docs/**'
+      - 'main'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-server:
+    name: Build trove-server preview image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tag from branch name
+        id: tag
+        run: |
+          # Sanitize branch name: replace / with -, strip non-alphanumeric
+          raw="${GITHUB_REF#refs/heads/}"
+          tag=$(echo "$raw" | sed 's|/|-|g' | tr -cd '[:alnum:]._-')
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Building image tag: $tag"
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.server
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/techdox/trove-server:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Add a preview-images.yml workflow that builds and pushes the trove-server Docker image to GHCR on every push to feature branches (feat/*, fix/*, refactor/*, ci/*, docs/*) and main.

Images are tagged with a sanitized branch name, e.g.:
  ghcr.io/techdox/trove-server:feat-oidc-auth

This lets you test a PR build without merging to main:
  docker pull ghcr.io/techdox/trove-server:feat-oidc-auth

Multi-arch (amd64 + arm64) with GitHub Actions cache for fast rebuilds. Only builds the server image — agents use the latest released image for testing. Never publishes to :latest (goreleaser owns that).