### PR TITLE
ci: add Dockerfile drift check and token expiry alert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           fi
       - name: go vet
         run: go vet ./...
+      - name: Dockerfile drift check
+        run: ./scripts/check-dockerfile-drift.sh
       - name: golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
       - name: go test with coverage

--- a/.github/workflows/token-health.yml
+++ b/.github/workflows/token-health.yml
@@ -1,0 +1,63 @@
+name: token-health
+
+# RELEASE_PLEASE_TOKEN is a PAT with an expiry date. When it lapses,
+# release-please silently stops opening release PRs — the workflow "succeeds"
+# at doing nothing or fails quietly on a schedule nobody watches. This job
+# checks the token weekly and fails loudly (which triggers a GitHub
+# notification email to the repo owner) if the token is invalid or expires
+# within 30 days.
+#
+# How it works: any API call authenticated with an expiring token returns a
+# `github-authentication-token-expiration` response header. We read it and
+# compare against now + 30 days. Non-expiring classic PATs omit the header,
+# which we treat as healthy.
+
+on:
+  schedule:
+    # Mondays 09:00 UTC — weekly is enough lead time with a 30-day threshold.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check-release-please-token:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check RELEASE_PLEASE_TOKEN validity and expiry
+        env:
+          TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TOKEN" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN secret is not set"
+            exit 1
+          fi
+
+          headers=$(mktemp)
+          status=$(curl -sS -o /dev/null -D "$headers" -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" \
+            https://api.github.com/user)
+
+          if [ "$status" != "200" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN is invalid or revoked (HTTP $status). release-please cannot open release PRs."
+            exit 1
+          fi
+
+          expiry=$(grep -i '^github-authentication-token-expiration:' "$headers" \
+            | sed 's/^[^:]*: *//' | tr -d '\r' || true)
+
+          if [ -z "$expiry" ]; then
+            echo "token is valid and has no expiration date"
+            exit 0
+          fi
+
+          expiry_epoch=$(date -d "$expiry" +%s)
+          threshold_epoch=$(date -d '+30 days' +%s)
+          days_left=$(( (expiry_epoch - $(date +%s)) / 86400 ))
+
+          echo "token expires: $expiry (~$days_left days)"
+          if [ "$expiry_epoch" -lt "$threshold_epoch" ]; then
+            echo "::error::RELEASE_PLEASE_TOKEN expires in $days_left days ($expiry). Rotate it: repo Settings -> Secrets -> Actions -> RELEASE_PLEASE_TOKEN. See CONTRIBUTING.md for required scopes."
+            exit 1
+          fi

--- a/scripts/check-dockerfile-drift.sh
+++ b/scripts/check-dockerfile-drift.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Check that dev/compose Dockerfiles and their goreleaser release counterparts
+# stay in sync on the bits that matter at runtime: final base image, ENV
+# defaults, EXPOSE, and VOLUME. The header comments in each Dockerfile promise
+# this sync; this script enforces it in CI.
+#
+# Pairs checked (dev -> release):
+#   Dockerfile.server -> build/docker/Dockerfile.server
+#   Dockerfile.agent  -> build/docker/Dockerfile.agent-docker
+#   Dockerfile.agents -> build/docker/Dockerfile.agent-k8s
+#   Dockerfile.agents -> build/docker/Dockerfile.agent-proxmox
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# Extract the final stage of a Dockerfile (everything from the last FROM on),
+# then keep only runtime-relevant directives, normalising whitespace and
+# stripping comments and line continuations.
+final_stage_runtime() {
+  local file=$1
+  awk '/^FROM /{stage=""} {stage=stage $0 "\n"} END{printf "%s", stage}' "$file" \
+    | sed -e 's/#.*$//' \
+    | tr -d '\\' \
+    | tr -s ' \t' ' ' \
+    | grep -E '^ ?(FROM|ENV|EXPOSE|VOLUME) ' \
+    | sed -e 's/^ //' -e 's/ $//' \
+    | sort
+}
+
+check_pair() {
+  local dev=$1 release=$2
+  local dev_sig release_sig
+  dev_sig=$(final_stage_runtime "$dev")
+  release_sig=$(final_stage_runtime "$release")
+  if [ "$dev_sig" != "$release_sig" ]; then
+    echo "DRIFT: $dev and $release differ in final-stage runtime directives" >&2
+    diff <(printf '%s\n' "$dev_sig") <(printf '%s\n' "$release_sig") >&2 || true
+    fail=1
+  else
+    echo "ok: $dev == $release"
+  fi
+}
+
+check_pair Dockerfile.server build/docker/Dockerfile.server
+check_pair Dockerfile.agent  build/docker/Dockerfile.agent-docker
+check_pair Dockerfile.agents build/docker/Dockerfile.agent-k8s
+check_pair Dockerfile.agents build/docker/Dockerfile.agent-proxmox
+
+exit "$fail"


### PR DESCRIPTION
## Summary

Two small CI follow-ups from the project review — the last remaining pipeline items after #34.

### Dockerfile drift check

`scripts/check-dockerfile-drift.sh`, wired into the CI `test` job. The dev/compose Dockerfiles and their goreleaser release counterparts each carry a "keep in sync" comment; this enforces it. Compares final-stage runtime directives (`FROM`, `ENV`, `EXPOSE`, `VOLUME`) across:

- `Dockerfile.server` ↔ `build/docker/Dockerfile.server`
- `Dockerfile.agent` ↔ `build/docker/Dockerfile.agent-docker`
- `Dockerfile.agents` ↔ `build/docker/Dockerfile.agent-k8s` and `Dockerfile.agent-proxmox`

Fails with a diff of exactly what drifted.

### RELEASE_PLEASE_TOKEN expiry alert

`.github/workflows/token-health.yml` — weekly scheduled job (Mondays 09:00 UTC, plus `workflow_dispatch`). Calls the GitHub API with the token and reads the `github-authentication-token-expiration` response header. Fails loudly if the token is invalid/revoked or expires within 30 days, so the failure notification lands before release-please silently stops opening release PRs. Non-expiring tokens (no header) pass.

## Verification

- [x] Drift script passes clean on the current tree (all 4 pairs `ok`)
- [x] Negative test: mutating `TROVE_ADDR` in `Dockerfile.server` makes the script exit 1 with a correct diff
- [x] Token expiry logic tested locally with simulated headers: near-expiry token (11 days) alerts, no-expiry header passes
- [x] `workflow_dispatch` included so the token job can be smoke-run manually after merge

## Notes

The token-health job needs one manual `workflow_dispatch` run after merge to confirm it works against the real secret — scheduled workflows only run from the default branch.
