### PR TITLE
fix: clear stale service parent links

### DIFF
--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -149,26 +149,29 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 	}
 
 	// 5. Resolve parent/child links. Both parent and child are present in the
-	// same full-state report, so all ids are known by now regardless of order.
-	// Only touch services that report a parent (leaves standalone rows' NULL
-	// parent_id untouched, avoiding needless writes).
+	// Resolve parent links after all services are upserted (parents and children
+	// may appear in any order in the report). Touch every reported service so a
+	// child that later becomes standalone has its old parent_id cleared.
 	for i := range r.Services {
 		svc := &r.Services[i]
-		if svc.ParentExternalID == "" {
-			continue
-		}
 		childID, ok := idByExtID[svc.ExternalID]
 		if !ok {
 			continue
 		}
+
 		var parentID sql.NullInt64
-		if pid, ok := idByExtID[svc.ParentExternalID]; ok {
+		if svc.ParentExternalID != "" {
+			pid, ok := idByExtID[svc.ParentExternalID]
+			if !ok {
+				// Unknown parent in this host snapshot. Leave parent_id unchanged
+				// rather than guessing across hosts/agents.
+				continue
+			}
 			parentID = sql.NullInt64{Int64: pid, Valid: true}
 		}
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE services SET parent_id = ? WHERE id = ?`, parentID, childID,
-		); err != nil {
-			return fmt.Errorf("link service %q to parent: %w", svc.ExternalID, err)
+
+		if _, err := tx.ExecContext(ctx, `UPDATE services SET parent_id = ? WHERE id = ?`, parentID, childID); err != nil {
+			return fmt.Errorf("link service %q to parent %q: %w", svc.ExternalID, svc.ParentExternalID, err)
 		}
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -319,6 +319,33 @@ func TestApplyReportParentChild(t *testing.T) {
 	}
 }
 
+func TestApplyReportParentChildClearsStaleParent(t *testing.T) {
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "k8s")
+
+	dep := model.ReportService{ExternalID: "deploy/default/web", Name: "web", Kind: model.KindDeployment, State: "1/1", Health: model.HealthHealthy}
+	podWithParent := model.ReportService{ExternalID: "pod/default/web-a", ParentExternalID: "deploy/default/web", Name: "web-a", Kind: model.KindPod, State: "running", Health: model.HealthHealthy}
+	if err := st.ApplyReport(ctx, agent.ID, report(dep, podWithParent)); err != nil {
+		t.Fatalf("apply with parent: %v", err)
+	}
+
+	podStandalone := podWithParent
+	podStandalone.ParentExternalID = ""
+	if err := st.ApplyReport(ctx, agent.ID, report(dep, podStandalone)); err != nil {
+		t.Fatalf("apply standalone: %v", err)
+	}
+
+	rows, _ := st.ListServices(ctx)
+	byID := map[string]ServiceRow{}
+	for _, r := range rows {
+		byID[r.ExternalID] = r
+	}
+	if got := byID["pod/default/web-a"].ParentExternalID; got.Valid {
+		t.Fatalf("stale parent link persisted as %q", got.String)
+	}
+}
+
 func TestFreshnessJoinAndDue(t *testing.T) {
 	st, clock := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- resolve parent links for every reported service, not only services currently reporting a parent
- clear parent_id when a previously-child service becomes standalone
- add a regression test for stale parent cleanup

## Verification
- make fmt
- make vet
- make test
- go test -race ./...
- make build