### PR TITLE
fix: bump go toolchain to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/techdox/trove
 
-go 1.26.4
+go 1.26.5
 
 require modernc.org/sqlite v1.53.0
 


### PR DESCRIPTION
## Summary
- bump Go toolchain from 1.26.4 to 1.26.5 to pick up the stdlib security fix reported by govulncheck

## Verification
- make fmt
- make vet
- make test
- go test -race ./...
- make build
- go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./... → No vulnerabilities found