### PR TITLE
docs: refresh auth and release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Static binaries for everything (including the bare-metal agent) are on the
 
 ```sh
 # pick the URL for your arch off the releases page, e.g.:
-VERSION=0.4.0        # the release you're installing
+VERSION=0.11.0       # check https://github.com/techdox/trove/releases/latest for newer releases
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
 
@@ -238,7 +238,7 @@ Dex, etc.):
 When `TROVE_OIDC_ISSUER` is set, browser requests without a session are
 redirected to your IdP's login page. After login, a signed session cookie
 is set (8h default, no server-side session store). API requests with
-`Authorization: Bearer <your-api-token>` bypass OIDC for script access.
+`Authorization: Bearer TROVE_API_TOKEN_VALUE` bypass OIDC for script access.
 
 Logout clears Trove's local session cookie and, when the provider exposes an
 OIDC `end_session_endpoint`, redirects through provider logout so users are not
@@ -248,18 +248,18 @@ Agent ingest (`POST /api/v1/report`) and `/healthz` are never gated by OIDC.
 
 **Authentik setup:** create an OAuth2/OpenID provider with these settings:
 
-- Redirect URI: `https://trove.<your-domain>/oauth2/callback`
-- Post-logout redirect/return URI: `https://trove.<your-domain>/`
+- Redirect URI: `https://trove.example.com/oauth2/callback`
+- Post-logout redirect/return URI: `https://trove.example.com/`
 - Client type: Confidential
 - Scopes: `openid`, `profile`, `email`
 
 Then set the env vars:
 
 ```sh
-TROVE_OIDC_ISSUER=https://auth.<your-domain>/application/o/trove/
+TROVE_OIDC_ISSUER=https://auth.example.com/application/o/trove/
 TROVE_OIDC_CLIENT_ID=trove
-TROVE_OIDC_CLIENT_SECRET=<your-client-secret>
-TROVE_OIDC_REDIRECT_URL=https://trove.<your-domain>/oauth2/callback
+TROVE_OIDC_CLIENT_SECRET=OIDC_CLIENT_SECRET_VALUE
+TROVE_OIDC_REDIRECT_URL=https://trove.example.com/oauth2/callback
 ```
 
 Full setup, logout behaviour, verification commands, and troubleshooting live

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,11 @@
 # Trove Roadmap
 
-**Status:** `v0.10.0` is the current public release. Phases 1–4 are shipped on
+**Status:** `v0.11.0` is the current public release. Phases 1–4 are shipped on
 `main` — Docker/Kubernetes/Proxmox/bare-metal agents, per-agent token auth,
 heartbeat/staleness, image freshness, the parent/child model, configurable
 retention, and alerting (webhook/Discord/ntfy + email digest — see
 [docs/alerts.md](docs/alerts.md)). Phase 5 is partially delivered: OIDC auth
-for the dashboard and read APIs shipped in `v0.10.0`; Helm packaging remains.
+for the dashboard and read APIs shipped in `v0.10.0`; observability/API hardening shipped in `v0.11.0`; Helm packaging remains.
 Both pinned decisions are resolved: D2 (parent/child) shipped with Phase 3, D1
 (retention) with Phase 4. Trove is MIT licensed and public. See the
 [README](README.md) for what exists today.

--- a/deploy/kubernetes/trove-agent.yaml
+++ b/deploy/kubernetes/trove-agent.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: trove-agent
       containers:
         - name: agent
-          image: ghcr.io/techdox/trove-agent-k8s:latest
+          image: ghcr.io/techdox/trove-agent-k8s:0.11.0
           env:
             - name: TROVE_SERVER_URL
               value: "http://trove-server.example.internal:8080"

--- a/deploy/systemd/trove-server.service
+++ b/deploy/systemd/trove-server.service
@@ -9,8 +9,8 @@
 # manual mkdir needed (and a manual one can mis-own it against DynamicUser).
 #
 # Override settings via a drop-in (systemctl edit trove-server) or
-# /etc/trove-server.env. The dashboard has no auth — bind to a trusted
-# interface or front with an authenticating reverse proxy.
+# /etc/trove-server.env. The dashboard is open unless you configure OIDC —
+# bind to a trusted interface, set TROVE_OIDC_*, or front it with auth.
 
 [Unit]
 Description=Trove server (read-only service catalog)

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -26,7 +26,7 @@ docker compose exec server trove-server agent create nas01
 ```sh
 # grab the archive for your arch from the latest release. Set VERSION to the
 # release you're installing (see https://github.com/techdox/trove/releases).
-VERSION=0.4.0
+VERSION=0.11.0
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-agent-local_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-agent-local_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-agent-local /usr/local/bin/

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Trove's API is read-mostly by design. Agents push full-state reports into the server, and humans or automation read catalog state back out.
 
-If OIDC is enabled, read APIs require either an authenticated dashboard session or `Authorization: Bearer $TROVE_API_TOKEN` when `TROVE_API_TOKEN` is configured. Agent ingest always uses the agent token and is never gated by OIDC.
+If OIDC is enabled, read APIs require either an authenticated dashboard session or `Authorization: Bearer TROVE_API_TOKEN_VALUE` when `TROVE_API_TOKEN` is configured. Agent ingest always uses the agent token and is never gated by OIDC.
 
 ## Endpoints
 
@@ -31,7 +31,8 @@ Optional query parameters:
 Example:
 
 ```sh
-curl -H "Authorization: Bearer $TROVE_API_TOKEN" \
+TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
+  curl --oauth2-bearer "$TROVE_API_TOKEN" \
   'https://trove.example/api/v1/services?limit=100&offset=0&since=2026-07-01T00:00:00Z'
 ```
 
@@ -64,7 +65,8 @@ Optional query parameters:
 Example:
 
 ```sh
-curl -H "Authorization: Bearer $TROVE_API_TOKEN" \
+TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
+  curl --oauth2-bearer "$TROVE_API_TOKEN" \
   'https://trove.example/api/v1/events?kind=health&limit=50&offset=50'
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -49,9 +49,9 @@ Example:
 ```env
 TROVE_OIDC_ISSUER=https://auth.example.com/application/o/trove/
 TROVE_OIDC_CLIENT_ID=trove
-TROVE_OIDC_CLIENT_SECRET=change-me
+TROVE_OIDC_CLIENT_SECRET=OIDC_CLIENT_SECRET_VALUE
 TROVE_OIDC_REDIRECT_URL=https://trove.example.com/oauth2/callback
-TROVE_API_TOKEN=<your-api-token>
+TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE
 TROVE_OIDC_SESSION_MAX_AGE=8h
 ```
 
@@ -117,7 +117,8 @@ After the provider logout finishes, the user lands back at the dashboard root an
 If OIDC is enabled and you want scripts to query read APIs, set `TROVE_API_TOKEN` and send it as a bearer token:
 
 ```sh
-curl -H "Authorization: Bearer <your-api-token>" \
+TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \\
+  curl --oauth2-bearer "$TROVE_API_TOKEN" \\
   https://trove.example.com/api/v1/services
 ```
 
@@ -146,7 +147,8 @@ curl -i https://trove.example.com/api/v1/services
 API requests with `TROVE_API_TOKEN` should return JSON:
 
 ```sh
-curl -H "Authorization: Bearer <your-api-token>" \
+TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \\
+  curl --oauth2-bearer "$TROVE_API_TOKEN" \\
   https://trove.example.com/api/v1/services
 ```
 

--- a/examples/docker-compose.proxmox.yml
+++ b/examples/docker-compose.proxmox.yml
@@ -22,8 +22,8 @@
 # and add its agent (see the per-platform guides):
 #        docker compose exec server trove-server agent create <name>
 #
-# ⚠ The dashboard has no authentication yet — keep port 8080 on a trusted
-#   network (LAN/VPN) or behind an authenticating reverse proxy.
+# ⚠ The dashboard is open unless you configure OIDC — keep port 8080 on a trusted
+#   network (LAN/VPN), enable TROVE_OIDC_*, or put it behind auth.
 
 services:
   server:

--- a/examples/docker-compose.server.yml
+++ b/examples/docker-compose.server.yml
@@ -18,8 +18,8 @@
 #        docker compose -f docker-compose.server.yml exec server \
 #          trove-server agent create <name>
 #
-# ⚠ The dashboard has no authentication yet — keep port 8080 on a trusted
-#   network (LAN/VPN) or behind an authenticating reverse proxy.
+# ⚠ The dashboard is open unless you configure OIDC — keep port 8080 on a trusted
+#   network (LAN/VPN), enable TROVE_OIDC_*, or put it behind auth.
 
 services:
   server:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -14,8 +14,8 @@
 # own token with:
 #        docker compose exec server trove-server agent create <name>
 #
-# ⚠ The dashboard has no authentication yet — keep port 8080 on a trusted
-#   network (LAN/VPN) or behind an authenticating reverse proxy.
+# ⚠ The dashboard is open unless you configure OIDC — keep port 8080 on a trusted
+#   network (LAN/VPN), enable TROVE_OIDC_*, or put it behind auth.
 
 services:
   server:


### PR DESCRIPTION
## Summary
- update stale no-auth wording now that OIDC exists
- fix bearer-token examples and renderer-hostile placeholders
- refresh release-version examples and roadmap status
- pin the Kubernetes deployment example to the current released image instead of latest

## Verification
- git diff --check
- docs placeholder checks via Python
- node --check web/public/app.js