### PR TITLE
fix: retry alerts after failed delivery

### DIFF
--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -118,7 +118,11 @@ func (e *Engine) sweepEvents(ctx context.Context) {
 	for _, ev := range events {
 		if e.cfg.Kinds[ev.Kind] {
 			if key, n, verdict, ok := classify(ev); ok {
-				e.deliver(ctx, key, verdict, n)
+				if !e.deliver(ctx, key, verdict, n) {
+					// Leave this event unconsumed so the next sweep can retry the
+					// notification instead of marking a failed send as delivered.
+					break
+				}
 			}
 		}
 		cursor = ev.ID
@@ -372,32 +376,34 @@ func (e *Engine) sweepFreshness(ctx context.Context) {
 //     original cooldown anchor. One exception: an escalation — a *worse*
 //     value at critical level after an already-notified bad — bypasses
 //     cooldown once (e.g. agent stale → offline).
-func (e *Engine) deliver(ctx context.Context, key string, v verdictT, n Notification) {
+func (e *Engine) deliver(ctx context.Context, key string, v verdictT, n Notification) bool {
 	now := e.now().Unix()
 	st, seen, err := e.store.GetAlertState(ctx, key)
 	if err != nil {
 		e.log.Error("alert: state read", "key", key, "err", err)
-		return
+		return false
 	}
 
 	if v.bad == "" { // recovery
 		if !seen || st.Value == "" {
-			return // nothing was bad; stay quiet
+			return true // nothing was bad; stay quiet
 		}
 		if st.Notified {
-			e.send(ctx, n)
+			if !e.send(ctx, n) {
+				return false
+			}
 			_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: "", Notified: false, SentAt: now})
 		} else {
 			// The bad state was never announced — clear silently and keep the
 			// cooldown anchor so an immediate re-flap doesn't reset the window.
 			_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: "", Notified: false, SentAt: st.SentAt})
 		}
-		return
+		return true
 	}
 
 	// bad path
 	if seen && st.Value == v.bad && st.Notified {
-		return // same already-announced incident re-observed; nothing to do
+		return true // same already-announced incident re-observed; nothing to do
 	}
 	inCooldown := seen && now-st.SentAt < int64(e.cfg.Cooldown.Seconds())
 	escalation := st.Notified && st.Value != "" && st.Value != v.bad && v.level == LevelCritical
@@ -405,20 +411,26 @@ func (e *Engine) deliver(ctx context.Context, key string, v verdictT, n Notifica
 		if st.Value != v.bad || st.Notified {
 			_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: v.bad, Notified: false, SentAt: st.SentAt})
 		}
-		return
+		return true
 	}
-	e.send(ctx, n)
+	if !e.send(ctx, n) {
+		return false
+	}
 	_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: v.bad, Notified: true, SentAt: now})
+	return true
 }
 
-func (e *Engine) send(ctx context.Context, n Notification) {
+func (e *Engine) send(ctx context.Context, n Notification) bool {
+	sent := false
 	for _, d := range e.dispatchers {
 		if err := d.Send(ctx, n); err != nil {
 			e.log.Error("alert: send failed", "channel", d.Name(), "title", n.Title, "err", err)
 		} else {
+			sent = true
 			e.log.Info("alert sent", "channel", d.Name(), "level", n.Level, "title", n.Title)
 		}
 	}
+	return sent
 }
 
 // SendTest pushes a test notification through every configured channel and

--- a/internal/alert/engine_test.go
+++ b/internal/alert/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -183,6 +184,46 @@ func TestEngineAgentTransitions(t *testing.T) {
 	e.Sweep(ctx)
 	if s.count() != 1 || s.titles()[0] != "resolved: agent docker-a recovered" {
 		t.Fatalf("want agent recovery notice, got: %v", s.titles())
+	}
+}
+
+func TestEngineRetriesEventWhenAllDispatchersFail(t *testing.T) {
+	e, st, s, _ := newTestEngine(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "docker-a")
+
+	_ = st.ApplyReport(ctx, agent.ID, testReport(testSvc("running", model.HealthHealthy)))
+	e.Sweep(ctx) // seed cursor
+
+	s.fail = true
+	_ = st.ApplyReport(ctx, agent.ID, testReport(testSvc("running", model.HealthUnhealthy)))
+	e.Sweep(ctx)
+	failedAttempts := s.count()
+	if failedAttempts == 0 {
+		t.Fatal("want at least one failed delivery attempt")
+	}
+
+	rows, err := st.ListServices(ctx)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list services: rows=%+v err=%v", rows, err)
+	}
+	key := "svc:" + strconv.FormatInt(rows[0].ID, 10) + ":health"
+	state, seen, err := st.GetAlertState(ctx, key)
+	if err != nil {
+		t.Fatalf("get alert state: %v", err)
+	}
+	if seen && state.Notified {
+		t.Fatalf("failed delivery was marked notified: %+v", state)
+	}
+
+	s.fail = false
+	e.Sweep(ctx)
+	if s.count() != failedAttempts+1 {
+		t.Fatalf("want one successful retry after dispatcher recovers, got titles: %v", s.titles())
+	}
+	state, seen, err = st.GetAlertState(ctx, key)
+	if err != nil || !seen || !state.Notified || state.Value != "unhealthy" {
+		t.Fatalf("successful retry did not mark notified: state=%+v seen=%v err=%v", state, seen, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make alert delivery report whether at least one dispatcher succeeded
- do not mark incidents notified when every dispatcher fails
- keep failed event alerts unconsumed so the next sweep retries instead of advancing past them
- add regression coverage for failed-send retry behavior

## Verification
- make fmt
- make vet
- make test
- go test -race ./...
- make build
- previous stacked PR checks passed before #48 merged