### PR TITLE
fix: harden oidc return paths

### DIFF
--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -275,6 +275,38 @@ func isBrowserRequest(r *http.Request) bool {
 	return strings.Contains(accept, "text/html")
 }
 
+// safeReturnPath accepts only local absolute paths. It rejects absolute URLs,
+// protocol-relative URLs (//host/path), malformed paths, and path strings that
+// do not start at the dashboard root.
+func safeReturnPath(raw string) string {
+	if raw == "" || strings.HasPrefix(raw, "//") {
+		return "/"
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.IsAbs() || u.Host != "" || u.Path == "" || !strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, "//") {
+		return "/"
+	}
+	u.Scheme = ""
+	u.Host = ""
+	return u.RequestURI()
+}
+
+func stateWithReturn(state, returnPath string) string {
+	return state + "." + base64.RawURLEncoding.EncodeToString([]byte(safeReturnPath(returnPath)))
+}
+
+func returnPathFromState(state string) string {
+	parts := strings.SplitN(state, ".", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "/"
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "/"
+	}
+	return safeReturnPath(string(decoded))
+}
+
 // ---- Handlers --------------------------------------------------------------
 
 // handleOIDCLogin redirects the user to the IdP's authorization endpoint.
@@ -285,6 +317,14 @@ func (p *oidcProvider) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "internal error")
 		return
 	}
+	returnPath := "/"
+	if ret := r.URL.Query().Get("return"); ret != "" {
+		if decoded, err := base64.RawURLEncoding.DecodeString(ret); err == nil {
+			returnPath = safeReturnPath(string(decoded))
+		}
+	}
+	state = stateWithReturn(state, returnPath)
+
 	// Store state in a short-lived cookie for CSRF verification on callback.
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
@@ -368,17 +408,8 @@ func (p *oidcProvider) handleOIDCCallback(w http.ResponseWriter, r *http.Request
 
 	p.log.Info("oidc login", "subject", idToken.Subject, "email", claims.Email)
 
-	// Redirect to the return URL or dashboard root.
-	returnURL := "/"
-	if ret := r.URL.Query().Get("return"); ret != "" {
-		if decoded, err := base64.RawURLEncoding.DecodeString(ret); err == nil {
-			returnURL = string(decoded)
-			// Basic safety: only allow paths starting with /.
-			if !strings.HasPrefix(returnURL, "/") {
-				returnURL = "/"
-			}
-		}
-	}
+	// Redirect to the return URL carried in the verified OAuth state.
+	returnURL := returnPathFromState(stateParam)
 	http.Redirect(w, r, returnURL, http.StatusSeeOther)
 }
 

--- a/internal/server/oidc_test.go
+++ b/internal/server/oidc_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 // testProvider builds an oidcProvider without doing real OIDC discovery,
@@ -18,6 +20,12 @@ import (
 func testProvider(t *testing.T) *oidcProvider {
 	t.Helper()
 	return &oidcProvider{
+		oauth2: &oauth2.Config{
+			ClientID:    "test-client",
+			RedirectURL: "https://trove.example/oauth2/callback",
+			Endpoint:    oauth2.Endpoint{AuthURL: "https://idp.example/auth", TokenURL: "https://idp.example/token"},
+			Scopes:      []string{"openid", "profile", "email"},
+		},
 		cfg: OIDCConfig{
 			Issuer:        "https://idp.example",
 			ClientID:      "test-client",
@@ -241,6 +249,71 @@ func TestIsBrowserRequest(t *testing.T) {
 		if got != c.wantBrowser {
 			t.Errorf("isBrowserRequest(accept=%q, auth=%q) = %v, want %v", c.accept, c.auth, got, c.wantBrowser)
 		}
+	}
+}
+
+func TestSafeReturnPath(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"root", "/", "/"},
+		{"path with query", "/api/v1/services?status=unhealthy", "/api/v1/services?status=unhealthy"},
+		{"relative", "api/v1/services", "/"},
+		{"absolute url", "https://evil.example/phish", "/"},
+		{"protocol relative", "//evil.example/phish", "/"},
+		{"triple slash", "///evil.example/phish", "/"},
+		{"javascript", "javascript:alert(1)", "/"},
+		{"empty", "", "/"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := safeReturnPath(c.raw); got != c.want {
+				t.Fatalf("safeReturnPath(%q) = %q, want %q", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestHandleOIDCLoginCarriesSafeReturnInState(t *testing.T) {
+	p := testProvider(t)
+	ret := base64.RawURLEncoding.EncodeToString([]byte("/api/v1/services?status=unhealthy"))
+	req := httptest.NewRequest("GET", "/oauth2/login?return="+ret, nil)
+	w := httptest.NewRecorder()
+	p.handleOIDCLogin(w, req)
+
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusSeeOther)
+	}
+	loc := w.Header().Get("Location")
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state := u.Query().Get("state")
+	if got := returnPathFromState(state); got != "/api/v1/services?status=unhealthy" {
+		t.Fatalf("state return path = %q", got)
+	}
+	cookie := w.Result().Cookies()[0]
+	if cookie.Name != stateCookieName || cookie.Value != state {
+		t.Fatalf("state cookie = %s/%q, want %s/%q", cookie.Name, cookie.Value, stateCookieName, state)
+	}
+}
+
+func TestHandleOIDCLoginSanitizesUnsafeReturnInState(t *testing.T) {
+	p := testProvider(t)
+	ret := base64.RawURLEncoding.EncodeToString([]byte("//evil.example/phish"))
+	req := httptest.NewRequest("GET", "/oauth2/login?return="+ret, nil)
+	w := httptest.NewRecorder()
+	p.handleOIDCLogin(w, req)
+
+	u, err := url.Parse(w.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if got := returnPathFromState(u.Query().Get("state")); got != "/" {
+		t.Fatalf("unsafe return path = %q, want /", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve login deep links by carrying the sanitized return path inside verified OAuth state
- reject absolute URLs, protocol-relative URLs, and malformed return values
- redirect callback using the verified state value instead of a loose callback query parameter
- add sanitizer and login-state regression tests

## Verification
- make fmt
- make vet
- make test
- go test -race ./...
- make build
- previous stacked PR checks passed before #48 merged