### PR TITLE
fix: align freshness badge label with chip and verdict

### DIFF
--- a/web/public/app.js
+++ b/web/public/app.js
@@ -216,7 +216,7 @@ function portsHTML(ports) {
 function freshnessCell(s) {
   switch (s.freshness) {
     case "outdated":
-      return `<span class="badge b-peach" title="A newer image is available for this tag.&#10;running: ${esc(s.image_digest || "?")}&#10;latest:  ${esc(s.latest_digest || "?")}">update</span>`;
+      return `<span class="badge b-peach" title="A newer image is available for this tag.&#10;running: ${esc(s.image_digest || "?")}&#10;latest:  ${esc(s.latest_digest || "?")}>outdated</span>`;
     case "current":
       return '<span class="badge b-blue">up to date</span>';
     default:
@@ -434,7 +434,29 @@ function renderHosts() {
 
   el.innerHTML = sections.length > 0
     ? sections.join("")
-    : '<div class="host"><div class="empty">No services match the current filter.</div></div>';
+    : `<div class="host"><div class="empty">${emptyMessage()}</div></div>`;
+}
+
+function emptyMessage() {
+  const c = computeCounts();
+  // If only chip filters are active and every active chip has zero matches,
+  // the empty state is a positive: nothing is in that state.
+  const activeChips = [...state.chips];
+  if (!state.q.trim() && activeChips.length > 0) {
+    const allZero = activeChips.every((k) => {
+      const def = CHIP_DEFS.find((d) => d.key === k);
+      return def && countsForChip(k, c) === 0;
+    });
+    if (allZero) {
+      const label = activeChips.length === 1 ? activeChips[0] : "selected";
+      return `No services are currently ${label}.`;
+    }
+  }
+  return "No services match the current filter.";
+}
+
+function countsForChip(key, c) {
+  return { running: c.running, unhealthy: c.unhealthy, outdated: c.outdated, stale: c.stale }[key] ?? 0;
 }
 
 // -------------------------------------------------------------- events ----
@@ -536,7 +558,7 @@ function renderDrawer() {
     <div class="d-badges">
       ${badge(stateClass(s.state), s.state || "?")}
       ${badge(HEALTH_CLASS[s.health] || "b-gray", s.health || "unknown")}
-      ${s.freshness === "outdated" ? badge("b-peach", "update available")
+      ${s.freshness === "outdated" ? badge("b-peach", "outdated")
         : s.freshness === "current" ? badge("b-blue", "up to date") : ""}
     </div>
     ${s.health_detail


### PR DESCRIPTION
## What

Two dashboard UX fixes found via an adversarial UX test (persona: non-technical user landing on the dashboard for the first time).

### 1. Freshness label mismatch

The freshness chip filter and verdict strip both said **"outdated"**, but the per-service badge said **"update"** and the drawer said **"update available"**. Same concept, three different labels.

Now all surfaces use **"outdated"** consistently.

### 2. Smart empty state for zero-count chips

Clicking a zero-count chip like **"stale 0"** showed "No services match the current filter" — which reads as broken, not as a positive.

Now it says **"No services are currently stale."** when the only active filters are chips with zero matches. Falls back to the generic message for text-search no-results.

## Verification

- `make build` — clean
- `go test ./...` — all pass
- No Go changes (pure `app.js`)

## Adversarial UX test context

The deployed instance is running v0.6.0 but the repo is at v0.11.1. Most persona complaints (verdict banner, clear-filters button, row hover, FRESHNESS tooltip) were already fixed in the repo. These two were the real remaining items.