### PR TITLE
fix: retry only failed alert channels

### DIFF
--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -389,7 +389,7 @@ func (e *Engine) deliver(ctx context.Context, key string, v verdictT, n Notifica
 			return true // nothing was bad; stay quiet
 		}
 		if st.Notified {
-			if !e.send(ctx, n) {
+			if !e.send(ctx, deliveryKey(key, v), n) {
 				return false
 			}
 			_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: "", Notified: false, SentAt: now})
@@ -413,24 +413,58 @@ func (e *Engine) deliver(ctx context.Context, key string, v verdictT, n Notifica
 		}
 		return true
 	}
-	if !e.send(ctx, n) {
+	if !e.send(ctx, deliveryKey(key, v), n) {
 		return false
 	}
 	_ = e.store.SetAlertState(ctx, key, store.AlertState{Value: v.bad, Notified: true, SentAt: now})
 	return true
 }
 
-func (e *Engine) send(ctx context.Context, n Notification) bool {
-	sent := false
+// deliveryKey identifies one pending incident notification. It intentionally
+// excludes the timestamp so retries of a freshness transition (which creates a
+// new Notification timestamp on each sweep) still resume the same fan-out.
+func deliveryKey(key string, v verdictT) string {
+	if v.bad == "" {
+		return key + "\x1frecovery"
+	}
+	return key + "\x1fbad\x1f" + v.bad
+}
+
+// send delivers n to every configured channel. Successful channels are
+// persisted while any sibling channel is failing, so a retry resumes only the
+// failed channels and does not duplicate notifications already accepted.
+func (e *Engine) send(ctx context.Context, key string, n Notification) bool {
+	allDelivered := true
 	for _, d := range e.dispatchers {
+		delivered, err := e.store.ChannelDelivered(ctx, key, d.Name())
+		if err != nil {
+			e.log.Error("alert: read channel delivery", "channel", d.Name(), "title", n.Title, "err", err)
+			allDelivered = false
+			continue
+		}
+		if delivered {
+			continue
+		}
 		if err := d.Send(ctx, n); err != nil {
 			e.log.Error("alert: send failed", "channel", d.Name(), "title", n.Title, "err", err)
-		} else {
-			sent = true
-			e.log.Info("alert sent", "channel", d.Name(), "level", n.Level, "title", n.Title)
+			allDelivered = false
+			continue
 		}
+		if err := e.store.MarkChannelDelivered(ctx, key, d.Name()); err != nil {
+			e.log.Error("alert: record channel delivery", "channel", d.Name(), "title", n.Title, "err", err)
+			allDelivered = false
+			continue
+		}
+		e.log.Info("alert sent", "channel", d.Name(), "level", n.Level, "title", n.Title)
 	}
-	return sent
+	if !allDelivered {
+		return false
+	}
+	if err := e.store.ClearChannelDeliveries(ctx, key); err != nil {
+		e.log.Error("alert: clear channel deliveries", "title", n.Title, "err", err)
+		return false
+	}
+	return true
 }
 
 // SendTest pushes a test notification through every configured channel and

--- a/internal/alert/engine_test.go
+++ b/internal/alert/engine_test.go
@@ -26,6 +26,13 @@ type sink struct {
 	fail bool
 }
 
+type namedDispatcher struct {
+	name string
+	Dispatcher
+}
+
+func (d namedDispatcher) Name() string { return d.name }
+
 func newSink(t *testing.T) *sink {
 	t.Helper()
 	s := &sink{}
@@ -224,6 +231,35 @@ func TestEngineRetriesEventWhenAllDispatchersFail(t *testing.T) {
 	state, seen, err = st.GetAlertState(ctx, key)
 	if err != nil || !seen || !state.Notified || state.Value != "unhealthy" {
 		t.Fatalf("successful retry did not mark notified: state=%+v seen=%v err=%v", state, seen, err)
+	}
+}
+
+func TestEngineRetriesOnlyFailedChannelAfterPartialFanout(t *testing.T) {
+	e, st, good, _ := newTestEngine(t)
+	ctx := context.Background()
+	flaky := newSink(t)
+	flaky.fail = true
+	e.dispatchers = []Dispatcher{
+		namedDispatcher{name: "good", Dispatcher: &webhookDispatcher{client: good.srv.Client(), url: good.srv.URL}},
+		namedDispatcher{name: "flaky", Dispatcher: &webhookDispatcher{client: flaky.srv.Client(), url: flaky.srv.URL}},
+	}
+	_, agent, _ := st.CreateAgent(ctx, "docker-a")
+
+	_ = st.ApplyReport(ctx, agent.ID, testReport(testSvc("running", model.HealthHealthy)))
+	e.Sweep(ctx) // seed cursor
+	_ = st.ApplyReport(ctx, agent.ID, testReport(testSvc("running", model.HealthUnhealthy)))
+	e.Sweep(ctx)
+	if good.count() != 1 || flaky.count() != 3 { // dispatcher retries each failure three times
+		t.Fatalf("first fanout good=%d flaky=%d, want 1/3", good.count(), flaky.count())
+	}
+
+	flaky.fail = false
+	e.Sweep(ctx)
+	if good.count() != 1 {
+		t.Fatalf("successful channel was duplicated during retry: %d sends", good.count())
+	}
+	if flaky.count() != 4 {
+		t.Fatalf("failed channel was not retried after recovery: %d sends", flaky.count())
 	}
 }
 

--- a/internal/store/alerting.go
+++ b/internal/store/alerting.go
@@ -87,3 +87,39 @@ func (s *Store) SetAlertState(ctx context.Context, key string, st AlertState) er
 	}
 	return nil
 }
+
+// ChannelDelivered reports whether channel already accepted this in-progress
+// delivery. It lets the alert engine retry only channels that failed, rather
+// than duplicating a notification to channels that already succeeded.
+func (s *Store) ChannelDelivered(ctx context.Context, deliveryKey, channel string) (bool, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM alert_channel_deliveries WHERE delivery_key = ? AND channel = ?`,
+		deliveryKey, channel,
+	).Scan(&n); err != nil {
+		return false, fmt.Errorf("check alert channel delivery %q/%q: %w", deliveryKey, channel, err)
+	}
+	return n > 0, nil
+}
+
+// MarkChannelDelivered records one successful channel delivery. The caller
+// clears this short-lived state after all configured channels have succeeded.
+func (s *Store) MarkChannelDelivered(ctx context.Context, deliveryKey, channel string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO alert_channel_deliveries(delivery_key, channel, delivered_at) VALUES (?, ?, ?)
+		 ON CONFLICT(delivery_key, channel) DO NOTHING`,
+		deliveryKey, channel, s.now().Unix(),
+	); err != nil {
+		return fmt.Errorf("mark alert channel delivery %q/%q: %w", deliveryKey, channel, err)
+	}
+	return nil
+}
+
+// ClearChannelDeliveries removes retry bookkeeping after the entire fan-out
+// completed. A subsequent, distinct incident starts with a clean slate.
+func (s *Store) ClearChannelDeliveries(ctx context.Context, deliveryKey string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM alert_channel_deliveries WHERE delivery_key = ?`, deliveryKey); err != nil {
+		return fmt.Errorf("clear alert channel deliveries %q: %w", deliveryKey, err)
+	}
+	return nil
+}

--- a/internal/store/migrations/0007_alert_channel_deliveries.sql
+++ b/internal/store/migrations/0007_alert_channel_deliveries.sql
@@ -1,0 +1,9 @@
+-- Track successful instant-alert deliveries per incident and channel. A
+-- temporary row exists only while another configured channel still needs a
+-- retry; it is removed once the entire fan-out succeeds.
+CREATE TABLE alert_channel_deliveries (
+    delivery_key TEXT NOT NULL,
+    channel      TEXT NOT NULL,
+    delivered_at INTEGER NOT NULL,
+    PRIMARY KEY (delivery_key, channel)
+);


### PR DESCRIPTION
## Summary
- persist successful channel deliveries while a sibling channel is failing
- retry only the failed channels without duplicating notifications already accepted
- advance alert state/cursor only after every configured instant channel accepts the notification

## Verification
- `go test ./internal/store ./internal/alert -count=1`
- `go test -race ./internal/store ./internal/alert`

Fixes the partial-fanout case where one successful channel previously caused a failed sibling channel to be dropped permanently.