### PR TITLE
fix: harden report ingest contract

### DIFF
--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -34,6 +34,13 @@ import (
 // version is stamped at build time via -ldflags "-X main.version=...".
 var version = "dev"
 
+const (
+	readHeaderTimeout = 10 * time.Second
+	readTimeout       = 30 * time.Second
+	writeTimeout      = 30 * time.Second
+	idleTimeout       = 120 * time.Second
+)
+
 func main() {
 	args := os.Args[1:]
 	cmd := "serve"
@@ -156,7 +163,10 @@ func runServe() error {
 	httpSrv := &http.Server{
 		Addr:              addr,
 		Handler:           srv.Handler(),
-		ReadHeaderTimeout: 10 * time.Second,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
 
 	serveErr := make(chan error, 1)

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -162,12 +162,12 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 		var parentID sql.NullInt64
 		if svc.ParentExternalID != "" {
 			pid, ok := idByExtID[svc.ParentExternalID]
-			if !ok {
-				// Unknown parent in this host snapshot. Leave parent_id unchanged
-				// rather than guessing across hosts/agents.
-				continue
+			if ok {
+				parentID = sql.NullInt64{Int64: pid, Valid: true}
 			}
-			parentID = sql.NullInt64{Int64: pid, Valid: true}
+			// A full-state report names parents within its own host snapshot.
+			// If the referenced parent is absent, clear any old link instead of
+			// preserving a relationship the agent no longer reports.
 		}
 
 		if _, err := tx.ExecContext(ctx, `UPDATE services SET parent_id = ? WHERE id = ?`, parentID, childID); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -346,6 +346,30 @@ func TestApplyReportParentChildClearsStaleParent(t *testing.T) {
 	}
 }
 
+func TestApplyReportParentChildClearsMissingParent(t *testing.T) {
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "k8s")
+
+	dep := model.ReportService{ExternalID: "deploy/default/web", Name: "web", Kind: model.KindDeployment, State: "1/1", Health: model.HealthHealthy}
+	pod := model.ReportService{ExternalID: "pod/default/web-a", ParentExternalID: dep.ExternalID, Name: "web-a", Kind: model.KindPod, State: "running", Health: model.HealthHealthy}
+	if err := st.ApplyReport(ctx, agent.ID, report(dep, pod)); err != nil {
+		t.Fatalf("apply with parent: %v", err)
+	}
+
+	pod.ParentExternalID = "deploy/default/missing"
+	if err := st.ApplyReport(ctx, agent.ID, report(pod)); err != nil {
+		t.Fatalf("apply with missing parent: %v", err)
+	}
+
+	rows, _ := st.ListServices(ctx)
+	for _, row := range rows {
+		if row.ExternalID == pod.ExternalID && row.ParentExternalID.Valid {
+			t.Fatalf("stale parent link persisted as %q", row.ParentExternalID.String)
+		}
+	}
+}
+
 func TestFreshnessJoinAndDue(t *testing.T) {
 	st, clock := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -179,6 +179,12 @@ func (r *Report) Validate() error {
 		if !s.Kind.Valid() {
 			return fmt.Errorf("services[%d].kind %q is not a recognized kind", i, s.Kind)
 		}
+		if strings.TrimSpace(s.State) == "" {
+			return fmt.Errorf("services[%d].state is required", i)
+		}
+		if s.State == StateRemoved {
+			return fmt.Errorf("services[%d].state %q is server-derived", i, s.State)
+		}
 		if !s.Health.Valid() {
 			return fmt.Errorf("services[%d].health %q is not an agent-reportable health value", i, s.Health)
 		}

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -27,6 +27,8 @@ func TestReportValidate(t *testing.T) {
 		{"missing hostname", func(r *Report) { r.Host.Hostname = "" }},
 		{"missing external id", func(r *Report) { r.Services[0].ExternalID = "" }},
 		{"bad kind", func(r *Report) { r.Services[0].Kind = "widget" }},
+		{"missing service state", func(r *Report) { r.Services[0].State = " 	" }},
+		{"agent may not report removed", func(r *Report) { r.Services[0].State = StateRemoved }},
 		{"agent may not report stale", func(r *Report) { r.Services[0].Health = HealthStale }},
 		{"duplicate external id", func(r *Report) {
 			r.Services = append(r.Services, r.Services[0])


### PR DESCRIPTION
## Summary
- clear stale parent links when a full-state report references a missing parent
- reject blank and server-derived service states from agent reports
- set read, write, and idle timeouts on the HTTP server

## Verification
- `go test ./pkg/model ./internal/store ./cmd/trove-server -count=1`
- `go test -race ./pkg/model ./internal/store ./cmd/trove-server`

This preserves the full-snapshot contract and makes malformed reports and slow connections less able to create ambiguous state.