### PR TITLE
fix: use stable identities in dashboard events

### DIFF
--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -16,6 +16,7 @@ import (
 // ---- response DTOs -------------------------------------------------------
 
 type serviceDTO struct {
+	ID               int64           `json:"id"`
 	ExternalID       string          `json:"external_id"`
 	ParentExternalID string          `json:"parent_external_id,omitempty"`
 	Name             string          `json:"name"`
@@ -73,6 +74,7 @@ type agentsResponse struct {
 
 type eventDTO struct {
 	ID        int64  `json:"id"`
+	ServiceID *int64 `json:"service_id,omitempty"`
 	Kind      string `json:"kind"` // state | health | agent
 	Service   string `json:"service,omitempty"`
 	Hostname  string `json:"hostname,omitempty"`
@@ -137,6 +139,7 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 		freshness := row.FreshnessVerdict()
 
 		hosts[idx].Services = append(hosts[idx].Services, serviceDTO{
+			ID:               row.ID,
 			ExternalID:       row.ExternalID,
 			ParentExternalID: row.ParentExternalID.String,
 			Name:             row.Name,
@@ -214,8 +217,14 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	out := make([]eventDTO, 0, len(events))
 	for _, e := range events {
+		var serviceID *int64
+		if e.ServiceID.Valid {
+			id := e.ServiceID.Int64
+			serviceID = &id
+		}
 		out = append(out, eventDTO{
 			ID:        e.ID,
+			ServiceID: serviceID,
 			Kind:      e.Kind,
 			Service:   e.Service,
 			Hostname:  e.Hostname,

--- a/internal/server/read_test.go
+++ b/internal/server/read_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/techdox/trove/internal/store"
+	"github.com/techdox/trove/pkg/model"
+)
+
+func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	_, agent, err := st.CreateAgent(ctx, "docker-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := func(state string) *model.Report {
+		return &model.Report{
+			Agent: model.ReportAgent{Name: "docker-a", Platform: model.PlatformDocker, Version: "test"},
+			Host:  model.ReportHost{Hostname: "host-a"},
+			Services: []model.ReportService{{
+				ExternalID: "container-1", Name: "web", Kind: model.KindContainer,
+				State: state, Health: model.HealthHealthy,
+			}},
+		}
+	}
+	if err := st.ApplyReport(ctx, agent.ID, report("running")); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyReport(ctx, agent.ID, report("exited")); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(st, slog.Default())
+	servicesReq := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
+	servicesRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(servicesRec, servicesReq)
+	if servicesRec.Code != http.StatusOK {
+		t.Fatalf("services status = %d", servicesRec.Code)
+	}
+	var services struct {
+		Hosts []struct {
+			Services []struct {
+				ID int64 `json:"id"`
+			} `json:"services"`
+		} `json:"hosts"`
+	}
+	if err := json.NewDecoder(servicesRec.Body).Decode(&services); err != nil {
+		t.Fatal(err)
+	}
+	if len(services.Hosts) != 1 || len(services.Hosts[0].Services) != 1 || services.Hosts[0].Services[0].ID == 0 {
+		t.Fatalf("services response omitted stable id: %+v", services)
+	}
+	serviceID := services.Hosts[0].Services[0].ID
+
+	eventsReq := httptest.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	eventsRec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(eventsRec, eventsReq)
+	if eventsRec.Code != http.StatusOK {
+		t.Fatalf("events status = %d", eventsRec.Code)
+	}
+	var events struct {
+		Events []struct {
+			ServiceID *int64 `json:"service_id"`
+		} `json:"events"`
+	}
+	if err := json.NewDecoder(eventsRec.Body).Decode(&events); err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events.Events {
+		if event.ServiceID != nil && *event.ServiceID == serviceID {
+			return
+		}
+	}
+	t.Fatalf("events response omitted matching service id: %+v", events)
+}

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -411,14 +411,14 @@ function renderHosts() {
       ? `${visible.length}/${total} service(s)` : `${total} service(s)`;
 
     sections.push(`<div class="host${collapsed ? " collapsed" : ""}" data-hostkey="${esc(hostKey(h))}">
-      <div class="host-head" role="button" aria-expanded="${!collapsed}">
+      <button type="button" class="host-head" aria-expanded="${!collapsed}" aria-label="${collapsed ? "Expand" : "Collapse"} ${esc(h.hostname)}">
         <span class="chev">${collapsed ? "▸" : "▾"}</span>
         <span class="hostname">${esc(h.hostname)}</span>
         <span class="sub">${esc(hostPlatformLine(h))}</span>
         ${badge(AGENT_CLASS[st] || "b-gray", st)}
         <span class="rollup">${rollup}</span>
         <span class="count">${countLabel}</span>
-      </div>
+      </button>
       <div class="host-body">
         <table>
           <thead><tr>
@@ -535,7 +535,7 @@ function renderDrawer() {
     ? siblings.find((x) => x.external_id === s.parent_external_id) : null;
 
   const events = (state.data.events?.events || [])
-    .filter((e) => e.service === s.name && e.hostname === host.hostname)
+    .filter((e) => e.service_id === s.id)
     .slice(0, 12);
 
   const rawLabels = s.labels && typeof s.labels === "object" ? s.labels : {};
@@ -775,6 +775,7 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "j" || e.key === "ArrowDown") { e.preventDefault(); moveCursor(1); return; }
   if (e.key === "k" || e.key === "ArrowUp") { e.preventDefault(); moveCursor(-1); return; }
   if (e.key === "Enter") {
+    if (e.target.closest?.(".host-head")) return;
     const focused = document.activeElement?.closest?.("#hosts tr[data-ext]");
     if (focused) { openDrawer(rowKey(focused)); return; }
     if (state.cursorKey) openDrawer(state.cursorKey);

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -273,10 +273,15 @@ header h1 {
 }
 .host-head {
   display: flex;
+  width: 100%;
   align-items: center;
   gap: 11px;
   padding: 13px 16px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   background: rgba(15, 14, 25, 0.5);
+  border: 0;
   border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- expose stable service IDs in service and event API responses
- match drawer events by service identity rather than display name and hostname
- make host collapse controls real keyboard-accessible buttons

## Verification
- `go test ./internal/server -count=1`
- `go test -race ./internal/server`
- `node --check web/public/app.js`