### PR TITLE
ci: automate release version surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: go vet ./...
       - name: Dockerfile drift check
         run: ./scripts/check-dockerfile-drift.sh
+      - name: Release surface check
+        run: python3 ./scripts/check_release_surface.py
       - name: golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
       - name: go test with coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,8 +92,11 @@ version number and changelog computed from commit messages since the last
 release (`feat` → minor, `fix` → patch). When you want to ship, merge that
 release PR.
 
-Merging the release PR updates `CHANGELOG.md` and
-`.release-please-manifest.json` on `main`. The
+Merging the release PR updates `CHANGELOG.md`,
+`.release-please-manifest.json`, and the annotated release-facing install/docs
+surfaces listed in `release-please-config.json`. The CI release-surface check
+requires those annotations to match the manifest, so pinned examples and the
+Kubernetes manifest cannot quietly drift from the published release. The
 [release-tag.yml](.github/workflows/release-tag.yml) workflow sees that manifest
 change, creates the matching `vX.Y.Z` tag, and that tag triggers
 [release.yml](.github/workflows/release.yml) (goreleaser: cross-compiled

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Static binaries for everything (including the bare-metal agent) are on the
 
 ```sh
 # pick the URL for your arch off the releases page, e.g.:
-VERSION=0.11.3       # check https://github.com/techdox/trove/releases/latest for newer releases
+VERSION=0.11.3       # x-release-please-version; check https://github.com/techdox/trove/releases/latest for newer releases
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Static binaries for everything (including the bare-metal agent) are on the
 
 ```sh
 # pick the URL for your arch off the releases page, e.g.:
-VERSION=0.11.0       # check https://github.com/techdox/trove/releases/latest for newer releases
+VERSION=0.11.3       # check https://github.com/techdox/trove/releases/latest for newer releases
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Trove Roadmap
 
-**Status:** `v0.11.3` is the current public release. Phases 1–4 are shipped on
+**Status:** `v0.11.3` is the current public release. <!-- x-release-please-version --> Phases 1–4 are shipped on
 `main` — Docker/Kubernetes/Proxmox/bare-metal agents, per-agent token auth,
 heartbeat/staleness, image freshness, the parent/child model, configurable
 retention, and alerting (webhook/Discord/ntfy + email digest — see

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,11 +1,11 @@
 # Trove Roadmap
 
-**Status:** `v0.11.0` is the current public release. Phases 1–4 are shipped on
+**Status:** `v0.11.3` is the current public release. Phases 1–4 are shipped on
 `main` — Docker/Kubernetes/Proxmox/bare-metal agents, per-agent token auth,
 heartbeat/staleness, image freshness, the parent/child model, configurable
 retention, and alerting (webhook/Discord/ntfy + email digest — see
 [docs/alerts.md](docs/alerts.md)). Phase 5 is partially delivered: OIDC auth
-for the dashboard and read APIs shipped in `v0.10.0`; observability/API hardening shipped in `v0.11.0`; Helm packaging remains.
+for the dashboard and read APIs shipped in an earlier release; observability/API hardening has shipped; Helm packaging remains.
 Both pinned decisions are resolved: D2 (parent/child) shipped with Phase 3, D1
 (retention) with Phase 4. Trove is MIT licensed and public. See the
 [README](README.md) for what exists today.

--- a/deploy/kubernetes/trove-agent.yaml
+++ b/deploy/kubernetes/trove-agent.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: trove-agent
       containers:
         - name: agent
-          image: ghcr.io/techdox/trove-agent-k8s:0.11.0
+          image: ghcr.io/techdox/trove-agent-k8s:0.11.3
           env:
             - name: TROVE_SERVER_URL
               value: "http://trove-server.example.internal:8080"

--- a/deploy/kubernetes/trove-agent.yaml
+++ b/deploy/kubernetes/trove-agent.yaml
@@ -65,7 +65,7 @@ spec:
       serviceAccountName: trove-agent
       containers:
         - name: agent
-          image: ghcr.io/techdox/trove-agent-k8s:0.11.3
+          image: ghcr.io/techdox/trove-agent-k8s:0.11.3 # x-release-please-version
           env:
             - name: TROVE_SERVER_URL
               value: "http://trove-server.example.internal:8080"

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -26,7 +26,7 @@ docker compose exec server trove-server agent create nas01
 ```sh
 # grab the archive for your arch from the latest release. Set VERSION to the
 # release you're installing (see https://github.com/techdox/trove/releases).
-VERSION=0.11.0
+VERSION=0.11.3
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-agent-local_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-agent-local_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-agent-local /usr/local/bin/

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -26,7 +26,7 @@ docker compose exec server trove-server agent create nas01
 ```sh
 # grab the archive for your arch from the latest release. Set VERSION to the
 # release you're installing (see https://github.com/techdox/trove/releases).
-VERSION=0.11.3
+VERSION=0.11.3 # x-release-please-version
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-agent-local_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-agent-local_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-agent-local /usr/local/bin/

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -11,7 +11,7 @@ everything in lockstep. Pick the section that matches how you run the server.
   `CHANGELOG.md` for the version you're moving to.
 - **Back up the database** (see [Backup](#backup)). Migrations only ever move
   forward, so a backup is your rollback path.
-- In anything you care about, pin a specific version (e.g. `0.11.3`) rather than
+- In anything you care about, pin a specific version (e.g. `0.11.3`) <!-- x-release-please-version --> rather than
   `latest`, so upgrades are a deliberate change you control.
 
 ## Docker Compose
@@ -29,7 +29,7 @@ then `... up -d`. The database lives in the `trove-data` volume and survives the
 recreate; your `.env` (agent token) is reused.
 
 **Pin a version:** set the image tag in the compose file
-(`ghcr.io/techdox/trove-server:0.11.3` instead of `:latest`), then `pull` / `up -d`.
+(`ghcr.io/techdox/trove-server:0.11.3` <!-- x-release-please-version --> instead of `:latest`), then `pull` / `up -d`.
 
 ## Bare metal (systemd)
 
@@ -37,7 +37,7 @@ Download the release archive for the version you want and swap the binary in
 place — the database at `/var/lib/trove/trove.db` is untouched:
 
 ```sh
-VERSION=0.11.3
+VERSION=0.11.3 # x-release-please-version
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-server /usr/local/bin/
@@ -51,7 +51,7 @@ upgrades the same way with its own archive, then `sudo systemctl restart trove-a
 ## go install
 
 ```sh
-go install github.com/techdox/trove/cmd/trove-server@v0.11.3   # or @latest
+go install github.com/techdox/trove/cmd/trove-server@v0.11.3   # x-release-please-version; or @latest
 ```
 
 Then restart however you run it. (A `go install` build reports its version as

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -11,7 +11,7 @@ everything in lockstep. Pick the section that matches how you run the server.
   `CHANGELOG.md` for the version you're moving to.
 - **Back up the database** (see [Backup](#backup)). Migrations only ever move
   forward, so a backup is your rollback path.
-- In anything you care about, pin a specific version (e.g. `0.6.0`) rather than
+- In anything you care about, pin a specific version (e.g. `0.11.3`) rather than
   `latest`, so upgrades are a deliberate change you control.
 
 ## Docker Compose
@@ -29,7 +29,7 @@ then `... up -d`. The database lives in the `trove-data` volume and survives the
 recreate; your `.env` (agent token) is reused.
 
 **Pin a version:** set the image tag in the compose file
-(`ghcr.io/techdox/trove-server:0.6.0` instead of `:latest`), then `pull` / `up -d`.
+(`ghcr.io/techdox/trove-server:0.11.3` instead of `:latest`), then `pull` / `up -d`.
 
 ## Bare metal (systemd)
 
@@ -37,7 +37,7 @@ Download the release archive for the version you want and swap the binary in
 place — the database at `/var/lib/trove/trove.db` is untouched:
 
 ```sh
-VERSION=0.6.0
+VERSION=0.11.3
 curl -fLO "https://github.com/techdox/trove/releases/download/v${VERSION}/trove-server_${VERSION}_linux_amd64.tar.gz"
 tar xzf trove-server_${VERSION}_linux_amd64.tar.gz
 sudo install -m 0755 trove-server /usr/local/bin/
@@ -51,7 +51,7 @@ upgrades the same way with its own archive, then `sudo systemctl restart trove-a
 ## go install
 
 ```sh
-go install github.com/techdox/trove/cmd/trove-server@v0.6.0   # or @latest
+go install github.com/techdox/trove/cmd/trove-server@v0.11.3   # or @latest
 ```
 
 Then restart however you run it. (A `go install` build reports its version as

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,17 @@
   "release-type": "simple",
   "skip-github-release": true,
   "packages": {
-    ".": {}
+    ".": {
+      "extra-files": [
+        "README.md",
+        "ROADMAP.md",
+        "docs/agents/local.md",
+        "docs/upgrades.md",
+        {
+          "type": "generic",
+          "path": "deploy/kubernetes/trove-agent.yaml"
+        }
+      ]
+    }
   }
 }

--- a/scripts/check_release_surface.py
+++ b/scripts/check_release_surface.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Verify every release-please-managed version marker matches the manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / ".release-please-manifest.json"
+CONFIG = ROOT / "release-please-config.json"
+MARKER = "x-release-please-version"
+EXPECTED_FILES = {
+    "README.md",
+    "ROADMAP.md",
+    "docs/agents/local.md",
+    "docs/upgrades.md",
+    "deploy/kubernetes/trove-agent.yaml",
+}
+VERSION_RE = re.compile(r"(?<![0-9])v?(\d+\.\d+\.\d+)(?![0-9])")
+
+
+def release_version() -> str:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    version = manifest.get(".")
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        raise ValueError(".release-please-manifest.json must contain a SemVer version for '.'")
+    return version
+
+
+def configured_files() -> set[str]:
+    config = json.loads(CONFIG.read_text(encoding="utf-8"))
+    package = config.get("packages", {}).get(".", {})
+    files: set[str] = set()
+    for item in package.get("extra-files", []):
+        if isinstance(item, str):
+            files.add(item)
+        elif isinstance(item, dict) and isinstance(item.get("path"), str):
+            files.add(item["path"])
+        else:
+            raise ValueError(f"invalid extra-files entry: {item!r}")
+    return files
+
+
+def main() -> int:
+    version = release_version()
+    errors: list[str] = []
+
+    configured = configured_files()
+    if configured != EXPECTED_FILES:
+        errors.append(
+            "release-please extra-files do not match the release surface: "
+            f"got {sorted(configured)}, want {sorted(EXPECTED_FILES)}"
+        )
+
+    for relative in sorted(EXPECTED_FILES):
+        path = ROOT / relative
+        marker_lines = [
+            (line_number, line)
+            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1)
+            if MARKER in line
+        ]
+        if not marker_lines:
+            errors.append(f"{relative}: missing {MARKER} annotation")
+            continue
+        for line_number, line in marker_lines:
+            versions = VERSION_RE.findall(line)
+            if version not in versions:
+                errors.append(
+                    f"{relative}:{line_number}: annotated version does not match manifest "
+                    f"{version!r}: {line.strip()}"
+                )
+
+    if errors:
+        print("release surface check failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+
+    print(f"release surface matches v{version} across {len(EXPECTED_FILES)} files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- refresh install and upgrade examples to v0.11.3
- update the Kubernetes agent manifest
- remove stale release status from the roadmap

## Verification
- checked repository Markdown references for stale release examples
- `git diff --check`