### PR TITLE
feat: prioritize dashboard attention and triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,15 @@
 
 # Trove
 
-**One pane of glass for everything running in your homelab.** Small agents sit
-next to your workloads — Docker hosts, Kubernetes clusters, Proxmox nodes,
-plain Linux boxes — and push what they see to one server: what's running,
-where, what version, whether it's healthy, whether its image is outdated, and
-whether it's still reporting at all.
+**An automatically discovered, read-only inventory of everything running in
+your homelab.** Small agents sit next to your workloads — Docker hosts,
+Kubernetes clusters, Proxmox nodes, plain Linux boxes — and push what they see
+to one Trove service catalogue: what's running, where it lives, whether it's
+healthy, whether its image is outdated, and whether it is still reporting.
+
+Trove is the place to start an investigation, not the place to make a change.
+It links the facts across your homelab without becoming a homepage, Grafana,
+Portainer, or an infrastructure management interface.
 
 ![Trove dashboard](docs/screenshot.png)
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -1,0 +1,49 @@
+package web
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+)
+
+func TestDashboardAttentionHierarchyIsEmbedded(t *testing.T) {
+	t.Parallel()
+
+	assets := FS()
+	index, err := fs.ReadFile(assets, "index.html")
+	if err != nil {
+		t.Fatalf("read embedded index: %v", err)
+	}
+
+	last := -1
+	for _, heading := range []string{
+		"Needs attention",
+		"Recent changes",
+		"Infrastructure summary",
+		"Service catalogue",
+	} {
+		pos := strings.Index(string(index), heading)
+		if pos == -1 {
+			t.Errorf("dashboard is missing %q", heading)
+			continue
+		}
+		if pos < last {
+			t.Errorf("dashboard heading %q is out of hierarchy order", heading)
+		}
+		last = pos
+	}
+
+	app, err := fs.ReadFile(assets, "app.js")
+	if err != nil {
+		t.Fatalf("read embedded app: %v", err)
+	}
+	for _, marker := range []string{
+		"function attentionItems()",
+		"function showAttention(key)",
+		"STOPPED_STATES",
+	} {
+		if !strings.Contains(string(app), marker) {
+			t.Errorf("dashboard attention behaviour is missing %q", marker)
+		}
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -40,7 +40,7 @@ func TestDashboardAttentionHierarchyIsEmbedded(t *testing.T) {
 	for _, marker := range []string{
 		"function attentionItems()",
 		"function showAttention(key)",
-		"STOPPED_STATES",
+		`const STOPPED_STATES = new Set(["exited", "dead", "failed", "stopped"])`,
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard attention behaviour is missing %q", marker)

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -26,9 +26,12 @@ const state = {
 const CHIP_DEFS = [
   { key: "running",   cls: "c-green",  test: (s) => s.state === "running" },
   { key: "unhealthy", cls: "c-red",    test: (s) => s.health === "unhealthy" },
+  { key: "stopped",   cls: "c-yellow", test: (s) => STOPPED_STATES.has(s.state) },
   { key: "outdated",  cls: "c-peach",  test: (s) => s.freshness === "outdated" },
   { key: "stale",     cls: "c-gray",   test: (s) => s.health === "stale" },
 ];
+
+const STOPPED_STATES = new Set(["exited", "dead", "failed"]);
 
 // A service is identified by agent + hostname + external_id (hostnames are
 // only unique per agent).
@@ -248,7 +251,7 @@ function filterActive() {
 
 // counts over the full dataset (independent of the active filter)
 function computeCounts() {
-  const c = { hosts: 0, services: 0, running: 0, unhealthy: 0, outdated: 0, stale: 0, removed: 0 };
+  const c = { hosts: 0, services: 0, running: 0, unhealthy: 0, stopped: 0, outdated: 0, stale: 0, removed: 0 };
   for (const h of state.data.services?.hosts || []) {
     c.hosts++;
     for (const s of h.services || []) {
@@ -256,11 +259,63 @@ function computeCounts() {
       c.services++;
       if (s.state === "running") c.running++;
       if (s.health === "unhealthy") c.unhealthy++;
+      if (STOPPED_STATES.has(s.state)) c.stopped++;
       if (s.health === "stale") c.stale++;
       if (s.freshness === "outdated") c.outdated++;
     }
   }
   return c;
+}
+
+// ----------------------------------------------------------- attention ----
+
+// The attention queue deliberately groups evidence by the next useful
+// investigation step. It is not another collection of filter chips: it gives
+// the dashboard an operational starting point, then routes into the catalogue
+// or affected-agent list when the operator chooses to investigate.
+function attentionItems() {
+  const c = computeCounts();
+  const agents = state.data.agents?.agents || [];
+  const offline = agents.filter((a) => a.status === "offline").length;
+  const staleAgents = agents.filter((a) => a.status === "stale").length;
+  const item = (key, level, count, title, detail, action) => ({ key, level, count, title, detail, action });
+  return [
+    item("offline-agents", "critical", offline, "Offline agent", "Trove is no longer receiving reports from this source.", "Review agents"),
+    item("unhealthy", "critical", c.unhealthy, "Unhealthy service", "A platform health check or readiness signal is failing.", "Show services"),
+    item("stale-agents", "warning", staleAgents, "Stale agent", "This source has missed its expected reporting interval.", "Review agents"),
+    item("stopped", "warning", c.stopped, "Stopped service", "A discovered service is exited, dead, or failed.", "Show services"),
+    item("removed", "info", c.removed, "Recently disappeared service", "A service is absent from its latest full-state report.", "Show services"),
+    item("outdated", "info", c.outdated, "Outdated image", "The running image digest is behind the current tag.", "Show services"),
+  ].filter((i) => i.count > 0);
+}
+
+function renderAttention() {
+  const el = $("attention");
+  const items = attentionItems();
+  if (items.length === 0) {
+    el.innerHTML = `<div class="attention-healthy">
+      <span class="attention-icon" aria-hidden="true">✓</span>
+      <div><strong>Nothing needs attention right now.</strong><span>All reporting agents are online and discovered services have no current health, state, or image-freshness warnings.</span></div>
+    </div>`;
+    return;
+  }
+  el.innerHTML = items.map((i) => `<button type="button" class="attention-card attention-${i.level}" data-attention="${i.key}">
+    <span class="attention-count">${i.count}</span>
+    <span class="attention-copy"><strong>${esc(i.title)}${i.count === 1 ? "" : "s"}</strong><span>${esc(i.detail)}</span></span>
+    <span class="attention-action">${esc(i.action)} <span aria-hidden="true">→</span></span>
+  </button>`).join("");
+}
+
+function showAttention(key) {
+  clearFilters();
+  if (key === "offline-agents" || key === "stale-agents") {
+    $("agents").scrollIntoView({ behavior: "smooth", block: "center" });
+    return;
+  }
+  if (key === "removed") state.showRemoved = true;
+  else state.chips.add(key);
+  render();
+  $("hosts").scrollIntoView({ behavior: "smooth", block: "start" });
 }
 
 // ------------------------------------------------------------- summary ----
@@ -272,19 +327,10 @@ function renderSummary() {
   const c = computeCounts();
   const agentList = state.data.agents?.agents || [];
   const agents = agentList.length;
-  const agentsOffline = agentList.filter((a) => a.status === "offline").length;
-  const agentsStale = agentList.filter((a) => a.status === "stale").length;
-
-  // What "needs attention" — most urgent first.
-  const parts = [];
-  if (c.unhealthy) parts.push(`${c.unhealthy} unhealthy`);
-  if (agentsOffline) parts.push(`${agentsOffline} agent${agentsOffline === 1 ? "" : "s"} offline`);
-  if (c.stale) parts.push(`${c.stale} stale`);
-  if (agentsStale) parts.push(`${agentsStale} agent${agentsStale === 1 ? "" : "s"} not reporting`);
-  if (c.outdated) parts.push(`${c.outdated} outdated`);
-
-  const cls = parts.length === 0 ? "ok" : (c.unhealthy > 0 || agentsOffline > 0 ? "crit" : "warn");
-  const text = parts.length === 0 ? "All systems operational" : "Needs attention";
+  const items = attentionItems();
+  const critical = items.some((i) => i.level === "critical");
+  const cls = items.length === 0 ? "ok" : (critical ? "crit" : "warn");
+  const text = items.length === 0 ? "Current state looks healthy" : `${items.length} area${items.length === 1 ? "" : "s"} to review`;
   const overview =
     `${agents} agent${agents === 1 ? "" : "s"} · ` +
     `${c.hosts} host${c.hosts === 1 ? "" : "s"} · ` +
@@ -293,14 +339,13 @@ function renderSummary() {
   $("summary").innerHTML =
     `<div class="verdict verdict-${cls}"><span class="vdot"></span>` +
     `<span class="vtext">${text}</span>` +
-    (parts.length ? `<span class="vbreak">${esc(parts.join(" · "))}</span>` : "") +
     `</div>` +
     `<span class="overview">${esc(overview)}</span>`;
 }
 
 function renderChips() {
   const c = computeCounts();
-  const counts = { running: c.running, unhealthy: c.unhealthy, outdated: c.outdated, stale: c.stale };
+  const counts = { running: c.running, unhealthy: c.unhealthy, stopped: c.stopped, outdated: c.outdated, stale: c.stale };
   const chips = CHIP_DEFS.map((d) => {
     const active = state.chips.has(d.key) ? " active" : "";
     return `<button class="chip ${d.cls}${active}" data-chip="${d.key}" aria-pressed="${!!active}">
@@ -456,7 +501,7 @@ function emptyMessage() {
 }
 
 function countsForChip(key, c) {
-  return { running: c.running, unhealthy: c.unhealthy, outdated: c.outdated, stale: c.stale }[key] ?? 0;
+  return { running: c.running, unhealthy: c.unhealthy, stopped: c.stopped, outdated: c.outdated, stale: c.stale }[key] ?? 0;
 }
 
 // -------------------------------------------------------------- events ----
@@ -494,10 +539,29 @@ function eventRowHTML(e) {
         &nbsp;<span class="st-gray">${esc(from)}</span> <span class="arrow">→</span>
         <span class="${stateTextClass(e.to_state)}">${esc(e.to_state)}</span>`;
   }
-  return `<div class="event-row">
+  return `<div class="event-row event-${eventTone(e)}">
     <span class="when nowrap">${esc(relTime(e.at))}</span>
     <span class="what">${what}</span>
   </div>`;
+}
+
+function eventTone(e) {
+  if (e.kind === "agent") {
+    if (e.to_state === "offline") return "critical";
+    if (e.to_state === "stale") return "warning";
+    if (e.to_state === "ok") return "healthy";
+  }
+  if (e.kind === "health") {
+    if (e.to_state === "unhealthy") return "critical";
+    if (e.to_state === "stale") return "warning";
+    if (e.to_state === "healthy") return "healthy";
+  }
+  if (e.kind === "state") {
+    if (["dead", "failed"].includes(e.to_state)) return "critical";
+    if (["exited", "removed", "restarting", "paused"].includes(e.to_state)) return "warning";
+    if (e.to_state === "running") return "healthy";
+  }
+  return "info";
 }
 
 // -------------------------------------------------------------- drawer ----
@@ -634,6 +698,7 @@ function openDrawer(key) {
 
 function render() {
   if (!state.data.services || !state.data.agents) return;
+  renderAttention();
   renderSummary();
   renderChips();
   renderAgents();
@@ -736,6 +801,9 @@ function clearFilters() {
 
 document.addEventListener("click", (e) => {
   if (e.target.closest("[data-clear]")) { clearFilters(); return; }
+
+  const attention = e.target.closest("[data-attention]");
+  if (attention) { showAttention(attention.dataset.attention); return; }
 
   const chip = e.target.closest("[data-chip]");
   if (chip) { toggleChip(chip.dataset.chip); return; }

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -31,7 +31,10 @@ const CHIP_DEFS = [
   { key: "stale",     cls: "c-gray",   test: (s) => s.health === "stale" },
 ];
 
-const STOPPED_STATES = new Set(["exited", "dead", "failed"]);
+// Platforms use different neutral stopped states. Proxmox reports `stopped`,
+// while Docker/systemd report `exited`, `dead`, or `failed`. Trove surfaces all
+// of them for investigation without assuming a powered-off guest is unhealthy.
+const STOPPED_STATES = new Set(["exited", "dead", "failed", "stopped"]);
 
 // A service is identified by agent + hostname + external_id (hostnames are
 // only unique per agent).
@@ -283,7 +286,7 @@ function attentionItems() {
     item("offline-agents", "critical", offline, "Offline agent", "Trove is no longer receiving reports from this source.", "Review agents"),
     item("unhealthy", "critical", c.unhealthy, "Unhealthy service", "A platform health check or readiness signal is failing.", "Show services"),
     item("stale-agents", "warning", staleAgents, "Stale agent", "This source has missed its expected reporting interval.", "Review agents"),
-    item("stopped", "warning", c.stopped, "Stopped service", "A discovered service is exited, dead, or failed.", "Show services"),
+    item("stopped", "info", c.stopped, "Stopped workload", "A discovered workload is not running. It may be intentional.", "Show services"),
     item("removed", "info", c.removed, "Recently disappeared service", "A service is absent from its latest full-state report.", "Show services"),
     item("outdated", "info", c.outdated, "Outdated image", "The running image digest is behind the current tag.", "Show services"),
   ].filter((i) => i.count > 0);
@@ -329,8 +332,11 @@ function renderSummary() {
   const agents = agentList.length;
   const items = attentionItems();
   const critical = items.some((i) => i.level === "critical");
-  const cls = items.length === 0 ? "ok" : (critical ? "crit" : "warn");
-  const text = items.length === 0 ? "Current state looks healthy" : `${items.length} area${items.length === 1 ? "" : "s"} to review`;
+  const warning = items.some((i) => i.level === "warning");
+  const cls = critical ? "crit" : (warning ? "warn" : "ok");
+  const text = critical || warning
+    ? `${items.filter((i) => i.level !== "info").length} area${items.filter((i) => i.level !== "info").length === 1 ? "" : "s"} to review`
+    : "Current state looks healthy";
   const overview =
     `${agents} agent${agents === 1 ? "" : "s"} · ` +
     `${c.hosts} host${c.hosts === 1 ? "" : "s"} · ` +
@@ -559,6 +565,7 @@ function eventTone(e) {
   if (e.kind === "state") {
     if (["dead", "failed"].includes(e.to_state)) return "critical";
     if (["exited", "removed", "restarting", "paused"].includes(e.to_state)) return "warning";
+    if (e.to_state === "stopped") return "info";
     if (e.to_state === "running") return "healthy";
   }
   return "info";

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,7 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="dark" />
   <meta name="theme-color" content="#12111d" />
-  <title>Trove</title>
+  <title>Trove Homelab | Read-only Service Catalogue</title>
+  <meta name="description" content="Trove by Techdox is an automatically discovered, read-only catalogue of what is running across your homelab." />
   <link rel="icon" href="favicon.ico" sizes="any" />
   <link rel="icon" href="favicon.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="trove-icon-180.png" />
@@ -15,11 +16,11 @@
 <body>
   <div class="wrap">
     <header>
-      <a class="brand" href="." aria-label="Trove">
+      <a class="brand" href="." aria-label="Trove Homelab service catalogue">
         <img class="mark" src="trove-mark.svg" alt="" width="30" height="30" />
         <h1>TROVE</h1>
       </a>
-      <span class="tagline">read-only service catalog</span>
+      <span class="tagline">read-only homelab service catalogue</span>
       <div class="status-line">
         <span id="updated">connecting…</span>
         <span class="pulse" id="pulse" title="live"></span>
@@ -29,25 +30,57 @@
 
     <div class="error-banner" id="error"></div>
 
-    <div class="summary" id="summary"></div>
+    <section class="dashboard-section attention-section" aria-labelledby="attention-title">
+      <div class="section-heading">
+        <div>
+          <div class="eyebrow">Operational overview</div>
+          <h2 id="attention-title">Needs attention</h2>
+        </div>
+        <p>What needs investigation first. Trove only shows the evidence; follow the link or use your usual tool to fix it.</p>
+      </div>
+      <div class="attention" id="attention"></div>
+    </section>
 
-    <div class="filterbar">
-      <input id="q" type="search" placeholder="filter by name, image, host, label…  ( / )"
-             autocomplete="off" spellcheck="false" aria-label="Filter services" />
-      <div class="chips" id="chips"></div>
-    </div>
+    <section class="dashboard-section changes-section" aria-labelledby="changes-title">
+      <div class="section-heading compact">
+        <div>
+          <div class="eyebrow">What changed</div>
+          <h2 id="changes-title">Recent changes</h2>
+        </div>
+        <p>State, health, and agent heartbeat transitions. Quiet reports are intentionally absent.</p>
+      </div>
+      <div class="events" id="events"></div>
+    </section>
 
-    <div class="section-title">Agents</div>
-    <div class="agents" id="agents"></div>
+    <section class="dashboard-section infrastructure-section" aria-labelledby="infrastructure-title">
+      <div class="section-heading compact">
+        <div>
+          <div class="eyebrow">Discovered infrastructure</div>
+          <h2 id="infrastructure-title">Infrastructure summary</h2>
+        </div>
+      </div>
+      <div class="summary" id="summary"></div>
+      <div class="agents" id="agents"></div>
+    </section>
 
-    <div class="section-title">Services</div>
-    <div id="hosts"></div>
-
-    <div class="section-title">Recent activity</div>
-    <div class="events" id="events"></div>
+    <section class="dashboard-section inventory-section" aria-labelledby="inventory-title">
+      <div class="section-heading compact">
+        <div>
+          <div class="eyebrow">Everything reported</div>
+          <h2 id="inventory-title">Service catalogue</h2>
+        </div>
+        <p>Filter the discovered inventory. Trove never changes a workload.</p>
+      </div>
+      <div class="filterbar">
+        <input id="q" type="search" placeholder="filter by name, image, host, label…  ( / )"
+               autocomplete="off" spellcheck="false" aria-label="Filter services" />
+        <div class="chips" id="chips"></div>
+      </div>
+      <div id="hosts"></div>
+    </section>
 
     <footer>
-      Trove &middot; read-only by design &middot; auto-refresh 10s &middot;
+      Trove by Techdox &middot; read-only by design &middot; auto-refresh 10s &middot;
       click a row (or <kbd>enter</kbd>) for details &middot;
       <kbd>/</kbd> filter &middot; <kbd>j</kbd>/<kbd>k</kbd> move &middot; <kbd>esc</kbd> close
     </footer>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -148,6 +148,109 @@ header h1 {
 @keyframes pulse-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
 @media (prefers-reduced-motion: reduce) { .pulse { animation: none; } }
 
+/* ---- dashboard hierarchy ---- */
+.dashboard-section { margin-top: 30px; }
+.section-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 13px;
+}
+.section-heading.compact { margin-bottom: 12px; }
+.eyebrow {
+  color: var(--purple);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  margin-bottom: 3px;
+}
+.section-heading h2 {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 20px;
+  letter-spacing: -0.02em;
+}
+.section-heading p {
+  max-width: 540px;
+  margin: 0;
+  color: var(--subtle);
+  font-size: 12.5px;
+  text-align: right;
+}
+
+/* ---- needs attention ---- */
+.attention {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+}
+.attention-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 82px;
+  padding: 13px 15px;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  background: linear-gradient(180deg, rgba(36, 34, 56, 0.9), rgba(26, 24, 40, 0.9));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background .15s ease, border-color .15s ease, transform .15s ease;
+}
+.attention-card:hover { transform: translateY(-1px); border-color: var(--border-strong); background: var(--panel-soft); }
+.attention-count {
+  display: grid;
+  place-items: center;
+  min-width: 30px;
+  height: 30px;
+  padding: 0 7px;
+  border-radius: 9px;
+  background: var(--panel);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-weight: 800;
+  font-size: 14px;
+}
+.attention-copy { min-width: 0; display: grid; gap: 2px; }
+.attention-copy strong { color: var(--text); font-family: var(--font-display); font-size: 14px; }
+.attention-copy span { color: var(--muted); font-size: 11.5px; line-height: 1.4; }
+.attention-action { color: var(--subtle); font-family: var(--font-mono); font-size: 10.5px; white-space: nowrap; }
+.attention-critical { border-color: rgba(255, 107, 122, 0.42); }
+.attention-critical .attention-count { color: var(--red); background: rgba(255, 107, 122, 0.12); }
+.attention-warning { border-color: rgba(242, 166, 90, 0.35); }
+.attention-warning .attention-count { color: var(--amber); background: rgba(242, 166, 90, 0.12); }
+.attention-info .attention-count { color: var(--blue); background: rgba(113, 183, 255, 0.1); }
+.attention-healthy {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 13px 16px;
+  border: 1px solid rgba(155, 226, 143, 0.24);
+  border-radius: 16px;
+  background: rgba(155, 226, 143, 0.055);
+}
+.attention-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: var(--green);
+  background: rgba(155, 226, 143, 0.12);
+  font-weight: 800;
+}
+.attention-healthy div { display: grid; gap: 2px; }
+.attention-healthy strong { color: var(--green); font-family: var(--font-display); }
+.attention-healthy span { color: var(--muted); font-size: 12px; }
+
 /* ---- summary strip ---- */
 .summary {
   display: flex;
@@ -433,6 +536,10 @@ tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
   align-items: baseline;
 }
 .event-row:last-child { border-bottom: none; }
+.event-row.event-critical { box-shadow: inset 3px 0 0 var(--red); background: rgba(255, 107, 122, 0.045); }
+.event-row.event-warning { box-shadow: inset 3px 0 0 var(--amber); }
+.event-row.event-healthy { box-shadow: inset 3px 0 0 var(--green); }
+.event-row.event-info { box-shadow: inset 3px 0 0 var(--blue); }
 .event-row .when { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; min-width: 84px; }
 .event-row .what { color: var(--muted); }
 .event-row .what strong { color: var(--text); font-weight: 600; }
@@ -565,4 +672,12 @@ footer kbd {
   padding: 1px 5px;
   color: var(--muted);
   background: var(--panel);
+}
+
+@media (max-width: 680px) {
+  .wrap { padding: 18px 14px 44px; }
+  .section-heading { align-items: start; flex-direction: column; gap: 5px; }
+  .section-heading p { text-align: left; }
+  .attention-card { grid-template-columns: auto minmax(0, 1fr); }
+  .attention-action { grid-column: 2; }
 }


### PR DESCRIPTION
## What changed
- Adds a first-class Needs attention queue above the catalogue.
- Prioritizes offline/stale agents, unhealthy/stopped/disappeared services, and outdated images with direct investigation routes.
- Reorders the dashboard: attention, recent changes, infrastructure summary, then the full inventory.
- Refreshes the dashboard and README positioning around an automatically discovered, read-only homelab service catalogue.

## Deliberate scope
- Uses existing read APIs and event data; no database migration or new permission surface.
- Does not claim flap detection yet; that needs a purpose-built historical query/aggregation design.

## Validation
- `node --check web/public/app.js`
- `make fmt`
- `make test`
- `make build`
- Embedded dashboard smoke test via a locally started `trove-server`