### PR TITLE
fix: move recent changes below catalogue

### DIFF
--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -18,9 +18,9 @@ func TestDashboardAttentionHierarchyIsEmbedded(t *testing.T) {
 	last := -1
 	for _, heading := range []string{
 		"Needs attention",
-		"Recent changes",
 		"Infrastructure summary",
 		"Service catalogue",
+		"Recent changes",
 	} {
 		pos := strings.Index(string(index), heading)
 		if pos == -1 {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -41,17 +41,6 @@
       <div class="attention" id="attention"></div>
     </section>
 
-    <section class="dashboard-section changes-section" aria-labelledby="changes-title">
-      <div class="section-heading compact">
-        <div>
-          <div class="eyebrow">What changed</div>
-          <h2 id="changes-title">Recent changes</h2>
-        </div>
-        <p>State, health, and agent heartbeat transitions. Quiet reports are intentionally absent.</p>
-      </div>
-      <div class="events" id="events"></div>
-    </section>
-
     <section class="dashboard-section infrastructure-section" aria-labelledby="infrastructure-title">
       <div class="section-heading compact">
         <div>
@@ -77,6 +66,17 @@
         <div class="chips" id="chips"></div>
       </div>
       <div id="hosts"></div>
+    </section>
+
+    <section class="dashboard-section changes-section" aria-labelledby="changes-title">
+      <div class="section-heading compact">
+        <div>
+          <div class="eyebrow">History</div>
+          <h2 id="changes-title">Recent changes</h2>
+        </div>
+        <p>State, health, and agent heartbeat transitions. Quiet reports are intentionally absent.</p>
+      </div>
+      <div class="events" id="events"></div>
     </section>
 
     <footer>


### PR DESCRIPTION
## Why
Recent changes is useful history but noisy as a top-of-page dashboard section. It should not compete with the attention queue or inventory.

## Change
- Moves Recent changes below the service catalogue.
- Reframes it as History.
- Updates the embedded-dashboard hierarchy regression test.

## Validation
- `node --check web/public/app.js`
- `go test ./web`
- `make test`
- `make build`
- `git diff --check`