### PR TITLE
fix: improve dashboard mobile and keyboard usability

### DIFF
--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -40,10 +40,21 @@ func TestDashboardAttentionHierarchyIsEmbedded(t *testing.T) {
 	for _, marker := range []string{
 		"function attentionItems()",
 		"function showAttention(key)",
+		"function focusInvestigationTarget(id)",
+		"Swipe or scroll horizontally to see all service details",
 		`const STOPPED_STATES = new Set(["exited", "dead", "failed", "stopped"])`,
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard attention behaviour is missing %q", marker)
+		}
+	}
+
+	for _, marker := range []string{
+		`id="infrastructure-title" tabindex="-1"`,
+		`id="inventory-title" tabindex="-1"`,
+	} {
+		if !strings.Contains(string(index), marker) {
+			t.Errorf("dashboard focus target is missing %q", marker)
 		}
 	}
 }

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -312,13 +312,22 @@ function renderAttention() {
 function showAttention(key) {
   clearFilters();
   if (key === "offline-agents" || key === "stale-agents") {
-    $("agents").scrollIntoView({ behavior: "smooth", block: "center" });
+    $("infrastructure-title").scrollIntoView({ behavior: "smooth", block: "start" });
+    focusInvestigationTarget("infrastructure-title");
     return;
   }
   if (key === "removed") state.showRemoved = true;
   else state.chips.add(key);
   render();
-  $("hosts").scrollIntoView({ behavior: "smooth", block: "start" });
+  $("inventory-title").scrollIntoView({ behavior: "smooth", block: "start" });
+  focusInvestigationTarget("inventory-title");
+}
+
+// Attention cards are replaced by render(), so keyboard focus cannot remain on
+// the button that invoked an investigation. Move it to the visible destination
+// instead of leaving it on document.body.
+function focusInvestigationTarget(id) {
+  requestAnimationFrame(() => $(id)?.focus({ preventScroll: true }));
 }
 
 // ------------------------------------------------------------- summary ----
@@ -470,6 +479,7 @@ function renderHosts() {
         <span class="rollup">${rollup}</span>
         <span class="count">${countLabel}</span>
       </button>
+      <p class="table-scroll-hint">Swipe or scroll horizontally to see all service details <span aria-hidden="true">→</span></p>
       <div class="host-body">
         <table>
           <thead><tr>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -45,7 +45,7 @@
       <div class="section-heading compact">
         <div>
           <div class="eyebrow">Discovered infrastructure</div>
-          <h2 id="infrastructure-title">Infrastructure summary</h2>
+          <h2 id="infrastructure-title" tabindex="-1">Infrastructure summary</h2>
         </div>
       </div>
       <div class="summary" id="summary"></div>
@@ -56,7 +56,7 @@
       <div class="section-heading compact">
         <div>
           <div class="eyebrow">Everything reported</div>
-          <h2 id="inventory-title">Service catalogue</h2>
+          <h2 id="inventory-title" tabindex="-1">Service catalogue</h2>
         </div>
         <p>Filter the discovered inventory. Trove never changes a workload.</p>
       </div>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -36,7 +36,8 @@
   --border-strong: #5b527a;
   --text: #eee8ff;
   --muted: #aaa4c6;
-  --subtle: #7e789b;
+  /* Normal-sized secondary copy must meet AA contrast on --panel (4.71:1). */
+  --subtle: #9189b0;
   --purple: #b48cff;
   --green: #9be28f;
   --amber: #f2a65a;
@@ -401,6 +402,7 @@ header h1 {
 .host-head .sub { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
 .host-head .rollup { display: inline-flex; gap: 6px; }
 .host-head .count { margin-left: auto; color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
+.table-scroll-hint { display: none; }
 .host-body { overflow-x: auto; }
 
 table { width: 100%; border-collapse: collapse; table-layout: fixed; min-width: 820px; }
@@ -680,4 +682,14 @@ footer kbd {
   .section-heading p { text-align: left; }
   .attention-card { grid-template-columns: auto minmax(0, 1fr); }
   .attention-action { grid-column: 2; }
+  .table-scroll-hint {
+    display: block;
+    margin: 0;
+    padding: 8px 14px;
+    color: var(--subtle);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    border-bottom: 1px solid var(--border);
+    background: rgba(15, 14, 25, 0.35);
+  }
 }


### PR DESCRIPTION
## Summary
- keep keyboard focus on the investigation destination after attention-card navigation
- add a mobile-only horizontal table-scroll hint without hiding catalogue columns
- raise secondary dashboard copy to AA contrast on panels
- guard embedded dashboard structure for the new focus and mobile affordance

## Verification
- `node --check web/public/app.js`
- `go test ./web`
- `make fmt`
- `make test`
- `make build`
- `git diff --check`
- Chromium + axe QA at 1366×768 and 390×844 using copied fixture data