### PR TITLE
fix: make dashboard identifiers readable

### DIFF
--- a/web/public/app.js
+++ b/web/public/app.js
@@ -483,7 +483,7 @@ function renderHosts() {
       <div class="host-body">
         <table>
           <thead><tr>
-            <th class="w-service">Service</th><th>Image</th><th class="w-state">State</th>
+            <th class="w-service">Service</th><th class="w-image">Image</th><th class="w-state">State</th>
             <th class="w-health">Health</th><th class="w-fresh">Freshness</th>
             <th class="w-ports">Ports</th><th class="w-seen">Last seen</th>
           </tr></thead>
@@ -709,6 +709,14 @@ function openDrawer(key) {
   state.drawerKey = key;
   state.cursorKey = key;
   render();
+  requestAnimationFrame(() => document.querySelector(".d-close")?.focus({ preventScroll: true }));
+}
+
+function closeDrawer() {
+  const key = state.drawerKey;
+  state.drawerKey = null;
+  render();
+  requestAnimationFrame(() => visibleRows().find((tr) => rowKey(tr) === key)?.focus({ preventScroll: true }));
 }
 
 // -------------------------------------------------------------- render ----
@@ -806,6 +814,7 @@ function toggleChip(key) {
     state.chips.add(key);
   }
   render();
+  requestAnimationFrame(() => document.querySelector(`[data-chip=\"${key}\"]`)?.focus({ preventScroll: true }));
 }
 
 function clearFilters() {
@@ -825,7 +834,7 @@ document.addEventListener("click", (e) => {
   const chip = e.target.closest("[data-chip]");
   if (chip) { toggleChip(chip.dataset.chip); return; }
 
-  if (e.target.closest(".d-close")) { state.drawerKey = null; render(); return; }
+  if (e.target.closest(".d-close")) { closeDrawer(); return; }
   if (e.target.closest("#drawer")) return; // clicks inside the drawer stay put
 
   const head = e.target.closest(".host-head");
@@ -851,7 +860,7 @@ document.addEventListener("keydown", (e) => {
   }
   if (e.key === "Escape") {
     if (typing) { e.target.blur(); return; }
-    if (state.drawerKey) { state.drawerKey = null; render(); return; }
+    if (state.drawerKey) { closeDrawer(); return; }
     if (state.q || state.chips.size > 0 || state.showRemoved) clearFilters();
     return;
   }

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -405,7 +405,7 @@ header h1 {
 .table-scroll-hint { display: none; }
 .host-body { overflow-x: auto; }
 
-table { width: 100%; border-collapse: collapse; table-layout: fixed; min-width: 820px; }
+table { width: 100%; border-collapse: collapse; table-layout: fixed; min-width: 1154px; }
 thead th {
   text-align: left;
   font-family: var(--font-mono);
@@ -419,6 +419,7 @@ thead th {
   background: rgba(15, 14, 25, 0.35);
 }
 th.w-service { width: 22%; }
+th.w-image   { width: 280px; }
 th.w-state   { width: 116px; }
 th.w-health  { width: 112px; }
 th.w-fresh   { width: 124px; }
@@ -430,8 +431,7 @@ tbody td {
   padding: 10px 14px;
   border-bottom: 1px solid rgba(59, 54, 85, 0.5);
   vertical-align: middle;
-  white-space: nowrap;
-  overflow: hidden;
+  overflow-wrap: anywhere;
   color: var(--muted);
   font-size: 13px;
 }
@@ -444,7 +444,7 @@ tbody tr.open td:first-child { box-shadow: inset 3px 0 0 var(--purple); }
 tbody tr.removed { opacity: 0.5; }
 tbody tr.removed .svc-name { text-decoration: line-through; }
 
-td.svc { text-overflow: ellipsis; }
+td.svc { overflow-wrap: anywhere; }
 /* Badge-only cells (state/health/freshness): tighter padding so the column
    width goes to the badge, not wasted margin. */
 tbody td.badgecell { padding-left: 8px; padding-right: 8px; }
@@ -463,26 +463,18 @@ tbody td.badgecell { padding-left: 8px; padding-right: 8px; }
 }
 tbody tr.child .svc-name { color: var(--muted); font-family: var(--font-body); font-weight: 500; }
 
-/* image cell: prefix shrinks first, name:tag stays visible */
-.img-wrap { display: flex; min-width: 0; color: var(--muted); font-family: var(--font-mono); font-size: 12px; }
+/* Image references are operational identifiers: wrap them rather than silently
+   hiding registry, name, or tag information behind an ellipsis. */
+.img-wrap { color: var(--muted); font-family: var(--font-mono); font-size: 12px; overflow-wrap: anywhere; }
 .img-prefix {
-  flex: 0 999 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: var(--subtle);
 }
 .img-name {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 .img-name .tag { color: var(--blue); }
 
-.ports { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; text-overflow: ellipsis; }
+.ports { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; overflow-wrap: anywhere; }
 .ports .more { color: var(--muted); }
 .muted { color: var(--subtle); }
 .nowrap { white-space: nowrap; }


### PR DESCRIPTION
## Summary
- wrap service, image, and port identifiers instead of silently clipping them
- retain keyboard focus on filters after rerendering
- move focus into the service drawer and return it to the invoking row on close

## Verification
- `node --check web/public/app.js`
- `make fmt`
- `make test`
- Playwright against the demo fixture with this branch
  - no console errors
  - no clipped service/image/port cells at 390 px
  - no page-level horizontal overflow
  - filter and drawer focus continuity passes