### PR TITLE
fix(release): preserve release commit metadata

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -182,6 +182,9 @@ changelog:
     exclude: ["^docs:", "^chore:", "^ci:"]
 
 release:
+  # Preserve the exact tagged commit in GitHub release metadata. Release Please
+  # uses that reference to identify the latest release boundary.
+  target_commitish: "{{ .Commit }}"
   footer: |
     **Container images** (multi-arch, amd64 + arm64):
     - `ghcr.io/techdox/trove-server:{{ .Version }}`


### PR DESCRIPTION
## Summary
- record the exact tagged commit as GitHub release metadata
- lets Release Please find the latest published release instead of replaying historical conventional commits
- repaired the current v0.12.4 release metadata and closed phantom PR #82

## Verification
- `make fmt`
- `make test`
- `make build`
- `go run github.com/goreleaser/goreleaser/v2@latest check`
- GitHub GraphQL confirms release `v0.12.4` resolves to commit `d216532`