### PR TITLE
feat: secure auth and track per-host liveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ Static binaries for everything (including the bare-metal agent) are on the
   every node in its cluster. On the dashboard, services are grouped by host.
 - **Push model**: agents POST full-state snapshots on an interval. The server
   never reaches into your infrastructure — homelab/NAT friendly.
-- **Heartbeats**: miss 3 intervals → agent (and its services) marked *stale*;
-  miss 10 → *offline*. Thresholds scale with each agent's own interval.
+- **Heartbeats**: agents and hosts are tracked independently. Miss 3 intervals
+  → *stale*; miss 10 → *offline*. Services follow their host's status, so one
+  healthy host cannot hide another missing host from the same agent. Thresholds
+  scale with each agent's own interval.
 - **Full-state reports** are idempotent and tolerate lost pushes. Services
   that disappear are soft-removed and pruned after 24h (configurable,
   `TROVE_REMOVED_RETENTION`).
@@ -229,6 +231,7 @@ go install github.com/techdox/trove/cmd/trove-server@latest
 | `TROVE_REGISTRY_AUTHS`     | _(unset)_  | Credentials for private registries — see below.                        |
 | `TROVE_EVENT_RETENTION`    | `720h` (30d) | How long events (activity feed / alert stream) are kept.             |
 | `TROVE_REMOVED_RETENTION`  | `24h`      | How long removed services linger before being purged.                  |
+| `TROVE_HOST_RETENTION`     | `720h` (30d) | How long a silent host and its remaining inventory are retained.     |
 | `TROVE_ALERT_*` / `TROVE_SMTP_*` | _(unset)_ | Notification channels & SMTP — see [docs/alerts.md](docs/alerts.md). |
 | `TROVE_DIGEST`             | `daily@08:00`* | Digest schedule; *only takes effect once `TROVE_SMTP_*` is set — see [docs/alerts.md](docs/alerts.md). |
 | `TROVE_BOOTSTRAP_AGENT` / `TROVE_BOOTSTRAP_TOKEN` | _(unset)_ | Seed one agent at startup (used by the quickstart compose). |
@@ -249,10 +252,16 @@ Dex, etc.):
 | `TROVE_API_TOKEN` | _(optional)_ Bearer token for programmatic API access (bypasses OIDC) |
 | `TROVE_OIDC_SESSION_MAX_AGE` | _(optional)_ Session duration (default `8h`) |
 
-When `TROVE_OIDC_ISSUER` is set, browser requests without a session are
-redirected to your IdP's login page. After login, a signed session cookie
-API requests with a bearer token matching `TROVE_API_TOKEN` bypass OIDC for
-script access. See the safe, copyable example in
+OIDC is enabled only when all four required `TROVE_OIDC_*` settings are
+present. If any required setting is present while another is missing, the
+server fails startup and names the missing variables instead of leaving the
+dashboard open. `TROVE_API_TOKEN` is valid only alongside a complete OIDC
+configuration.
+
+When OIDC is enabled, browser requests without a session are redirected to
+your IdP's login page. After login, Trove sets a signed session cookie. API
+requests with a bearer token matching `TROVE_API_TOKEN` bypass OIDC for script
+access. See the safe, copyable example in
 [docs/authentication.md](docs/authentication.md#programmatic-api-access).
 
 Logout clears Trove's local session cookie and, when the provider exposes an
@@ -343,9 +352,10 @@ interface; see [CONTRIBUTING.md](CONTRIBUTING.md).
 - Agent ingest is authenticated with per-agent bearer tokens (256-bit random,
   stored only as SHA-256 hashes). Revoke by deleting the agent.
 - **The dashboard and read APIs support optional OIDC authentication.** When
-  `TROVE_OIDC_ISSUER` is set, the dashboard and all read APIs require a valid
-  OIDC session. When unset, the dashboard is open — bind to a trusted network
-  (LAN/VPN/tailnet) or front it with an authenticating reverse proxy. See
+  all four required OIDC settings are set, the dashboard and all read APIs
+  require a valid OIDC session. Partial configuration fails startup. When all
+  authentication settings are unset, the dashboard is open — bind to a trusted
+  network or front it with an authenticating reverse proxy. See
   [Dashboard authentication](#dashboard-authentication-oidc).
 - Agents cannot change anything on the platforms they watch — read-only is
   enforced in code, not convention. Details in [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,12 @@ Trove's security posture is deliberately simple in the current phase:
   minted by `trove-server agent create`. Tokens are 256-bit random values and
   are stored server-side only as SHA-256 hashes.
 - **The dashboard and read APIs support optional OIDC authentication.** When
-  `TROVE_OIDC_ISSUER` is set, the dashboard and all read APIs require a valid
-  OIDC session (any standard OIDC provider — Authentik, Keycloak, Auth0, Google,
-  Dex). When unset, the dashboard is open — bind to a trusted network (LAN/VPN/
-  tailnet) or front it with an authenticating reverse proxy. Agent ingest
+  all four required OIDC settings are set, the dashboard and all read APIs
+  require a valid OIDC session (any standard OIDC provider — Authentik,
+  Keycloak, Auth0, Google, Dex). Partial configuration fails startup and names
+  the missing variables. When all authentication settings are unset, the
+  dashboard is open — bind to a trusted network (LAN/VPN/tailnet) or front it
+  with an authenticating reverse proxy. Agent ingest
   (`POST /api/v1/report`) and `/healthz` are never gated by OIDC. An optional
   `TROVE_API_TOKEN` allows Bearer-token access for programmatic API clients
   that can't do a browser-based OAuth flow. Logout uses the provider's OIDC

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -91,11 +91,12 @@ Environment:
   TROVE_DB                sqlite path    (default "trove.db")
   TROVE_BOOTSTRAP_AGENT   dev-only: seed an agent with this name at startup
   TROVE_BOOTSTRAP_TOKEN   dev-only: token for the bootstrapped agent
-  TROVE_OIDC_ISSUER       OIDC discovery URL (enables dashboard auth when set)
+  TROVE_OIDC_ISSUER       OIDC discovery URL (set with all required OIDC settings)
   TROVE_OIDC_CLIENT_ID    OAuth2 client ID
   TROVE_OIDC_CLIENT_SECRET  OAuth2 client secret
   TROVE_OIDC_REDIRECT_URL   OAuth2 callback URL
   TROVE_API_TOKEN         Bearer token for programmatic API access (with OIDC)
+  TROVE_HOST_RETENTION    Retain silent hosts before pruning (default "720h")
 `)
 }
 
@@ -147,9 +148,9 @@ func runServe() error {
 	srv.ConfigureFreshness(server.LoadFreshnessConfigFromEnv())
 	srv.ConfigureRetention(server.LoadRetentionConfigFromEnv())
 
-	// Configure OIDC if env vars are set. When configured, the dashboard
-	// and read APIs require an OIDC session; when unset, behavior is
-	// unchanged (no auth — bind to a trusted network).
+	// Configure OIDC if all required env vars are set. Partial configuration
+	// fails startup; when all auth settings are absent, behavior is unchanged
+	// (no auth — bind to a trusted network).
 	if err := srv.ConfigureOIDC(server.LoadOIDCConfigFromEnv()); err != nil {
 		return fmt.Errorf("configure oidc: %w", err)
 	}

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -104,14 +104,15 @@ override quiet hours if you configure ntfy that way.
 | Kind        | Fires on                                                     | Level    |
 | ----------- | ------------------------------------------------------------ | -------- |
 | `agent`     | agent stale (missed 3 pushes) / offline (missed 10) / recovery | warning / critical / resolved |
+| `host`      | host stale / offline / recovery while its agent is reporting | warning / critical / resolved |
 | `health`    | service health → unhealthy, and recovery                     | critical / resolved |
 | `state`     | service stopped/failed/removed/degraded, and recovery        | warning / resolved |
 | `freshness` | a running image falls behind its registry tag                 | warning / resolved |
 
-All four are on by default. Trim with:
+All five are on by default. Trim with:
 
 ```sh
-TROVE_ALERT_EVENTS=agent,health     # e.g. quiet mode for chatty clusters
+TROVE_ALERT_EVENTS=agent,host,health     # e.g. quiet mode for chatty clusters
 ```
 
 Built-in noise control (not configurable, by design):
@@ -119,16 +120,17 @@ Built-in noise control (not configurable, by design):
 - **Transitions only** — an ongoing bad state never re-alerts by itself.
 - **New services don't alert on appearance** (feed-only) — a deploy isn't an
   incident. On Kubernetes, note that pod churn from deploys still produces
-  `state: removed` alerts; set `TROVE_ALERT_EVENTS=agent,health` if that's
+  `state: removed` alerts; set `TROVE_ALERT_EVENTS=agent,host,health` if that's
   too chatty for your cluster.
-- **Cooldown** (`TROVE_ALERT_COOLDOWN`, default `5m`) — per service/agent,
+- **Cooldown** (`TROVE_ALERT_COOLDOWN`, default `5m`) — per service/agent/host,
   repeated flapping inside the window is suppressed, and a "resolved" notice
   is only sent for alerts that were actually delivered. Escalations (e.g.
   agent stale → offline) bypass the cooldown once.
 - **No alarm floods at boot** — the engine starts from the current state; it
   never replays history or announces fifteen already-outdated images.
 - When an agent goes offline, you get **one** agent alert, not one per
-  service on that host.
+  service or host. If the agent recovers while one of its hosts remains
+  missing, that host then alerts independently.
 
 ## Email digest
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -161,7 +161,8 @@ slot, the digest is sent once on the next check (no double-sends).
 Alerting reads the same event stream the dashboard's activity feed shows.
 Retention is configurable:
 
-| Variable                  | Default | Purpose                                        |
-| ------------------------- | ------- | ---------------------------------------------- |
-| `TROVE_EVENT_RETENTION`   | `720h`  | How long state/health/agent events are kept.   |
-| `TROVE_REMOVED_RETENTION` | `24h`   | How long removed services linger before purge. |
+| Variable                  | Default | Purpose                                                   |
+| ------------------------- | ------- | --------------------------------------------------------- |
+| `TROVE_EVENT_RETENTION`   | `720h`  | How long state/health/agent events are kept.              |
+| `TROVE_REMOVED_RETENTION` | `24h`   | How long removed services linger before purge.            |
+| `TROVE_HOST_RETENTION`    | `720h`  | How long silent hosts and their inventory are retained.   |

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,8 +61,11 @@ Optional query parameters:
 
 - `limit`: positive integer, capped at `500`.
 - `offset`: non-negative integer.
-- `kind`: exact event kind, for example `state`, `health`, `agent`, or `freshness`.
+- `kind`: exact event kind, for example `state`, `health`, `agent`, `host`, or `freshness`.
 - `since`: Unix timestamp or RFC3339 time. Filters events by `at >= since`.
+
+Service events include `service_id`; host events include `host_id`. These are
+soft historical references and remain in the feed after their subject is pruned.
 
 Example:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,9 @@ If OIDC is enabled, read APIs require either an authenticated dashboard session 
 
 ### `GET /api/v1/services`
 
-By default, Trove returns all services grouped by agent and host for the dashboard.
+By default, Trove returns all services grouped by agent and host for the dashboard. Reported hosts with no services are included with an empty `services` array so their liveness remains visible.
+
+Each host group includes its own derived `status` (`ok`, `stale`, `offline`, or `unknown`) and `last_seen_at`, plus `agent_status` for the owning agent. Host and agent status can differ when a multi-host agent continues reporting some hosts after another disappears.
 
 Optional query parameters:
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -4,6 +4,8 @@ Trove is still read-only, but the dashboard and read APIs can be protected with 
 
 When OIDC is not configured, Trove keeps the original behaviour: the dashboard and read APIs are open. In that mode, keep the server on a trusted network, VPN, tailnet, or behind an authenticating reverse proxy.
 
+Open mode requires all OIDC authentication settings to be absent. If any required `TROVE_OIDC_*` setting is present while another is missing, Trove fails startup and lists the missing variables. `TROVE_API_TOKEN` cannot be used without a complete OIDC configuration.
+
 ## What OIDC protects
 
 When `TROVE_OIDC_ISSUER` and the other required OIDC settings are present, Trove protects:
@@ -36,6 +38,8 @@ Set these on the `trove-server` process:
 | `TROVE_OIDC_CLIENT_ID` | OAuth2/OIDC client ID from the provider. |
 | `TROVE_OIDC_CLIENT_SECRET` | OAuth2/OIDC client secret from the provider. |
 | `TROVE_OIDC_REDIRECT_URL` | Trove callback URL. Example: `https://trove.example.com/oauth2/callback` |
+
+All four settings are required together. Trove performs OIDC discovery during startup with a ten-second timeout; invalid, unreachable, or incomplete configuration prevents the server from listening.
 
 Optional:
 

--- a/internal/alert/config.go
+++ b/internal/alert/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	NtfyURL       string
 	NtfyToken     string
 
-	// Kinds enabled for instant notifications: state, health, agent, freshness.
+	// Kinds enabled for instant notifications: state, health, agent, host, freshness.
 	Kinds map[string]bool
 
 	// Cooldown is the minimum interval between notifications for the same key
@@ -42,7 +42,7 @@ const (
 //	TROVE_ALERT_DISCORD_URL     Discord webhook
 //	TROVE_ALERT_NTFY_URL      full ntfy topic URL (e.g. https://ntfy.sh/my-trove)
 //	TROVE_ALERT_NTFY_TOKEN    optional ntfy access token
-//	TROVE_ALERT_EVENTS        comma list of kinds (default "agent,health,state,freshness")
+//	TROVE_ALERT_EVENTS        comma list of kinds (default "agent,host,health,state,freshness")
 //	TROVE_ALERT_COOLDOWN      per-key flap suppression window (default 5m)
 func LoadConfigFromEnv() Config {
 	cfg := Config{
@@ -57,7 +57,7 @@ func LoadConfigFromEnv() Config {
 	}
 	kinds := os.Getenv("TROVE_ALERT_EVENTS")
 	if kinds == "" {
-		kinds = "agent,health,state,freshness"
+		kinds = "agent,host,health,state,freshness"
 	}
 	for _, k := range strings.Split(kinds, ",") {
 		if k = strings.TrimSpace(strings.ToLower(k)); k != "" {

--- a/internal/alert/digest.go
+++ b/internal/alert/digest.go
@@ -300,8 +300,11 @@ func (d *Digester) build(ctx context.Context, since time.Time) (subject, text, h
 		}
 		for _, e := range recent[:max] {
 			subjectName := e.Service
-			if e.Kind == store.EventKindAgent {
+			switch e.Kind {
+			case store.EventKindAgent:
 				subjectName = "agent " + e.Agent
+			case store.EventKindHost:
+				subjectName = "host " + e.Hostname
 			}
 			fmt.Fprintf(&b, "  - %s  %s %s → %s\n",
 				time.Unix(e.At, 0).Format("2 Jan 15:04"), subjectName, orNone(e.FromState), e.ToState)

--- a/internal/alert/dispatch.go
+++ b/internal/alert/dispatch.go
@@ -25,7 +25,7 @@ const (
 
 // Notification is one outbound message, channel-agnostic.
 type Notification struct {
-	Kind    string    `json:"kind"`  // state | health | agent | freshness | test
+	Kind    string    `json:"kind"`  // state | health | agent | host | freshness | test
 	Level   string    `json:"level"` // info | warning | critical | resolved
 	Title   string    `json:"title"`
 	Body    string    `json:"body"`

--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -179,6 +179,33 @@ func classify(ev store.EventRow) (string, Notification, verdictT, bool) {
 		}
 		return "", n, verdictT{}, false
 
+	case store.EventKindHost:
+		// Host IDs are never reused, so a retained alert state cannot suppress a
+		// later outage after an old host is pruned and the same name reappears.
+		key := "host:" + strconv.FormatInt(ev.HostID.Int64, 10)
+		source := ev.Hostname
+		if ev.Agent != "" {
+			source += " (agent " + ev.Agent + ")"
+		}
+		switch ev.ToState {
+		case "offline":
+			n.Level = LevelCritical
+			n.Title = fmt.Sprintf("host %s offline", ev.Hostname)
+			n.Body = fmt.Sprintf("host %s stopped reporting (%s → offline)", source, ev.FromState)
+			return key, n, verdictT{bad: "offline", level: n.Level}, true
+		case "stale":
+			n.Level = LevelWarning
+			n.Title = fmt.Sprintf("host %s stale", ev.Hostname)
+			n.Body = fmt.Sprintf("host %s has missed several reports (%s → stale)", source, ev.FromState)
+			return key, n, verdictT{bad: "stale", level: n.Level}, true
+		case "ok":
+			n.Level = LevelResolved
+			n.Title = fmt.Sprintf("host %s recovered", ev.Hostname)
+			n.Body = fmt.Sprintf("host %s is reporting again (%s → ok)", source, ev.FromState)
+			return key, n, verdictT{bad: "", level: n.Level}, true
+		}
+		return "", n, verdictT{}, false
+
 	case store.EventKindHealth:
 		key := "svc:" + strconv.FormatInt(ev.ServiceID.Int64, 10) + ":health"
 		switch ev.ToState {

--- a/internal/alert/engine_test.go
+++ b/internal/alert/engine_test.go
@@ -264,10 +264,11 @@ func TestEngineRetriesOnlyFailedChannelAfterPartialFanout(t *testing.T) {
 }
 
 // TestEngineReconnectAfterMassStaleDoesNotDropNotifiedBit reproduces a
-// specific pre-fix bug: when an agent goes stale, MarkServicesStaleForAgents
+// specific pre-fix bug: when a host goes stale, MarkServicesStaleForHosts
 // mass-flips every live service's health to "stale" directly in SQL (no
-// event, by design — one agent alert instead of an alert per service). When
-// the agent reconnects and reports the SAME still-unhealthy service,
+// event, by design — staleness is surfaced at host level instead of emitting
+// an event per service).
+// When the host reconnects and reports the SAME still-unhealthy service,
 // ApplyReport diffs against that clobbered "stale" baseline and synthesizes a
 // fresh stale->unhealthy event, even though nothing actually changed from the
 // operator's perspective. Before the fix, deliver() treated that replay as a
@@ -292,9 +293,13 @@ func TestEngineReconnectAfterMassStaleDoesNotDropNotifiedBit(t *testing.T) {
 		t.Fatalf("want 1 unhealthy alert, got: %v", s.titles())
 	}
 
-	// Agent goes stale shortly after (well within cooldown): mass-flip, no event.
+	// Host goes stale shortly after (well within cooldown): mass-flip, no event.
 	*clock = clock.Add(time.Second)
-	if _, err := st.MarkServicesStaleForAgents(ctx, []int64{agent.ID}); err != nil {
+	hosts, err := st.ListHosts(ctx)
+	if err != nil || len(hosts) != 1 {
+		t.Fatalf("list hosts: hosts=%+v err=%v", hosts, err)
+	}
+	if _, err := st.MarkServicesStaleForHosts(ctx, []int64{hosts[0].ID}); err != nil {
 		t.Fatalf("mark stale: %v", err)
 	}
 	s.reset()

--- a/internal/alert/engine_test.go
+++ b/internal/alert/engine_test.go
@@ -79,7 +79,7 @@ func newTestEngine(t *testing.T) (*Engine, *store.Store, *sink, *time.Time) {
 	s := newSink(t)
 	cfg := Config{
 		WebhookURL: s.srv.URL,
-		Kinds:      map[string]bool{"agent": true, "health": true, "state": true, "freshness": true},
+		Kinds:      map[string]bool{"agent": true, "host": true, "health": true, "state": true, "freshness": true},
 		Cooldown:   5 * time.Minute,
 		Interval:   time.Hour, // sweeps are driven manually in tests
 	}
@@ -101,6 +101,14 @@ func testSvc(state string, health model.Health) model.ReportService {
 	return model.ReportService{
 		ExternalID: "c1", Name: "web", Kind: model.KindContainer,
 		Image: "nginx:alpine", State: state, Health: health,
+	}
+}
+
+func TestDefaultAlertKindsIncludeHostLiveness(t *testing.T) {
+	t.Setenv("TROVE_ALERT_EVENTS", "")
+	cfg := LoadConfigFromEnv()
+	if !cfg.Kinds[store.EventKindHost] {
+		t.Fatalf("default alert kinds = %+v, want host liveness enabled", cfg.Kinds)
 	}
 }
 
@@ -159,6 +167,54 @@ func TestEngineLifecycle(t *testing.T) {
 	e.Sweep(ctx)
 	if s.count() != 2 {
 		t.Fatalf("post-cooldown incident must alert, got: %v", s.titles())
+	}
+}
+
+func TestEngineHostLifecycle(t *testing.T) {
+	e, st, s, _ := newTestEngine(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "proxmox-a")
+	rep := testReport()
+	rep.Agent.Name = "proxmox-a"
+	rep.Agent.Platform = model.PlatformProxmox
+	rep.Host.Hostname = "node-a"
+	if err := st.ApplyReport(ctx, agent.ID, rep); err != nil {
+		t.Fatalf("apply report: %v", err)
+	}
+	hosts, err := st.ListHosts(ctx)
+	if err != nil || len(hosts) != 1 {
+		t.Fatalf("list hosts: hosts=%+v err=%v", hosts, err)
+	}
+	host := hosts[0]
+	if _, err := st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "ok"); err != nil {
+		t.Fatalf("seed host status: %v", err)
+	}
+	e.Sweep(ctx) // seed event cursor
+
+	if _, err := st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "stale"); err != nil {
+		t.Fatalf("mark host stale: %v", err)
+	}
+	e.Sweep(ctx)
+	if got := s.titles(); len(got) != 1 || got[0] != "warning: host node-a stale" {
+		t.Fatalf("stale alert = %v, want host warning", got)
+	}
+
+	s.reset()
+	if _, err := st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "offline"); err != nil {
+		t.Fatalf("mark host offline: %v", err)
+	}
+	e.Sweep(ctx)
+	if got := s.titles(); len(got) != 1 || got[0] != "critical: host node-a offline" {
+		t.Fatalf("offline alert = %v, want host critical escalation", got)
+	}
+
+	s.reset()
+	if _, err := st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "ok"); err != nil {
+		t.Fatalf("recover host: %v", err)
+	}
+	e.Sweep(ctx)
+	if got := s.titles(); len(got) != 1 || got[0] != "resolved: host node-a recovered" {
+		t.Fatalf("recovery alert = %v, want host resolution", got)
 	}
 }
 
@@ -443,6 +499,7 @@ func TestEngineKindFiltering(t *testing.T) {
 
 func TestClassifyTable(t *testing.T) {
 	sid := sql.NullInt64{Int64: 7, Valid: true}
+	hid := sql.NullInt64{Int64: 5, Valid: true}
 	aid := sql.NullInt64{Int64: 3, Valid: true}
 	cases := []struct {
 		name      string
@@ -462,6 +519,9 @@ func TestClassifyTable(t *testing.T) {
 		{"agent stale", store.EventRow{Kind: "agent", AgentID: aid, FromState: "ok", ToState: "stale"}, true, LevelWarning},
 		{"agent offline", store.EventRow{Kind: "agent", AgentID: aid, FromState: "stale", ToState: "offline"}, true, LevelCritical},
 		{"agent recovered", store.EventRow{Kind: "agent", AgentID: aid, FromState: "offline", ToState: "ok"}, true, LevelResolved},
+		{"host stale", store.EventRow{Kind: "host", HostID: hid, AgentID: aid, Hostname: "node-a", FromState: "ok", ToState: "stale"}, true, LevelWarning},
+		{"host offline", store.EventRow{Kind: "host", HostID: hid, AgentID: aid, Hostname: "node-a", FromState: "stale", ToState: "offline"}, true, LevelCritical},
+		{"host recovered", store.EventRow{Kind: "host", HostID: hid, AgentID: aid, Hostname: "node-a", FromState: "offline", ToState: "ok"}, true, LevelResolved},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -473,6 +533,29 @@ func TestClassifyTable(t *testing.T) {
 				t.Fatalf("level = %q, want %q", n.Level, tc.wantLevel)
 			}
 		})
+	}
+}
+
+func TestClassifyHostKeyUsesImmutableID(t *testing.T) {
+	event := store.EventRow{
+		Kind:      store.EventKindHost,
+		HostID:    sql.NullInt64{Int64: 5, Valid: true},
+		AgentID:   sql.NullInt64{Int64: 3, Valid: true},
+		Hostname:  "node-a",
+		FromState: "ok",
+		ToState:   "stale",
+	}
+	first, _, _, ok := classify(event)
+	if !ok {
+		t.Fatal("first host event was not classified")
+	}
+	event.HostID.Int64 = 6 // same agent/name after retention pruning and rediscovery
+	second, _, _, ok := classify(event)
+	if !ok {
+		t.Fatal("second host event was not classified")
+	}
+	if first == second {
+		t.Fatalf("host alert keys collided across immutable IDs: %q", first)
 	}
 }
 

--- a/internal/server/maintenance.go
+++ b/internal/server/maintenance.go
@@ -12,18 +12,26 @@ type RetentionConfig struct {
 	Events time.Duration
 	// Removed: how long soft-removed services linger before hard deletion.
 	Removed time.Duration
+	// Hosts: how long a host can remain silent before its inventory is deleted.
+	Hosts time.Duration
 }
 
 const (
 	defaultEventRetention   = 30 * 24 * time.Hour // 30 days
 	defaultRemovedRetention = 24 * time.Hour
+	defaultHostRetention    = 30 * 24 * time.Hour
 	maintenanceInterval     = time.Hour
 )
 
 // LoadRetentionConfigFromEnv reads TROVE_EVENT_RETENTION and
-// TROVE_REMOVED_RETENTION (Go durations, e.g. "720h"), with safe defaults.
+// TROVE_REMOVED_RETENTION and TROVE_HOST_RETENTION (Go durations, e.g.
+// "720h"), with safe defaults.
 func LoadRetentionConfigFromEnv() RetentionConfig {
-	cfg := RetentionConfig{Events: defaultEventRetention, Removed: defaultRemovedRetention}
+	cfg := RetentionConfig{
+		Events:  defaultEventRetention,
+		Removed: defaultRemovedRetention,
+		Hosts:   defaultHostRetention,
+	}
 	if v := os.Getenv("TROVE_EVENT_RETENTION"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			cfg.Events = d
@@ -32,6 +40,11 @@ func LoadRetentionConfigFromEnv() RetentionConfig {
 	if v := os.Getenv("TROVE_REMOVED_RETENTION"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			cfg.Removed = d
+		}
+	}
+	if v := os.Getenv("TROVE_HOST_RETENTION"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			cfg.Hosts = d
 		}
 	}
 	return cfg
@@ -54,6 +67,9 @@ func (s *Server) RunMaintenanceLoop(ctx context.Context) {
 	if s.retention.Removed <= 0 {
 		s.retention.Removed = defaultRemovedRetention
 	}
+	if s.retention.Hosts <= 0 {
+		s.retention.Hosts = defaultHostRetention
+	}
 	t := time.NewTicker(maintenanceInterval)
 	defer t.Stop()
 	s.runMaintenance(ctx)
@@ -69,13 +85,17 @@ func (s *Server) RunMaintenanceLoop(ctx context.Context) {
 
 func (s *Server) runMaintenance(ctx context.Context) {
 	stats, err := s.store.Prune(ctx,
-		int64(s.retention.Events.Seconds()), int64(s.retention.Removed.Seconds()))
+		int64(s.retention.Events.Seconds()),
+		int64(s.retention.Removed.Seconds()),
+		int64(s.retention.Hosts.Seconds()))
 	if err != nil {
 		s.log.Error("maintenance: prune", "err", err)
 		return
 	}
-	if stats.Events > 0 || stats.RemovedServices > 0 {
+	if stats.Events > 0 || stats.RemovedServices > 0 || stats.Hosts > 0 {
 		s.log.Info("maintenance: pruned",
-			"events", stats.Events, "removed_services", stats.RemovedServices)
+			"events", stats.Events,
+			"removed_services", stats.RemovedServices,
+			"hosts", stats.Hosts)
 	}
 }

--- a/internal/server/maintenance_test.go
+++ b/internal/server/maintenance_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoadRetentionConfigFromEnvIncludesHosts(t *testing.T) {
+	t.Setenv("TROVE_EVENT_RETENTION", "48h")
+	t.Setenv("TROVE_REMOVED_RETENTION", "12h")
+	t.Setenv("TROVE_HOST_RETENTION", "168h")
+
+	cfg := LoadRetentionConfigFromEnv()
+	if cfg.Events != 48*time.Hour {
+		t.Errorf("Events = %v, want 48h", cfg.Events)
+	}
+	if cfg.Removed != 12*time.Hour {
+		t.Errorf("Removed = %v, want 12h", cfg.Removed)
+	}
+	if cfg.Hosts != 168*time.Hour {
+		t.Errorf("Hosts = %v, want 168h", cfg.Hosts)
+	}
+}
+
+func TestLoadRetentionConfigFromEnvUsesSafeHostDefault(t *testing.T) {
+	t.Setenv("TROVE_EVENT_RETENTION", "")
+	t.Setenv("TROVE_REMOVED_RETENTION", "")
+	t.Setenv("TROVE_HOST_RETENTION", "invalid")
+
+	cfg := LoadRetentionConfigFromEnv()
+	if cfg.Hosts != defaultHostRetention {
+		t.Errorf("Hosts = %v, want default %v", cfg.Hosts, defaultHostRetention)
+	}
+}

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -42,9 +42,41 @@ type OIDCConfig struct {
 	SessionMaxAge time.Duration
 }
 
+const oidcDiscoveryTimeout = 10 * time.Second
+
 // Enabled reports whether OIDC authentication is active.
 func (c OIDCConfig) Enabled() bool {
 	return c.Issuer != "" && c.ClientID != "" && c.ClientSecret != "" && c.RedirectURL != ""
+}
+
+// validate rejects partial authentication configuration. APIToken is included
+// in the intent check because it is only a bypass for a complete OIDC setup;
+// setting it alone must not leave the dashboard open unexpectedly.
+func (c OIDCConfig) validate() error {
+	configured := c.Issuer != "" || c.ClientID != "" || c.ClientSecret != "" || c.RedirectURL != "" || c.APIToken != ""
+	if !configured {
+		return nil
+	}
+
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"TROVE_OIDC_ISSUER", c.Issuer},
+		{"TROVE_OIDC_CLIENT_ID", c.ClientID},
+		{"TROVE_OIDC_CLIENT_SECRET", c.ClientSecret},
+		{"TROVE_OIDC_REDIRECT_URL", c.RedirectURL},
+	}
+	missing := make([]string, 0, len(required))
+	for _, setting := range required {
+		if setting.value == "" {
+			missing = append(missing, setting.name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("incomplete OIDC configuration: missing %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // LoadOIDCConfigFromEnv reads OIDC configuration from the environment.
@@ -84,8 +116,8 @@ type oidcProvider struct {
 }
 
 // newOIDCProvider discovers the issuer and builds the OAuth2 config + verifier.
-func newOIDCProvider(cfg OIDCConfig, log *slog.Logger) (*oidcProvider, error) {
-	provider, err := oidc.NewProvider(context.Background(), cfg.Issuer)
+func newOIDCProvider(ctx context.Context, cfg OIDCConfig, log *slog.Logger) (*oidcProvider, error) {
+	provider, err := oidc.NewProvider(ctx, cfg.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("oidc discovery for %q: %w", cfg.Issuer, err)
 	}

--- a/internal/server/oidc_test.go
+++ b/internal/server/oidc_test.go
@@ -1,14 +1,18 @@
 package server
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -372,6 +376,146 @@ func TestOIDCConfigEnabledValidation(t *testing.T) {
 				t.Errorf("Enabled() = %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+func TestConfigureOIDCAllowsAllAuthenticationSettingsUnset(t *testing.T) {
+	srv := New(nil, nil)
+	if err := srv.ConfigureOIDC(OIDCConfig{}); err != nil {
+		t.Fatalf("ConfigureOIDC: %v", err)
+	}
+	if srv.oidc != nil {
+		t.Fatal("OIDC provider configured for empty settings")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("open-mode /api/v1/me status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestConfigureOIDCRejectsEveryPartialRequiredCombination(t *testing.T) {
+	settings := []struct {
+		name  string
+		value string
+		set   func(*OIDCConfig, string)
+	}{
+		{"TROVE_OIDC_ISSUER", "https://idp.example", func(cfg *OIDCConfig, value string) { cfg.Issuer = value }},
+		{"TROVE_OIDC_CLIENT_ID", "client", func(cfg *OIDCConfig, value string) { cfg.ClientID = value }},
+		{"TROVE_OIDC_CLIENT_SECRET", "secret", func(cfg *OIDCConfig, value string) { cfg.ClientSecret = value }},
+		{"TROVE_OIDC_REDIRECT_URL", "https://trove.example/oauth2/callback", func(cfg *OIDCConfig, value string) { cfg.RedirectURL = value }},
+	}
+
+	for mask := 1; mask < (1<<len(settings))-1; mask++ {
+		t.Run(fmt.Sprintf("set_%04b", mask), func(t *testing.T) {
+			cfg := OIDCConfig{}
+			var missing []string
+			for i, setting := range settings {
+				if mask&(1<<i) != 0 {
+					setting.set(&cfg, setting.value)
+				} else {
+					missing = append(missing, setting.name)
+				}
+			}
+
+			srv := New(nil, nil)
+			err := srv.ConfigureOIDC(cfg)
+			if err == nil {
+				t.Fatal("ConfigureOIDC accepted partial configuration")
+			}
+			for _, name := range missing {
+				if !strings.Contains(err.Error(), name) {
+					t.Errorf("error %q does not name missing setting %s", err, name)
+				}
+			}
+			if srv.oidc != nil {
+				t.Fatal("OIDC provider configured after validation failure")
+			}
+		})
+	}
+}
+
+func TestConfigureOIDCRejectsAPITokenWithoutOIDC(t *testing.T) {
+	srv := New(nil, nil)
+	err := srv.ConfigureOIDC(OIDCConfig{APIToken: "api-token"})
+	if err == nil {
+		t.Fatal("ConfigureOIDC accepted API token without OIDC")
+	}
+	for _, name := range []string{
+		"TROVE_OIDC_ISSUER",
+		"TROVE_OIDC_CLIENT_ID",
+		"TROVE_OIDC_CLIENT_SECRET",
+		"TROVE_OIDC_REDIRECT_URL",
+	} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error %q does not name missing setting %s", err, name)
+		}
+	}
+}
+
+func TestConfigureOIDCAcceptsCompleteConfiguration(t *testing.T) {
+	var issuer string
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 issuer,
+			"authorization_endpoint": issuer + "/authorize",
+			"token_endpoint":         issuer + "/token",
+			"jwks_uri":               issuer + "/keys",
+		}); err != nil {
+			t.Errorf("encode discovery response: %v", err)
+		}
+	}))
+	issuer = discovery.URL
+	t.Cleanup(discovery.Close)
+
+	srv := New(nil, nil)
+	err := srv.ConfigureOIDC(OIDCConfig{
+		Issuer:       issuer,
+		ClientID:     "client",
+		ClientSecret: "secret",
+		RedirectURL:  "https://trove.example/oauth2/callback",
+	})
+	if err != nil {
+		t.Fatalf("ConfigureOIDC: %v", err)
+	}
+	if srv.oidc == nil {
+		t.Fatal("OIDC provider not configured")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("protected API status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestOIDCDiscoveryHonorsContextDeadline(t *testing.T) {
+	release := make(chan struct{})
+	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-release:
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		discovery.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := newOIDCProvider(ctx, OIDCConfig{Issuer: discovery.URL}, nil)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("newOIDCProvider error = %v, want context deadline exceeded", err)
 	}
 }
 

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -77,7 +77,8 @@ type agentsResponse struct {
 type eventDTO struct {
 	ID        int64  `json:"id"`
 	ServiceID *int64 `json:"service_id,omitempty"`
-	Kind      string `json:"kind"` // state | health | agent
+	HostID    *int64 `json:"host_id,omitempty"`
+	Kind      string `json:"kind"` // state | health | agent | host
 	Service   string `json:"service,omitempty"`
 	Hostname  string `json:"hostname,omitempty"`
 	Agent     string `json:"agent,omitempty"`
@@ -250,9 +251,15 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			id := e.ServiceID.Int64
 			serviceID = &id
 		}
+		var hostID *int64
+		if e.HostID.Valid {
+			id := e.HostID.Int64
+			hostID = &id
+		}
 		out = append(out, eventDTO{
 			ID:        e.ID,
 			ServiceID: serviceID,
+			HostID:    hostID,
 			Kind:      e.Kind,
 			Service:   e.Service,
 			Hostname:  e.Hostname,

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -39,6 +39,8 @@ type hostGroupDTO struct {
 	Agent       string          `json:"agent"`
 	Hostname    string          `json:"hostname"`
 	Platform    string          `json:"platform"`
+	Status      string          `json:"status"`
+	LastSeenAt  *string         `json:"last_seen_at"`
 	AgentStatus string          `json:"agent_status"`
 	Meta        json.RawMessage `json:"meta"`
 	Services    []serviceDTO    `json:"services"`
@@ -118,6 +120,30 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 	// Rows are ordered (agent, host, name); group consecutively by host id.
 	var hosts []hostGroupDTO
 	byHost := map[int64]int{} // host id -> index in hosts
+	// The unpaginated dashboard view includes hosts with no services. This is
+	// important for Proxmox nodes, which are reported even when they have no
+	// guests, and lets their heartbeat remain visible independently.
+	if limit == 0 && offset == 0 && since == 0 {
+		knownHosts, err := s.store.ListHosts(r.Context())
+		if err != nil {
+			s.log.Error("list hosts", "err", err)
+			writeError(w, http.StatusInternalServerError, "failed to load hosts")
+			return
+		}
+		for _, host := range knownHosts {
+			hosts = append(hosts, hostGroupDTO{
+				Agent:       host.AgentName,
+				Hostname:    host.Hostname,
+				Platform:    host.AgentPlatform,
+				Status:      string(heartbeatStatus(host.LastSeenAt, host.AgentIntervalSeconds, now)),
+				LastSeenAt:  rfc3339Ptr(host.LastSeenAt),
+				AgentStatus: string(heartbeatStatus(host.AgentLastSeenAt, host.AgentIntervalSeconds, now)),
+				Meta:        rawJSON(host.MetaJSON, "{}"),
+				Services:    []serviceDTO{},
+			})
+			byHost[host.ID] = len(hosts) - 1
+		}
+	}
 	for _, row := range rows {
 		idx, ok := byHost[row.HostID]
 		if !ok {
@@ -125,7 +151,9 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 				Agent:       row.AgentName,
 				Hostname:    row.Hostname,
 				Platform:    row.AgentPlatform,
-				AgentStatus: string(agentStatus(row.AgentLastSeenAt, row.AgentIntervalSeconds, now)),
+				Status:      string(heartbeatStatus(row.HostLastSeenAt, row.AgentIntervalSeconds, now)),
+				LastSeenAt:  rfc3339Ptr(row.HostLastSeenAt),
+				AgentStatus: string(heartbeatStatus(row.AgentLastSeenAt, row.AgentIntervalSeconds, now)),
 				Meta:        rawJSON(row.HostMetaJSON, "{}"),
 				Services:    []serviceDTO{},
 			})
@@ -181,7 +209,7 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 			Platform:        a.Platform,
 			Version:         a.Version,
 			IntervalSeconds: a.IntervalSeconds,
-			Status:          string(agentStatus(a.LastSeenAt, a.IntervalSeconds, now)),
+			Status:          string(heartbeatStatus(a.LastSeenAt, a.IntervalSeconds, now)),
 			CreatedAt:       rfc3339(a.CreatedAt),
 			LastSeenAt:      rfc3339Ptr(a.LastSeenAt),
 		})
@@ -251,10 +279,10 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 
 // ---- helpers -------------------------------------------------------------
 
-// agentStatus computes the heartbeat verdict for the /agents strip and the
-// per-host badge. It mirrors what the background ticker uses to flag services,
-// but is evaluated fresh on every read so the dashboard is always accurate.
-func agentStatus(lastSeen sql.NullInt64, intervalSeconds int, now time.Time) staleness.Status {
+// heartbeatStatus computes an agent or host heartbeat verdict. It mirrors what
+// the background ticker uses to flag services, but is evaluated fresh on every
+// read so the dashboard is always accurate.
+func heartbeatStatus(lastSeen sql.NullInt64, intervalSeconds int, now time.Time) staleness.Status {
 	var ls *time.Time
 	if lastSeen.Valid {
 		t := time.Unix(lastSeen.Int64, 0).UTC()

--- a/internal/server/read_test.go
+++ b/internal/server/read_test.go
@@ -128,6 +128,17 @@ func TestEvaluateStalenessUsesHostHeartbeat(t *testing.T) {
 
 	now := time.Now().UTC().Unix()
 	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE hosts SET last_seen_at = ?`, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE agents SET last_seen_at = ? WHERE id = ?`, now, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	srv := New(st, slog.Default())
+	srv.evaluateStaleness(ctx) // silently seed agent and host transition state
+
+	if _, err := st.DB().ExecContext(ctx,
 		`UPDATE hosts SET last_seen_at = ? WHERE hostname = 'node-a'`, now-4*60); err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +151,6 @@ func TestEvaluateStalenessUsesHostHeartbeat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	srv := New(st, slog.Default())
 	srv.evaluateStaleness(ctx)
 	rows, err := st.ListServices(ctx)
 	if err != nil {
@@ -182,6 +192,90 @@ func TestEvaluateStalenessUsesHostHeartbeat(t *testing.T) {
 	}
 	if statusByHost["node-a"] != "stale" || statusByHost["node-b"] != "ok" {
 		t.Fatalf("host statuses = %+v, want node-a stale and node-b ok", statusByHost)
+	}
+	events, err := st.ListEvents(ctx, store.EventListOptions{Kind: store.EventKindHost})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Hostname != "node-a" ||
+		events[0].FromState != "ok" || events[0].ToState != "stale" {
+		t.Fatalf("host events = %+v, want node-a ok->stale", events)
+	}
+}
+
+func TestEvaluateStalenessSuppressesHostEventsDuringAgentOutage(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	_, agent, err := st.CreateAgent(ctx, "proxmox-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyReport(ctx, agent.ID, &model.Report{
+		Agent: model.ReportAgent{
+			Name:            "proxmox-a",
+			Platform:        model.PlatformProxmox,
+			IntervalSeconds: 30,
+		},
+		Host: model.ReportHost{Hostname: "node-a"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Unix()
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE agents SET last_seen_at = ? WHERE id = ?`, now, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE hosts SET last_seen_at = ? WHERE agent_id = ?`, now, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	srv := New(st, slog.Default())
+	srv.evaluateStaleness(ctx) // silent ok seed
+
+	// The entire source goes stale: emit one agent transition and suppress the
+	// equivalent host transition.
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE agents SET last_seen_at = ? WHERE id = ?`, now-4*60, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE hosts SET last_seen_at = ? WHERE agent_id = ?`, now-4*60, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	srv.evaluateStaleness(ctx)
+	hostEvents, err := st.ListEvents(ctx, store.EventListOptions{Kind: store.EventKindHost})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hostEvents) != 0 {
+		t.Fatalf("whole-agent outage emitted duplicate host events: %+v", hostEvents)
+	}
+	agentEvents, err := st.ListEvents(ctx, store.EventListOptions{Kind: store.EventKindAgent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agentEvents) != 1 || agentEvents[0].ToState != "stale" {
+		t.Fatalf("agent events = %+v, want one stale event", agentEvents)
+	}
+
+	// The agent comes back but its host does not. The held host transition now
+	// becomes independently actionable.
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE agents SET last_seen_at = ? WHERE id = ?`, now, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+	srv.evaluateStaleness(ctx)
+	hostEvents, err = st.ListEvents(ctx, store.EventListOptions{Kind: store.EventKindHost})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hostEvents) != 1 || hostEvents[0].FromState != "ok" || hostEvents[0].ToState != "stale" {
+		t.Fatalf("post-recovery host events = %+v, want ok->stale", hostEvents)
 	}
 }
 

--- a/internal/server/read_test.go
+++ b/internal/server/read_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/techdox/trove/internal/store"
 	"github.com/techdox/trove/pkg/model"
@@ -50,7 +51,9 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 	}
 	var services struct {
 		Hosts []struct {
-			Services []struct {
+			Status     string  `json:"status"`
+			LastSeenAt *string `json:"last_seen_at"`
+			Services   []struct {
 				ID int64 `json:"id"`
 			} `json:"services"`
 		} `json:"hosts"`
@@ -60,6 +63,9 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 	}
 	if len(services.Hosts) != 1 || len(services.Hosts[0].Services) != 1 || services.Hosts[0].Services[0].ID == 0 {
 		t.Fatalf("services response omitted stable id: %+v", services)
+	}
+	if services.Hosts[0].Status != "ok" || services.Hosts[0].LastSeenAt == nil {
+		t.Fatalf("services response omitted host liveness: %+v", services.Hosts[0])
 	}
 	serviceID := services.Hosts[0].Services[0].ID
 
@@ -83,4 +89,145 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 		}
 	}
 	t.Fatalf("events response omitted matching service id: %+v", events)
+}
+
+func TestEvaluateStalenessUsesHostHeartbeat(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	_, agent, err := st.CreateAgent(ctx, "proxmox-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportHost := func(hostname, serviceID string) *model.Report {
+		return &model.Report{
+			Agent: model.ReportAgent{
+				Name:            "proxmox-a",
+				Platform:        model.PlatformProxmox,
+				IntervalSeconds: 30,
+			},
+			Host: model.ReportHost{Hostname: hostname},
+			Services: []model.ReportService{{
+				ExternalID: serviceID,
+				Name:       serviceID,
+				Kind:       model.KindVM,
+				State:      "running",
+				Health:     model.HealthHealthy,
+			}},
+		}
+	}
+	if err := st.ApplyReport(ctx, agent.ID, reportHost("node-a", "vm-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyReport(ctx, agent.ID, reportHost("node-b", "vm-b")); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC().Unix()
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE hosts SET last_seen_at = ? WHERE hostname = 'node-a'`, now-4*60); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE hosts SET last_seen_at = ? WHERE hostname = 'node-b'`, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx,
+		`UPDATE agents SET last_seen_at = ? WHERE id = ?`, now, agent.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(st, slog.Default())
+	srv.evaluateStaleness(ctx)
+	rows, err := st.ListServices(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	healthByHost := map[string]string{}
+	for _, row := range rows {
+		healthByHost[row.Hostname] = row.Health
+	}
+	if healthByHost["node-a"] != string(model.HealthStale) {
+		t.Fatalf("node-a service health = %q, want stale", healthByHost["node-a"])
+	}
+	if healthByHost["node-b"] != string(model.HealthHealthy) {
+		t.Fatalf("node-b service health = %q, want healthy", healthByHost["node-b"])
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("services status = %d", rec.Code)
+	}
+	var response struct {
+		Hosts []struct {
+			Hostname    string `json:"hostname"`
+			Status      string `json:"status"`
+			AgentStatus string `json:"agent_status"`
+		} `json:"hosts"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	statusByHost := map[string]string{}
+	for _, host := range response.Hosts {
+		if host.AgentStatus != "ok" {
+			t.Fatalf("agent status for %s = %q, want ok", host.Hostname, host.AgentStatus)
+		}
+		statusByHost[host.Hostname] = host.Status
+	}
+	if statusByHost["node-a"] != "stale" || statusByHost["node-b"] != "ok" {
+		t.Fatalf("host statuses = %+v, want node-a stale and node-b ok", statusByHost)
+	}
+}
+
+func TestServicesAPIIncludesEmptyHosts(t *testing.T) {
+	st, err := store.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	ctx := context.Background()
+	_, agent, err := st.CreateAgent(ctx, "proxmox-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ApplyReport(ctx, agent.ID, &model.Report{
+		Agent: model.ReportAgent{
+			Name:            "proxmox-a",
+			Platform:        model.PlatformProxmox,
+			IntervalSeconds: 30,
+		},
+		Host: model.ReportHost{Hostname: "empty-node"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := New(st, slog.Default())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("services status = %d", rec.Code)
+	}
+	var response struct {
+		Hosts []struct {
+			Hostname   string `json:"hostname"`
+			Status     string `json:"status"`
+			LastSeenAt string `json:"last_seen_at"`
+			Services   []any  `json:"services"`
+		} `json:"hosts"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Hosts) != 1 || response.Hosts[0].Hostname != "empty-node" ||
+		response.Hosts[0].Status != "ok" || response.Hosts[0].LastSeenAt == "" ||
+		len(response.Hosts[0].Services) != 0 {
+		t.Fatalf("empty host liveness response = %+v", response.Hosts)
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -146,6 +146,7 @@ func (s *Server) evaluateStaleness(ctx context.Context) {
 		return
 	}
 	now := time.Now().UTC()
+	agentStatusByID := make(map[int64]staleness.Status, len(agents))
 	for _, a := range agents {
 		var lastSeen *time.Time
 		if a.LastSeenAt.Valid {
@@ -153,6 +154,7 @@ func (s *Server) evaluateStaleness(ctx context.Context) {
 			lastSeen = &t
 		}
 		status := staleness.Evaluate(lastSeen, a.IntervalSeconds, now)
+		agentStatusByID[a.ID] = status
 		// Record heartbeat transitions (ok<->stale<->offline) as agent events
 		// for the feed and the alert engine. Never-seen agents are skipped so
 		// a freshly minted token doesn't sit in the feed as "unknown".
@@ -177,8 +179,23 @@ func (s *Server) evaluateStaleness(ctx context.Context) {
 			t := time.Unix(h.LastSeenAt.Int64, 0).UTC()
 			lastSeen = &t
 		}
-		if status := staleness.Evaluate(lastSeen, h.AgentIntervalSeconds, now); staleness.StaleOrWorse(status) {
+		status := staleness.Evaluate(lastSeen, h.AgentIntervalSeconds, now)
+		if staleness.StaleOrWorse(status) {
 			staleHostIDs = append(staleHostIDs, h.ID)
+		}
+		// Host alerts are useful only when the parent agent is healthy. During a
+		// whole-agent outage the agent event is the root-cause notification; not
+		// advancing host transition state lets a still-missing host alert as soon
+		// as the agent recovers or a sibling keeps it healthy.
+		if status != staleness.StatusUnknown && agentStatusByID[h.AgentID] == staleness.StatusOK {
+			changed, err := s.store.UpdateHostStatus(
+				ctx, h.ID, h.AgentID, h.Hostname, h.AgentName, string(status),
+			)
+			if err != nil {
+				s.log.Error("staleness: record host status", "host", h.Hostname, "agent", h.AgentName, "err", err)
+			} else if changed {
+				s.log.Info("host status changed", "host", h.Hostname, "agent", h.AgentName, "status", status)
+			}
 		}
 	}
 	n, err := s.store.MarkServicesStaleForHosts(ctx, staleHostIDs)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,7 @@ type Server struct {
 	mux   *http.ServeMux
 
 	// stalenessInterval is how often the background ticker re-evaluates agent
-	// heartbeats and flags stale services.
+	// and host heartbeats and flags services on stale hosts.
 	stalenessInterval time.Duration
 
 	// freshness holds the image-freshness checker config; registry is nil
@@ -60,13 +60,19 @@ func New(st *store.Store, log *slog.Logger) *Server {
 }
 
 // ConfigureOIDC enables OIDC authentication on the dashboard and read APIs.
-// Must be called before the server starts listening. Returns an error if
-// OIDC discovery fails (e.g. the issuer is unreachable).
+// Must be called before the server starts listening. Returns an error if the
+// configuration is partial or OIDC discovery fails (e.g. the issuer is
+// unreachable).
 func (s *Server) ConfigureOIDC(cfg OIDCConfig) error {
+	if err := cfg.validate(); err != nil {
+		return err
+	}
 	if !cfg.Enabled() {
 		return nil
 	}
-	provider, err := newOIDCProvider(cfg, s.log)
+	ctx, cancel := context.WithTimeout(context.Background(), oidcDiscoveryTimeout)
+	defer cancel()
+	provider, err := newOIDCProvider(ctx, cfg, s.log)
 	if err != nil {
 		return err
 	}
@@ -116,8 +122,9 @@ func (s *Server) routes() {
 }
 
 // RunStalenessLoop runs the background ticker until ctx is cancelled. It marks
-// services belonging to stale/offline agents as health="stale". It evaluates
-// once immediately so a freshly started server converges quickly.
+// services belonging to stale/offline hosts as health="stale". Agent status is
+// still evaluated independently for the infrastructure summary and events. It
+// evaluates once immediately so a freshly started server converges quickly.
 func (s *Server) RunStalenessLoop(ctx context.Context) {
 	t := time.NewTicker(s.stalenessInterval)
 	defer t.Stop()
@@ -139,7 +146,6 @@ func (s *Server) evaluateStaleness(ctx context.Context) {
 		return
 	}
 	now := time.Now().UTC()
-	var staleIDs []int64
 	for _, a := range agents {
 		var lastSeen *time.Time
 		if a.LastSeenAt.Valid {
@@ -157,16 +163,30 @@ func (s *Server) evaluateStaleness(ctx context.Context) {
 				s.log.Info("agent status changed", "agent", a.Name, "status", status)
 			}
 		}
-		if staleness.StaleOrWorse(status) {
-			staleIDs = append(staleIDs, a.ID)
+	}
+
+	hosts, err := s.store.ListHosts(ctx)
+	if err != nil {
+		s.log.Error("staleness: list hosts", "err", err)
+		return
+	}
+	var staleHostIDs []int64
+	for _, h := range hosts {
+		var lastSeen *time.Time
+		if h.LastSeenAt.Valid {
+			t := time.Unix(h.LastSeenAt.Int64, 0).UTC()
+			lastSeen = &t
+		}
+		if status := staleness.Evaluate(lastSeen, h.AgentIntervalSeconds, now); staleness.StaleOrWorse(status) {
+			staleHostIDs = append(staleHostIDs, h.ID)
 		}
 	}
-	n, err := s.store.MarkServicesStaleForAgents(ctx, staleIDs)
+	n, err := s.store.MarkServicesStaleForHosts(ctx, staleHostIDs)
 	if err != nil {
 		s.log.Error("staleness: mark services", "err", err)
 		return
 	}
 	if n > 0 {
-		s.log.Info("staleness: flagged services stale", "count", n, "agents", len(staleIDs))
+		s.log.Info("staleness: flagged services stale", "count", n, "hosts", len(staleHostIDs))
 	}
 }

--- a/internal/staleness/staleness.go
+++ b/internal/staleness/staleness.go
@@ -1,7 +1,7 @@
 // Package staleness holds the pure heartbeat-evaluation logic: given when an
-// agent was last seen and its push interval, decide whether it is ok, stale,
-// or offline. It has no I/O so it is trivially testable; the server runs a
-// ticker that applies these verdicts to the store.
+// agent or host was last seen and its push interval, decide whether it is ok,
+// stale, or offline. It has no I/O so it is trivially testable; the server runs
+// a ticker that applies these verdicts to the store.
 package staleness
 
 import (
@@ -10,7 +10,7 @@ import (
 	"github.com/techdox/trove/pkg/model"
 )
 
-// Status is an agent's heartbeat verdict.
+// Status is an agent or host heartbeat verdict.
 type Status string
 
 const (
@@ -33,9 +33,9 @@ func Interval(agentIntervalSeconds int) time.Duration {
 	return model.DefaultReportInterval()
 }
 
-// Evaluate returns the heartbeat status for an agent. lastSeen is nil if the
-// agent has never reported. Thresholds are multiples of the agent's own
-// interval, so a slow-polling agent is judged on its own cadence.
+// Evaluate returns a heartbeat status. lastSeen is nil if the subject has
+// never reported. Thresholds are multiples of the owning agent's interval, so
+// slow-polling agents and their hosts are judged on their own cadence.
 func Evaluate(lastSeen *time.Time, agentIntervalSeconds int, now time.Time) Status {
 	if lastSeen == nil {
 		return StatusUnknown
@@ -52,7 +52,7 @@ func Evaluate(lastSeen *time.Time, agentIntervalSeconds int, now time.Time) Stat
 	}
 }
 
-// StaleOrWorse reports whether a status means the agent's services should be
+// StaleOrWorse reports whether a status means the subject's services should be
 // shown as stale (i.e. stale or offline).
 func StaleOrWorse(s Status) bool {
 	return s == StatusStale || s == StatusOffline

--- a/internal/store/hosts.go
+++ b/internal/store/hosts.go
@@ -18,13 +18,14 @@ type Host struct {
 	AgentIntervalSeconds int
 	LastSeenAt           sql.NullInt64
 	AgentLastSeenAt      sql.NullInt64
+	LastStatus           string
 }
 
 // ListHosts returns every known host with the owning agent's report interval.
 // Host status is derived by callers from LastSeenAt and that interval.
 func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT h.id, h.agent_id, h.hostname, h.platform_meta_json, h.last_seen_at,
+		SELECT h.id, h.agent_id, h.hostname, h.platform_meta_json, h.last_seen_at, h.last_status,
 		       a.name, a.platform, a.report_interval_seconds, a.last_seen_at
 		  FROM hosts h
 		  JOIN agents a ON a.id = h.agent_id
@@ -38,7 +39,7 @@ func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 	for rows.Next() {
 		var h Host
 		if err := rows.Scan(
-			&h.ID, &h.AgentID, &h.Hostname, &h.MetaJSON, &h.LastSeenAt,
+			&h.ID, &h.AgentID, &h.Hostname, &h.MetaJSON, &h.LastSeenAt, &h.LastStatus,
 			&h.AgentName, &h.AgentPlatform, &h.AgentIntervalSeconds, &h.AgentLastSeenAt,
 		); err != nil {
 			return nil, err
@@ -46,4 +47,46 @@ func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 		out = append(out, h)
 	}
 	return out, rows.Err()
+}
+
+// UpdateHostStatus records a host heartbeat transition. The first evaluation
+// seeds silently, matching agent status behavior and preventing alert floods
+// after startup or migration. host_id is a soft event reference so history
+// survives retention pruning while a later same-named host gets fresh alert
+// state.
+func (s *Store) UpdateHostStatus(
+	ctx context.Context,
+	hostID, agentID int64,
+	hostname, agentName, status string,
+) (bool, error) {
+	now := s.now().Unix()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback() //nolint:errcheck // no-op after Commit
+
+	var last string
+	if err := tx.QueryRowContext(ctx,
+		`SELECT last_status FROM hosts WHERE id = ?`, hostID).Scan(&last); err != nil {
+		return false, fmt.Errorf("read host status: %w", err)
+	}
+	if last == status {
+		return false, tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE hosts SET last_status = ? WHERE id = ?`, status, hostID); err != nil {
+		return false, fmt.Errorf("update host status: %w", err)
+	}
+	if last == "" {
+		return false, tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO events(kind, host_id, agent_id, hostname, agent, from_state, to_state, at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		EventKindHost, hostID, agentID, hostname, agentName, last, status, now,
+	); err != nil {
+		return false, fmt.Errorf("insert host event: %w", err)
+	}
+	return true, tx.Commit()
 }

--- a/internal/store/hosts.go
+++ b/internal/store/hosts.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// Host is the heartbeat state needed to evaluate a host independently from
+// other hosts reported by the same agent.
+type Host struct {
+	ID                   int64
+	AgentID              int64
+	Hostname             string
+	MetaJSON             string
+	AgentName            string
+	AgentPlatform        string
+	AgentIntervalSeconds int
+	LastSeenAt           sql.NullInt64
+	AgentLastSeenAt      sql.NullInt64
+}
+
+// ListHosts returns every known host with the owning agent's report interval.
+// Host status is derived by callers from LastSeenAt and that interval.
+func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT h.id, h.agent_id, h.hostname, h.platform_meta_json, h.last_seen_at,
+		       a.name, a.platform, a.report_interval_seconds, a.last_seen_at
+		  FROM hosts h
+		  JOIN agents a ON a.id = h.agent_id
+		 ORDER BY a.name, h.hostname`)
+	if err != nil {
+		return nil, fmt.Errorf("list hosts: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Host
+	for rows.Next() {
+		var h Host
+		if err := rows.Scan(
+			&h.ID, &h.AgentID, &h.Hostname, &h.MetaJSON, &h.LastSeenAt,
+			&h.AgentName, &h.AgentPlatform, &h.AgentIntervalSeconds, &h.AgentLastSeenAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -204,12 +204,13 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 	return tx.Commit()
 }
 
-// Event kinds. The events table carries three streams that the dashboard feed
+// Event kinds. The events table carries four streams that the dashboard feed
 // and the alert engine both consume.
 const (
 	EventKindState  = "state"  // service platform-state transition
 	EventKindHealth = "health" // service health transition
 	EventKindAgent  = "agent"  // agent heartbeat-status transition
+	EventKindHost   = "host"   // host heartbeat-status transition
 )
 
 // insertEvent records a service-scoped event with its display context

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -15,6 +15,7 @@ import (
 //
 // Semantics:
 //   - the agent's last_seen/platform/version/interval are refreshed;
+//   - only the reported host's last_seen and metadata are refreshed;
 //   - each reported service is upserted (correlated by host + external_id);
 //   - a service whose state changed since last report records an event;
 //   - services previously seen but absent from this report are soft-removed
@@ -54,9 +55,11 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 	// 2. Upsert host, resolve host_id.
 	metaJSON := mustJSONObject(r.Host.Meta)
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO hosts(agent_id, hostname, platform_meta_json) VALUES (?, ?, ?)
-		 ON CONFLICT(agent_id, hostname) DO UPDATE SET platform_meta_json = excluded.platform_meta_json`,
-		agentID, r.Host.Hostname, metaJSON,
+		`INSERT INTO hosts(agent_id, hostname, platform_meta_json, last_seen_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(agent_id, hostname) DO UPDATE SET
+		     platform_meta_json = excluded.platform_meta_json,
+		     last_seen_at = excluded.last_seen_at`,
+		agentID, r.Host.Hostname, metaJSON, now,
 	); err != nil {
 		return fmt.Errorf("upsert host: %w", err)
 	}

--- a/internal/store/maintenance.go
+++ b/internal/store/maintenance.go
@@ -11,20 +11,24 @@ import (
 type PruneStats struct {
 	Events          int64
 	RemovedServices int64
+	Hosts           int64
 }
 
 // Prune deletes events older than eventRetention and hard-deletes services
-// that have been soft-removed for longer than removedRetention (both given in
-// seconds). It nulls any child's parent_id pointing at a to-be-pruned parent
-// first, so no dangling references are left (referential integrity here is
-// managed in code, not FKs — see migration 0003).
+// that have been soft-removed for longer than removedRetention. Hosts that
+// have not reported within hostRetention are deleted with their remaining
+// services. All retention values are given in seconds. It nulls any child's
+// parent_id pointing at a to-be-pruned parent first, so no dangling references
+// are left (referential integrity here is managed in code, not FKs — see
+// migration 0003).
 //
 // Pruning runs on the server's maintenance ticker, deliberately off the
 // report-ingest write path (ROADMAP decision D1).
-func (s *Store) Prune(ctx context.Context, eventRetentionSecs, removedRetentionSecs int64) (PruneStats, error) {
+func (s *Store) Prune(ctx context.Context, eventRetentionSecs, removedRetentionSecs, hostRetentionSecs int64) (PruneStats, error) {
 	now := s.now().Unix()
 	eventCutoff := now - eventRetentionSecs
 	removedCutoff := now - removedRetentionSecs
+	hostCutoff := now - hostRetentionSecs
 
 	var stats PruneStats
 
@@ -53,6 +57,13 @@ func (s *Store) Prune(ctx context.Context, eventRetentionSecs, removedRetentionS
 		return stats, fmt.Errorf("prune removed services: %w", err)
 	}
 	stats.RemovedServices, _ = res.RowsAffected()
+
+	res, err = tx.ExecContext(ctx,
+		`DELETE FROM hosts WHERE last_seen_at IS NOT NULL AND last_seen_at < ?`, hostCutoff)
+	if err != nil {
+		return stats, fmt.Errorf("prune stale hosts: %w", err)
+	}
+	stats.Hosts, _ = res.RowsAffected()
 
 	return stats, tx.Commit()
 }

--- a/internal/store/migrations/0008_host_liveness.sql
+++ b/internal/store/migrations/0008_host_liveness.sql
@@ -1,0 +1,17 @@
+-- Track report liveness per host. An agent can report several hosts, so its
+-- heartbeat cannot prove that every previously seen host is still present.
+--
+-- Existing hosts are seeded from their owning agent's last heartbeat. This
+-- gives upgraded installations one grace window before host-level staleness
+-- takes over; subsequent reports update only the host they describe.
+
+ALTER TABLE hosts ADD COLUMN last_seen_at INTEGER;
+
+UPDATE hosts
+   SET last_seen_at = (
+       SELECT agents.last_seen_at
+         FROM agents
+        WHERE agents.id = hosts.agent_id
+   );
+
+CREATE INDEX idx_hosts_last_seen ON hosts(last_seen_at);

--- a/internal/store/migrations/0008_host_liveness.sql
+++ b/internal/store/migrations/0008_host_liveness.sql
@@ -6,6 +6,8 @@
 -- takes over; subsequent reports update only the host they describe.
 
 ALTER TABLE hosts ADD COLUMN last_seen_at INTEGER;
+ALTER TABLE hosts ADD COLUMN last_status TEXT NOT NULL DEFAULT '';
+ALTER TABLE events ADD COLUMN host_id INTEGER; -- soft reference; events outlive hosts
 
 UPDATE hosts
    SET last_seen_at = (
@@ -14,4 +16,15 @@ UPDATE hosts
         WHERE agents.id = hosts.agent_id
    );
 
+-- Seed transition tracking from the owning agent. The server only emits host
+-- liveness events while that agent is healthy, avoiding one alert per host
+-- during a whole-agent outage while still detecting partial host loss.
+UPDATE hosts
+   SET last_status = COALESCE((
+       SELECT agents.last_status
+         FROM agents
+        WHERE agents.id = hosts.agent_id
+   ), '');
+
 CREATE INDEX idx_hosts_last_seen ON hosts(last_seen_at);
+CREATE INDEX idx_events_host ON events(host_id, at);

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+func TestHostLivenessMigrationBackfillsExistingHosts(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "upgrade.db")
+	db, err := sql.Open("sqlite", buildDSN(path))
+	if err != nil {
+		t.Fatalf("open pre-migration database: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE schema_migrations (
+		version TEXT PRIMARY KEY,
+		applied_at INTEGER NOT NULL
+	)`); err != nil {
+		t.Fatalf("create migration table: %v", err)
+	}
+	for _, name := range []string{
+		"0001_init.sql",
+		"0002_image_checks.sql",
+		"0003_service_parent.sql",
+		"0004_event_model.sql",
+		"0005_alert_notified.sql",
+		"0006_health_detail.sql",
+		"0007_alert_channel_deliveries.sql",
+	} {
+		script, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if _, err := db.ExecContext(ctx, string(script)); err != nil {
+			t.Fatalf("apply %s: %v", name, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO schema_migrations(version, applied_at) VALUES (?, 0)`, name); err != nil {
+			t.Fatalf("record %s: %v", name, err)
+		}
+	}
+	const lastSeen = int64(1_767_225_600)
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO agents(name, token_hash, created_at, last_seen_at)
+		VALUES ('proxmox-a', 'hash', 0, ?)`, lastSeen)
+	if err != nil {
+		t.Fatalf("insert agent: %v", err)
+	}
+	agentID, _ := res.LastInsertId()
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO hosts(agent_id, hostname) VALUES (?, 'node-a')`, agentID); err != nil {
+		t.Fatalf("insert host: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close pre-migration database: %v", err)
+	}
+
+	st, err := Open(path)
+	if err != nil {
+		t.Fatalf("open upgraded database: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	var got sql.NullInt64
+	if err := st.DB().QueryRowContext(ctx,
+		`SELECT last_seen_at FROM hosts WHERE hostname = 'node-a'`).Scan(&got); err != nil {
+		t.Fatalf("read migrated host heartbeat: %v", err)
+	}
+	if !got.Valid || got.Int64 != lastSeen {
+		t.Fatalf("migrated last_seen_at = %+v, want %d", got, lastSeen)
+	}
+}

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -44,8 +44,8 @@ func TestHostLivenessMigrationBackfillsExistingHosts(t *testing.T) {
 	}
 	const lastSeen = int64(1_767_225_600)
 	res, err := db.ExecContext(ctx, `
-		INSERT INTO agents(name, token_hash, created_at, last_seen_at)
-		VALUES ('proxmox-a', 'hash', 0, ?)`, lastSeen)
+		INSERT INTO agents(name, token_hash, created_at, last_seen_at, last_status)
+		VALUES ('proxmox-a', 'hash', 0, ?, 'ok')`, lastSeen)
 	if err != nil {
 		t.Fatalf("insert agent: %v", err)
 	}
@@ -65,11 +65,15 @@ func TestHostLivenessMigrationBackfillsExistingHosts(t *testing.T) {
 	t.Cleanup(func() { _ = st.Close() })
 
 	var got sql.NullInt64
+	var status string
 	if err := st.DB().QueryRowContext(ctx,
-		`SELECT last_seen_at FROM hosts WHERE hostname = 'node-a'`).Scan(&got); err != nil {
+		`SELECT last_seen_at, last_status FROM hosts WHERE hostname = 'node-a'`).Scan(&got, &status); err != nil {
 		t.Fatalf("read migrated host heartbeat: %v", err)
 	}
 	if !got.Valid || got.Int64 != lastSeen {
 		t.Fatalf("migrated last_seen_at = %+v, want %d", got, lastSeen)
+	}
+	if status != "ok" {
+		t.Fatalf("migrated last_status = %q, want ok", status)
 	}
 }

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -157,8 +157,9 @@ func (s *Store) ListServicesPage(ctx context.Context, opts ServiceListOptions) (
 // outlive their subjects.
 type EventRow struct {
 	ID        int64
-	Kind      string // state | health | agent
+	Kind      string // state | health | agent | host
 	ServiceID sql.NullInt64
+	HostID    sql.NullInt64
 	AgentID   sql.NullInt64
 	Service   string
 	Hostname  string
@@ -181,7 +182,7 @@ func (s *Store) ListEvents(ctx context.Context, opts EventListOptions) ([]EventR
 	}
 	var b strings.Builder
 	b.WriteString(`
-		SELECT id, kind, service_id, agent_id, service, hostname, agent, from_state, to_state, at
+		SELECT id, kind, service_id, host_id, agent_id, service, hostname, agent, from_state, to_state, at
 		  FROM events`)
 	var where []string
 	var args []any
@@ -214,7 +215,7 @@ func (s *Store) ListEvents(ctx context.Context, opts EventListOptions) ([]EventR
 	var out []EventRow
 	for rows.Next() {
 		var e EventRow
-		if err := rows.Scan(&e.ID, &e.Kind, &e.ServiceID, &e.AgentID,
+		if err := rows.Scan(&e.ID, &e.Kind, &e.ServiceID, &e.HostID, &e.AgentID,
 			&e.Service, &e.Hostname, &e.Agent, &e.FromState, &e.ToState, &e.At); err != nil {
 			return nil, err
 		}
@@ -230,7 +231,7 @@ func (s *Store) EventsAfter(ctx context.Context, cursor int64, limit int) ([]Eve
 		limit = 500
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, kind, service_id, agent_id, service, hostname, agent, from_state, to_state, at
+		SELECT id, kind, service_id, host_id, agent_id, service, hostname, agent, from_state, to_state, at
 		  FROM events
 		 WHERE id > ?
 		 ORDER BY id ASC
@@ -243,7 +244,7 @@ func (s *Store) EventsAfter(ctx context.Context, cursor int64, limit int) ([]Eve
 	var out []EventRow
 	for rows.Next() {
 		var e EventRow
-		if err := rows.Scan(&e.ID, &e.Kind, &e.ServiceID, &e.AgentID,
+		if err := rows.Scan(&e.ID, &e.Kind, &e.ServiceID, &e.HostID, &e.AgentID,
 			&e.Service, &e.Hostname, &e.Agent, &e.FromState, &e.ToState, &e.At); err != nil {
 			return nil, err
 		}

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -9,7 +9,7 @@ import (
 
 // ServiceRow is a fully-joined service record: the service plus its host and
 // owning agent. The dashboard groups these by host; the API layer overlays
-// derived staleness using the agent heartbeat fields.
+// independently derived host and agent staleness using their heartbeat fields.
 type ServiceRow struct {
 	ID           int64
 	ExternalID   string
@@ -26,9 +26,10 @@ type ServiceRow struct {
 	LastSeenAt   int64
 	UpdatedAt    int64
 
-	HostID       int64
-	Hostname     string
-	HostMetaJSON string
+	HostID         int64
+	Hostname       string
+	HostMetaJSON   string
+	HostLastSeenAt sql.NullInt64
 
 	AgentID              int64
 	AgentName            string
@@ -100,7 +101,7 @@ func (s *Store) ListServicesPage(ctx context.Context, opts ServiceListOptions) (
 		SELECT s.id, s.external_id, s.name, s.kind, s.image, s.image_digest, s.state, s.health,
 		       s.health_detail,
 		       s.ports_json, s.labels_json, s.first_seen_at, s.last_seen_at, s.updated_at,
-		       h.id, h.hostname, h.platform_meta_json,
+		       h.id, h.hostname, h.platform_meta_json, h.last_seen_at,
 		       a.id, a.name, a.platform, a.report_interval_seconds, a.last_seen_at,
 		       p.external_id AS parent_external_id,
 		       c.latest_digest, c.status, c.checked_at
@@ -139,7 +140,7 @@ func (s *Store) ListServicesPage(ctx context.Context, opts ServiceListOptions) (
 			&r.ID, &r.ExternalID, &r.Name, &r.Kind, &r.Image, &r.ImageDigest, &r.State, &r.Health,
 			&r.HealthDetail,
 			&r.PortsJSON, &r.LabelsJSON, &r.FirstSeenAt, &r.LastSeenAt, &r.UpdatedAt,
-			&r.HostID, &r.Hostname, &r.HostMetaJSON,
+			&r.HostID, &r.Hostname, &r.HostMetaJSON, &r.HostLastSeenAt,
 			&r.AgentID, &r.AgentName, &r.AgentPlatform, &r.AgentIntervalSeconds, &r.AgentLastSeenAt,
 			&r.ParentExternalID,
 			&r.LatestDigest, &r.FreshnessStatus, &r.FreshnessCheckedAt,

--- a/internal/store/staleness.go
+++ b/internal/store/staleness.go
@@ -8,21 +8,21 @@ import (
 	"github.com/techdox/trove/pkg/model"
 )
 
-// MarkServicesStaleForAgents sets health="stale" on all live (non-removed)
-// services belonging to the given agents, and returns the number of rows
+// MarkServicesStaleForHosts sets health="stale" on all live (non-removed)
+// services belonging to the given hosts, and returns the number of rows
 // changed. It skips services already marked stale so repeated ticks don't
-// churn updated_at (which would prevent pruning). When an agent later reports
+// churn updated_at (which would prevent pruning). When a host later reports
 // again, ApplyReport overwrites health with the freshly reported value, so no
 // explicit "un-stale" step is needed.
-func (s *Store) MarkServicesStaleForAgents(ctx context.Context, agentIDs []int64) (int64, error) {
-	if len(agentIDs) == 0 {
+func (s *Store) MarkServicesStaleForHosts(ctx context.Context, hostIDs []int64) (int64, error) {
+	if len(hostIDs) == 0 {
 		return 0, nil
 	}
 	now := s.now().Unix()
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(agentIDs)), ",")
-	args := make([]any, 0, len(agentIDs)+2)
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(hostIDs)), ",")
+	args := make([]any, 0, len(hostIDs)+2)
 	args = append(args, string(model.HealthStale), now)
-	for _, id := range agentIDs {
+	for _, id := range hostIDs {
 		args = append(args, id)
 	}
 	q := fmt.Sprintf(`
@@ -30,9 +30,7 @@ func (s *Store) MarkServicesStaleForAgents(ctx context.Context, agentIDs []int64
 		   SET health = ?, updated_at = ?
 		 WHERE state != '%s'
 		   AND health != '%s'
-		   AND host_id IN (
-		       SELECT id FROM hosts WHERE agent_id IN (%s)
-		   )`, model.StateRemoved, model.HealthStale, placeholders)
+		   AND host_id IN (%s)`, model.StateRemoved, model.HealthStale, placeholders)
 
 	res, err := s.db.ExecContext(ctx, q, args...)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -184,6 +184,47 @@ func TestUpdateAgentStatusEvents(t *testing.T) {
 	}
 }
 
+func TestUpdateHostStatusEvents(t *testing.T) {
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "proxmox-a")
+	rep := report()
+	rep.Agent.Platform = model.PlatformProxmox
+	rep.Host.Hostname = "node-a"
+	if err := st.ApplyReport(ctx, agent.ID, rep); err != nil {
+		t.Fatalf("apply report: %v", err)
+	}
+	hosts, err := st.ListHosts(ctx)
+	if err != nil || len(hosts) != 1 {
+		t.Fatalf("list hosts: hosts=%+v err=%v", hosts, err)
+	}
+	host := hosts[0]
+
+	changed, err := st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "ok")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if changed {
+		t.Fatal("first status must seed silently, not emit an event")
+	}
+	if changed, _ = st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "ok"); changed {
+		t.Fatal("unchanged status must not emit an event")
+	}
+	if changed, err = st.UpdateHostStatus(ctx, host.ID, agent.ID, host.Hostname, agent.Name, "stale"); err != nil || !changed {
+		t.Fatalf("ok->stale: changed=%v err=%v", changed, err)
+	}
+
+	events, err := st.ListEvents(ctx, EventListOptions{Kind: EventKindHost})
+	if err != nil {
+		t.Fatalf("list host events: %v", err)
+	}
+	if len(events) != 1 || events[0].HostID.Int64 != host.ID || events[0].AgentID.Int64 != agent.ID ||
+		events[0].Hostname != "node-a" || events[0].Agent != "proxmox-a" ||
+		events[0].FromState != "ok" || events[0].ToState != "stale" {
+		t.Fatalf("unexpected host event: %+v", events)
+	}
+}
+
 func TestApplyReportSoftRemove(t *testing.T) {
 	st, clock := newTestStore(t)
 	ctx := context.Background()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -230,7 +230,10 @@ func TestPruneRetentionWindows(t *testing.T) {
 
 	// Removed-retention (24h) has elapsed but event-retention (30d) has not:
 	// the removed service goes, the events stay.
-	stats, err := st.Prune(ctx, int64((30 * 24 * time.Hour).Seconds()), int64((24 * time.Hour).Seconds()))
+	stats, err := st.Prune(ctx,
+		int64((30 * 24 * time.Hour).Seconds()),
+		int64((24 * time.Hour).Seconds()),
+		int64((365 * 24 * time.Hour).Seconds()))
 	if err != nil {
 		t.Fatalf("prune: %v", err)
 	}
@@ -246,7 +249,10 @@ func TestPruneRetentionWindows(t *testing.T) {
 
 	// Now advance past event retention: events prune too.
 	*clock = clock.Add(31 * 24 * time.Hour)
-	stats, err = st.Prune(ctx, int64((30 * 24 * time.Hour).Seconds()), int64((24 * time.Hour).Seconds()))
+	stats, err = st.Prune(ctx,
+		int64((30 * 24 * time.Hour).Seconds()),
+		int64((24 * time.Hour).Seconds()),
+		int64((365 * 24 * time.Hour).Seconds()))
 	if err != nil {
 		t.Fatalf("prune 2: %v", err)
 	}
@@ -258,7 +264,7 @@ func TestPruneRetentionWindows(t *testing.T) {
 	}
 }
 
-func TestMarkServicesStale(t *testing.T) {
+func TestMarkServicesStaleForHosts(t *testing.T) {
 	st, _ := newTestStore(t)
 	ctx := context.Background()
 	_, agent, _ := st.CreateAgent(ctx, "docker-a")
@@ -267,7 +273,11 @@ func TestMarkServicesStale(t *testing.T) {
 		svc("c2", "exited", model.HealthUnhealthy),
 	))
 
-	n, err := st.MarkServicesStaleForAgents(ctx, []int64{agent.ID})
+	hosts, err := st.ListHosts(ctx)
+	if err != nil || len(hosts) != 1 {
+		t.Fatalf("list hosts: hosts=%+v err=%v", hosts, err)
+	}
+	n, err := st.MarkServicesStaleForHosts(ctx, []int64{hosts[0].ID})
 	if err != nil {
 		t.Fatalf("mark stale: %v", err)
 	}
@@ -282,8 +292,112 @@ func TestMarkServicesStale(t *testing.T) {
 	}
 
 	// Re-marking is a no-op (already stale) => 0 rows changed.
-	if n, _ := st.MarkServicesStaleForAgents(ctx, []int64{agent.ID}); n != 0 {
+	if n, _ := st.MarkServicesStaleForHosts(ctx, []int64{hosts[0].ID}); n != 0 {
 		t.Fatalf("re-mark should change 0 rows, got %d", n)
+	}
+}
+
+func TestHostHeartbeatIsIndependentWithinAgent(t *testing.T) {
+	st, clock := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "proxmox-a")
+
+	hostA := report(svc("vm-a", "running", model.HealthHealthy))
+	hostA.Agent.Platform = model.PlatformProxmox
+	hostA.Agent.IntervalSeconds = 30
+	hostA.Host.Hostname = "node-a"
+	if err := st.ApplyReport(ctx, agent.ID, hostA); err != nil {
+		t.Fatalf("apply node-a: %v", err)
+	}
+
+	*clock = clock.Add(30 * time.Second)
+	hostB := report(svc("vm-b", "running", model.HealthHealthy))
+	hostB.Agent.Platform = model.PlatformProxmox
+	hostB.Agent.IntervalSeconds = 30
+	hostB.Host.Hostname = "node-b"
+	if err := st.ApplyReport(ctx, agent.ID, hostB); err != nil {
+		t.Fatalf("apply node-b: %v", err)
+	}
+
+	hosts, err := st.ListHosts(ctx)
+	if err != nil {
+		t.Fatalf("list hosts: %v", err)
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("hosts = %+v, want node-a and node-b", hosts)
+	}
+	byName := map[string]Host{}
+	for _, host := range hosts {
+		byName[host.Hostname] = host
+	}
+	if got := byName["node-a"].LastSeenAt.Int64; got != clock.Add(-30*time.Second).Unix() {
+		t.Fatalf("node-a last_seen_at = %d, want independent original heartbeat", got)
+	}
+	if got := byName["node-b"].LastSeenAt.Int64; got != clock.Unix() {
+		t.Fatalf("node-b last_seen_at = %d, want latest heartbeat", got)
+	}
+
+	// node-a crosses the stale threshold while node-b and the shared agent are
+	// still healthy. Only node-a's inventory must become stale.
+	*clock = clock.Add(61 * time.Second)
+	n, err := st.MarkServicesStaleForHosts(ctx, []int64{byName["node-a"].ID})
+	if err != nil {
+		t.Fatalf("mark node-a stale: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("stale rows = %d, want 1", n)
+	}
+	rows, err := st.ListServices(ctx)
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	healthByHost := map[string]string{}
+	for _, row := range rows {
+		healthByHost[row.Hostname] = row.Health
+	}
+	if healthByHost["node-a"] != string(model.HealthStale) {
+		t.Fatalf("node-a health = %q, want stale", healthByHost["node-a"])
+	}
+	if healthByHost["node-b"] != string(model.HealthHealthy) {
+		t.Fatalf("node-b health = %q, want healthy", healthByHost["node-b"])
+	}
+}
+
+func TestPruneLongSilentHosts(t *testing.T) {
+	st, clock := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "proxmox-a")
+	nodeA := report(svc("vm-a", "running", model.HealthHealthy))
+	nodeA.Host.Hostname = "node-a"
+	if err := st.ApplyReport(ctx, agent.ID, nodeA); err != nil {
+		t.Fatalf("apply node-a: %v", err)
+	}
+
+	*clock = clock.Add(31 * 24 * time.Hour)
+	nodeB := report(svc("vm-b", "running", model.HealthHealthy))
+	nodeB.Host.Hostname = "node-b"
+	if err := st.ApplyReport(ctx, agent.ID, nodeB); err != nil {
+		t.Fatalf("apply node-b: %v", err)
+	}
+	stats, err := st.Prune(ctx,
+		int64((60 * 24 * time.Hour).Seconds()),
+		int64((60 * 24 * time.Hour).Seconds()),
+		int64((30 * 24 * time.Hour).Seconds()))
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if stats.Hosts != 1 {
+		t.Fatalf("pruned hosts = %d, want 1", stats.Hosts)
+	}
+	rows, err := st.ListServices(ctx)
+	if err != nil {
+		t.Fatalf("list services: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Hostname != "node-b" {
+		t.Fatalf("prune removed the active host or retained the silent host: %+v", rows)
+	}
+	if events, _ := st.RecentEvents(ctx, 10); len(events) != 2 {
+		t.Fatalf("host pruning should preserve event history, got %d events", len(events))
 	}
 }
 

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -96,6 +96,8 @@ func TestDashboardShowsIndependentHostLiveness(t *testing.T) {
 		`if (key === "offline-hosts" || key === "stale-hosts") {`,
 		"last report ${esc(relTime(h.last_seen_at))}",
 		"`host ${st}`",
+		`case "host":`,
+		`e.kind === "agent" || e.kind === "host"`,
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard host liveness is missing %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -79,3 +79,26 @@ func TestDashboardRemovedAttentionFiltersOnlyRemovedServices(t *testing.T) {
 		}
 	}
 }
+
+func TestDashboardShowsIndependentHostLiveness(t *testing.T) {
+	t.Parallel()
+
+	app, err := fs.ReadFile(FS(), "app.js")
+	if err != nil {
+		t.Fatalf("read embedded app: %v", err)
+	}
+
+	for _, marker := range []string{
+		`if (h.status === "stale" && h.agent_status !== "stale" && h.agent_status !== "offline") c.staleHosts++;`,
+		`if (h.status === "offline" && h.agent_status !== "offline") c.offlineHosts++;`,
+		`item("offline-hosts"`,
+		`item("stale-hosts"`,
+		`if (key === "offline-hosts" || key === "stale-hosts") {`,
+		"last report ${esc(relTime(h.last_seen_at))}",
+		"`host ${st}`",
+	} {
+		if !strings.Contains(string(app), marker) {
+			t.Errorf("dashboard host liveness is missing %q", marker)
+		}
+	}
+}

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -562,6 +562,12 @@ function eventRowHTML(e) {
         &nbsp;<span class="st-gray">${esc(from)}</span> <span class="arrow">→</span>
         <span class="${AGENT_TEXT_CLASS[e.to_state] || "st-gray"}">${esc(e.to_state)}</span>`;
       break;
+    case "host":
+      what = `<span class="kind">host</span> <strong>${esc(e.hostname)}</strong>
+        <span class="muted">@ ${esc(e.agent)}</span>
+        &nbsp;<span class="st-gray">${esc(from)}</span> <span class="arrow">→</span>
+        <span class="${AGENT_TEXT_CLASS[e.to_state] || "st-gray"}">${esc(e.to_state)}</span>`;
+      break;
     case "health":
       what = `<strong>${esc(e.service)}</strong> <span class="muted">@ ${esc(e.hostname)}</span>
         <span class="kind">health</span>
@@ -580,7 +586,7 @@ function eventRowHTML(e) {
 }
 
 function eventTone(e) {
-  if (e.kind === "agent") {
+  if (e.kind === "agent" || e.kind === "host") {
     if (e.to_state === "offline") return "critical";
     if (e.to_state === "stale") return "warning";
     if (e.to_state === "ok") return "healthy";

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -256,9 +256,14 @@ function filterActive() {
 
 // counts over the full dataset (independent of the active filter)
 function computeCounts() {
-  const c = { hosts: 0, services: 0, running: 0, unhealthy: 0, stopped: 0, outdated: 0, stale: 0, removed: 0 };
+  const c = {
+    hosts: 0, staleHosts: 0, offlineHosts: 0,
+    services: 0, running: 0, unhealthy: 0, stopped: 0, outdated: 0, stale: 0, removed: 0,
+  };
   for (const h of state.data.services?.hosts || []) {
     c.hosts++;
+    if (h.status === "stale" && h.agent_status !== "stale" && h.agent_status !== "offline") c.staleHosts++;
+    if (h.status === "offline" && h.agent_status !== "offline") c.offlineHosts++;
     for (const s of h.services || []) {
       if (s.state === "removed") { c.removed++; continue; }
       c.services++;
@@ -286,8 +291,10 @@ function attentionItems() {
   const item = (key, level, count, title, detail, action) => ({ key, level, count, title, detail, action });
   return [
     item("offline-agents", "critical", offline, "Offline agent", "Trove is no longer receiving reports from this source.", "Review agents"),
+    item("offline-hosts", "critical", c.offlineHosts, "Offline host", "This host has missed its own reporting window and its inventory is stale.", "Review hosts"),
     item("unhealthy", "critical", c.unhealthy, "Unhealthy service", "A platform health check or readiness signal is failing.", "Show services"),
     item("stale-agents", "warning", staleAgents, "Stale agent", "This source has missed its expected reporting interval.", "Review agents"),
+    item("stale-hosts", "warning", c.staleHosts, "Stale host", "This host has stopped reporting even if another host from the same agent is still active.", "Review hosts"),
     item("stopped", "info", c.stopped, "Stopped workload", "A discovered workload is not running. It may be intentional.", "Show services"),
     item("removed", "info", c.removed, "Recently disappeared service", "A service is absent from its latest full-state report.", "Show services"),
     item("outdated", "info", c.outdated, "Outdated image", "The running image digest is behind the current tag.", "Show services"),
@@ -316,6 +323,11 @@ function showAttention(key) {
   if (key === "offline-agents" || key === "stale-agents") {
     $("infrastructure-title").scrollIntoView({ behavior: "smooth", block: "start" });
     focusInvestigationTarget("infrastructure-title");
+    return;
+  }
+  if (key === "offline-hosts" || key === "stale-hosts") {
+    $("inventory-title").scrollIntoView({ behavior: "smooth", block: "start" });
+    focusInvestigationTarget("inventory-title");
     return;
   }
   if (key === "removed") state.removedOnly = true;
@@ -470,7 +482,7 @@ function renderHosts() {
       (nUnhealthy ? badge("b-red", `${nUnhealthy} unhealthy`, "mini") : "") +
       (nOutdated ? badge("b-peach", `${nOutdated} outdated`, "mini") : "");
 
-    const st = h.agent_status || "unknown";
+    const st = h.status || "unknown";
     const collapsed = state.collapsed.has(hostKey(h));
     const countLabel = filterActive() && visible.length !== total
       ? `${visible.length}/${total} service(s)` : `${total} service(s)`;
@@ -480,7 +492,8 @@ function renderHosts() {
         <span class="chev">${collapsed ? "▸" : "▾"}</span>
         <span class="hostname">${esc(h.hostname)}</span>
         <span class="sub">${esc(hostPlatformLine(h))}</span>
-        ${badge(AGENT_CLASS[st] || "b-gray", st)}
+        <span class="sub">last report ${esc(relTime(h.last_seen_at))}</span>
+        ${badge(AGENT_CLASS[st] || "b-gray", `host ${st}`)}
         <span class="rollup">${rollup}</span>
         <span class="count">${countLabel}</span>
       </button>


### PR DESCRIPTION
## Summary

- fail startup when OIDC configuration is incomplete and bound provider discovery to a 10-second timeout
- track host heartbeats independently so one active host cannot keep missing sibling inventory healthy
- persist host stale, offline, and recovery transitions for alerting without per-host fan-out during a whole-agent outage
- expose host status and last-seen data in the API and dashboard, including hosts with no services
- stale services by host, retain long-silent hosts for an explicit period, and prune them after the configured retention window
- add migration, store, server, UI, documentation, and regression coverage

## Why

Trove previously treated OIDC as enabled only when every required value happened to be present. A partial configuration therefore left the dashboard open without warning.

Agent heartbeat was also shared across every host reported by that agent. For multi-host collectors such as Proxmox, one healthy node could keep a missing node and its services looking healthy indefinitely.

## Compatibility and operator impact

- the agent report protocol is unchanged
- migration 0008 backfills existing host heartbeats from their owning agent
- all OIDC variables unset remains the supported open mode; setting any OIDC value now requires the complete configuration
- host retention defaults to 30 days and can be changed with `TROVE_HOST_RETENTION`
- existing agent status remains available separately from host status
- `host` is enabled in the default alert kinds; explicit `TROVE_ALERT_EVENTS` allowlists must include `host` to receive these notifications

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- golangci-lint: 0 issues
- govulncheck: no vulnerabilities
- GoReleaser configuration validation
- cross-compilation of all 10 binaries
- focused host-liveness tests repeated 20 times
- live browser smoke test covering one stale host beside a healthy sibling host, attention navigation, and console errors

The `feat:` classification is intentional so the next genuine release is prepared as `v0.13.0`; this PR does not merge or otherwise modify release PR #84.