### PR TITLE
fix: finish v0.13 release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,9 +365,12 @@ interface; see [CONTRIBUTING.md](CONTRIBUTING.md).
 Upgrades are a `pull` (or binary swap) and restart away: schema migrations apply
 automatically on startup and are additive, and the server and agents tolerate
 version skew within a minor version. Everything is one SQLite file (`trove.db` /
-the `trove-data` volume) — back it up by copying it with the server stopped or
-via `sqlite3 ... ".backup"`; state is rebuildable anyway, since agents repopulate
-the catalog within one interval (a lost database costs only event history).
+the `trove-data` volume) — treat it as durable and back it up with
+`trove-server backup` or `sqlite3 ... ".backup"`. It contains agent token hashes,
+inventory and event history, and alert cursor/delivery state. If it is lost,
+production agents must be recreated and configured with newly issued tokens
+before current inventory can repopulate; event history and prior alert state
+cannot be rebuilt.
 
 See **[docs/upgrades.md](docs/upgrades.md)** for per-method upgrade steps (Docker
 Compose, bare metal, `go install`, agents), version pinning, backup commands,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,8 @@ Both pinned decisions are resolved: D2 (parent/child) shipped with Phase 3, D1
 
 The path to `v1.0.0` is now a confidence pass, not a large feature push:
 
-- Dogfood OIDC behind a real provider (Authentik is the reference setup).
+- Repeat the production Authentik OIDC setup in Dev and verify browser and API
+  token access there as a release gate.
 - Validate the public docs, wiki, example config, and upgrade notes against that
   deployment.
 - Keep the read-only contract intact: no deploy/restart/exec/edit paths.
@@ -124,9 +125,10 @@ design (targets, SNI, self-signed policy); slated after `v1.0.0`.
 
 **Remaining:**
 
-- **Dogfood and documentation pass** before `v1.0.0`: run Trove behind a real
-  OIDC provider, confirm the API-token path, and keep the repo docs/wiki/example
-  config aligned with the tested setup.
+- **Dev OIDC and documentation confidence pass** before `v1.0.0`: Authentik has
+  been exercised on the production deployment; reproduce that setup in Dev,
+  confirm the API-token path, and keep the repo docs/wiki/example config aligned
+  with the tested setup.
 - **Helm chart** for Kubernetes deployment (natural companion to the Phase 3 K8s
   agent), planned after `v1.0.0`.
 - **Certificate-expiry monitoring** for HTTPS targets, including target config,

--- a/deploy/kubernetes/trove-agent.yaml
+++ b/deploy/kubernetes/trove-agent.yaml
@@ -1,6 +1,6 @@
 # Trove Kubernetes agent — in-cluster, strictly read-only.
 #
-# The ClusterRole grants only list/get/watch on the workload and pod resources
+# The ClusterRole grants only get/list on the workload and pod resources
 # the agent reads; it can never mutate anything. Trove is read-only by design.
 #
 # Before applying:
@@ -31,10 +31,10 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/agents/kubernetes.md
+++ b/docs/agents/kubernetes.md
@@ -2,7 +2,7 @@
 
 Watches a cluster's Deployments, StatefulSets, and DaemonSets (as parent
 services) and their Pods (as child instances, nested under the parent on the
-dashboard). Read-only: the agent's RBAC grants only `get`/`list`/`watch`.
+dashboard). Read-only: the agent's RBAC grants only `get`/`list`.
 
 Run **one agent per cluster**. It runs in-cluster as a Deployment.
 
@@ -49,7 +49,7 @@ kubectl apply -f trove-agent.yaml
 ```
 
 The manifest contains the ServiceAccount, a read-only ClusterRole
-(deployments/statefulsets/daemonsets/replicasets/pods; get/list/watch only),
+(deployments/statefulsets/daemonsets/replicasets/pods; get/list only),
 the binding, and the Deployment running
 `ghcr.io/techdox/trove-agent-k8s` as nonroot with a read-only filesystem. It
 also declares the `trove` namespace (harmless that step 2 created it too — we

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,9 +82,6 @@ TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
 Current metrics are intentionally non-sensitive:
 
 - `trove_uptime_seconds`
-- `trove_goroutines`
-- `trove_alloc_bytes`
-- `trove_sys_bytes`
 - `trove_reports_accepted_total`
 - `trove_sqlite_database_size_bytes`
 - `trove_agents{status=...}`

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -96,8 +96,24 @@ equivalent:
 sqlite3 /var/lib/trove/trove.db ".backup '/var/backups/trove.db'"
 ```
 
-Trove state is rebuildable anyway — agents repopulate the catalog within one
-push interval, so a lost database costs you only event history.
+Do not treat the database as disposable. In addition to current inventory and
+event history, it contains agent token hashes, image-freshness cache state, and
+alert cursor, cooldown, and per-channel delivery state. If the database is lost,
+manually registered agents receive `401` responses because the new server no
+longer recognises their tokens.
+
+Restore a backup whenever possible. If no backup exists:
+
+1. Recreate each production agent with `trove-server agent create <name>`.
+2. Replace that agent's `TROVE_TOKEN` value (or Kubernetes Secret) with the newly
+   issued token and restart the agent.
+3. Wait for successful reports; current inventory repopulates after the agents
+   authenticate and push again.
+
+Historical events and previous alert cursor/delivery state cannot be rebuilt.
+The quickstart's development-only bootstrap agent is recreated automatically
+only when its existing `TROVE_BOOTSTRAP_AGENT` and `TROVE_BOOTSTRAP_TOKEN`
+settings are still present.
 
 ## Rolling back
 


### PR DESCRIPTION
## Summary

- correct database-loss guidance so operators know agents need new tokens before inventory can repopulate
- align the documented Prometheus metric families with the server output
- record that Authentik has already been exercised in production while keeping Dev OIDC validation on the roadmap
- remove the unused Kubernetes `watch` permission and update the agent guide

## Validation

- exact emitted/documented metric-family comparison
- offline YAML parse and ClusterRole verb assertion
- `git diff --check`
- `gofmt -l .`
- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go test -race ./...`
- `make build`
- `./scripts/check-dockerfile-drift.sh`
- `python3 ./scripts/check_release_surface.py`
- `goreleaser check`

## Release coordination

This completes the remaining documentation and least-privilege work from the v0.13 audit after #85. Keep Release Please PR #84 on hold until this PR lands and Release Please refreshes the release branch.