### PR TITLE
chore(release): prevent post-release PR race

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,10 +12,41 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # release-tag.yml and release.yml own the manifest-bump push. Running
+      # release-please in parallel races the GitHub Release publication: it can
+      # see the new manifest version before the release exists, then replay the
+      # full commit history into a bogus next-version PR.
+      # actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+
+      - name: Detect merged release PR
+        id: release_merge
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --name-only "$BEFORE" "$AFTER" \
+            | grep -Fxq '.release-please-manifest.json'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Release manifest changed; tag and publish workflows own this push."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Needs a real PAT (RELEASE_PLEASE_TOKEN), not the default GITHUB_TOKEN:
       # GitHub refuses to trigger other workflows (i.e. CI) on PRs opened by
       # the built-in token, which would leave the release PR permanently
       # unable to satisfy main's required "test" check. See CONTRIBUTING.md.
       - uses: googleapis/release-please-action@v5
+        if: steps.release_merge.outputs.skip != 'true'
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Summary

- detect pushes that change `.release-please-manifest.json`
- skip Release Please on that release-merge push while `release-tag.yml` and GoReleaser tag and publish the release
- continue running Release Please normally on every subsequent product or maintenance change

## Root cause

Release Please, the release-tag workflow, and GoReleaser all start from the merged release PR push. Release Please can query the GitHub Releases API before GoReleaser has published the new release. It then sees the bumped manifest without a matching release boundary and replays historical commits into a bogus next-version PR, as happened with #89 after v0.14.0.

## Impact

This changes release orchestration only. It does not modify Trove binaries, images, application behaviour, or version files. The `chore(release):` title is intentionally non-releasable.

## Verification

- [x] workflow YAML parses successfully
- [x] embedded Bash passes `bash -n`
- [x] `actionlint` v1.7.12
- [x] historical branding range resolves to `run`
- [x] historical v0.14 release-manifest range resolves to `skip`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] release-surface check
- [x] Dockerfile drift check