### PR TITLE
feat: add Proxmox host health metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: go vet ./...
       - name: Dockerfile drift check
         run: ./scripts/check-dockerfile-drift.sh
+      - name: GitHub Actions lint
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10
       - name: Release surface check
         run: python3 ./scripts/check_release_surface.py
       - name: golangci-lint

--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -1,15 +1,16 @@
 name: Preview images
 
-# Builds and pushes branch-tagged Docker images to GHCR for server/runtime
-# changes on feature branches. This lets you test a PR build without merging
-# to main:
+# Builds and pushes branch-tagged Docker images to GHCR for server and agent
+# changes on feature branches. This lets you test a complete PR build without
+# merging to main:
 #
 #   docker pull ghcr.io/techdox/trove-server:feat-oidc-auth
+#   docker pull ghcr.io/techdox/trove-agent-proxmox:feat-oidc-auth
 #
-# Only the server image is built (it's the one with dashboard/auth changes).
-# Agent images are unchanged by most feature work and can be tested with
-# the latest released image. Docs-only branches/changes deliberately do not
-# publish preview images.
+# Every containerized binary is built from the same commit. This prevents a
+# preview server from silently running alongside a released agent whose report
+# contract is older. The local/systemd agent has no container image. Docs-only
+# branches/changes deliberately do not publish preview images.
 #
 # Images are tagged with a sanitized branch name. On main, the tag is
 # "main" (overwritten on every push). Tags are never published to
@@ -32,7 +33,12 @@ on:
     paths:
       - '.dockerignore'
       - '.github/workflows/preview-images.yml'
+      - 'Dockerfile.agent'
+      - 'Dockerfile.agents'
       - 'Dockerfile.server'
+      - 'cmd/trove-agent-docker/**'
+      - 'cmd/trove-agent-k8s/**'
+      - 'cmd/trove-agent-proxmox/**'
       - 'cmd/trove-server/**'
       - 'go.mod'
       - 'go.sum'
@@ -45,9 +51,46 @@ permissions:
   packages: write
 
 jobs:
-  build-server:
-    name: Build trove-server preview image
+  metadata:
+    name: Derive preview metadata
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Derive image tag and runtime version
+        id: tag
+        shell: bash
+        run: |
+          raw="${GITHUB_REF#refs/heads/}"
+          tag=$(echo "$raw" | sed 's|/|-|g' | tr -cd '[:alnum:]._-')
+          short_sha="${GITHUB_SHA:0:7}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=${tag}-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building preview tag $tag from $short_sha"
+
+  build-preview:
+    name: Build ${{ matrix.image }} preview image
+    needs: metadata
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: trove-server
+            dockerfile: Dockerfile.server
+            extra_build_args: ''
+          - image: trove-agent-docker
+            dockerfile: Dockerfile.agent
+            extra_build_args: ''
+          - image: trove-agent-k8s
+            dockerfile: Dockerfile.agents
+            extra_build_args: CMD=trove-agent-k8s
+          - image: trove-agent-proxmox
+            dockerfile: Dockerfile.agents
+            extra_build_args: CMD=trove-agent-proxmox
     steps:
       - uses: actions/checkout@v7
 
@@ -62,23 +105,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Derive image tag from branch name
-        id: tag
-        run: |
-          # Sanitize branch name: replace / with -, strip non-alphanumeric
-          raw="${GITHUB_REF#refs/heads/}"
-          tag=$(echo "$raw" | sed 's|/|-|g' | tr -cd '[:alnum:]._-')
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Building image tag: $tag"
-
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: Dockerfile.server
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/techdox/trove-server:${{ steps.tag.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ghcr.io/techdox/${{ matrix.image }}:${{ needs.metadata.outputs.tag }}
+          build-args: |
+            VERSION=${{ needs.metadata.outputs.version }}
+            ${{ matrix.extra_build_args }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -4,11 +4,12 @@
 # Dev/compose image; the release counterpart is
 # build/docker/Dockerfile.agent-docker — keep base image/user in sync.
 FROM golang:1.26 AS build
+ARG VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
     -o /out/trove-agent-docker ./cmd/trove-agent-docker
 
 FROM gcr.io/distroless/static-debian12

--- a/Dockerfile.agents
+++ b/Dockerfile.agents
@@ -13,11 +13,12 @@ ARG CMD=trove-agent-k8s
 
 FROM golang:1.26 AS build
 ARG CMD
+ARG VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /out/agent ./cmd/${CMD}
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o /out/agent ./cmd/${CMD}
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=build /out/agent /usr/local/bin/agent

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -3,11 +3,12 @@
 # goreleaser) is build/docker/Dockerfile.server — keep base image, user, and
 # ENV defaults in sync between the two.
 FROM golang:1.26 AS build
+ARG VERSION=dev
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
     -o /out/trove-server ./cmd/trove-server
 # Pre-create the data dir owned by the distroless nonroot uid (65532) so a
 # fresh named volume inherits writable ownership.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ not a feature toggle, and it's the project's one hard rule.
   healthchecks, K8s readiness), plus server-side staleness: an agent that goes
   quiet flags itself and all its services within ~90 seconds.
 - **Host condition + resources** — reporting health stays separate from the
-  platform's host condition. Proxmox nodes surface online/offline condition,
-  CPU, load, memory, root-disk usage, and uptime in a dedicated host-stats
-  drawer, opened from the clearly labelled action on each host.
+  platform's host condition. Proxmox and Linux hosts surface CPU, load, memory,
+  disk, and uptime; local Docker agents report the kernel metrics they can
+  observe truthfully; Kubernetes rolls up node readiness plus CPU/memory when
+  Metrics API is available. Open the dedicated host-stats drawer from each host.
 - **Image freshness** — the server checks registries (batched, cached,
   rate-limit-aware) and badges services whose running image is behind its tag.
 - **Alerts & digest** — instant notifications via webhook / Discord / ntfy when

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ not a feature toggle, and it's the project's one hard rule.
   quiet flags itself and all its services within ~90 seconds.
 - **Host condition + resources** — reporting health stays separate from the
   platform's host condition. Proxmox nodes surface online/offline condition,
-  CPU, load, memory, root-disk usage, and uptime directly in the host header.
+  CPU, load, memory, root-disk usage, and uptime in a dedicated host-stats
+  drawer, opened from the clearly labelled action on each host.
 - **Image freshness** — the server checks registries (batched, cached,
   rate-limit-aware) and badges services whose running image is behind its tag.
 - **Alerts & digest** — instant notifications via webhook / Discord / ntfy when

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ not a feature toggle, and it's the project's one hard rule.
 - **Health + heartbeats** — platform health where it exists (Docker
   healthchecks, K8s readiness), plus server-side staleness: an agent that goes
   quiet flags itself and all its services within ~90 seconds.
+- **Host condition + resources** — reporting health stays separate from the
+  platform's host condition. Proxmox nodes surface online/offline condition,
+  CPU, load, memory, root-disk usage, and uptime directly in the host header.
 - **Image freshness** — the server checks registries (batched, cached,
   rate-limit-aware) and badges services whose running image is behind its tag.
 - **Alerts & digest** — instant notifications via webhook / Discord / ntfy when

--- a/cmd/trove-agent-docker/collect.go
+++ b/cmd/trove-agent-docker/collect.go
@@ -14,8 +14,13 @@ import (
 // collector turns the Docker daemon's view into a Trove report. Docker is a
 // single-host platform, so Collect returns exactly one HostSnapshot.
 type collector struct {
-	cli *dockerClient
-	log *slog.Logger
+	cli     *dockerClient
+	log     *slog.Logger
+	metrics metricSampler
+}
+
+type metricSampler interface {
+	Collect() (*model.HostMetrics, error)
 }
 
 // Collect builds a full-state snapshot of every container on the host.
@@ -25,7 +30,28 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 		return nil, err
 	}
 
-	hostname, meta := c.hostInfo(ctx)
+	hostname, meta, info := c.hostInfo(ctx)
+	if meta == nil {
+		meta = map[string]string{}
+	}
+	if c.cli.localHost {
+		meta["docker.host_metrics"] = "local procfs"
+	} else {
+		meta["docker.host_metrics"] = "capacity only (remote daemon)"
+	}
+	var metrics *model.HostMetrics
+	if c.metrics != nil {
+		metrics, err = c.metrics.Collect()
+		if err != nil {
+			c.log.Debug("docker host metrics partially unavailable", "err", err)
+		}
+	}
+	if info.NCPU > 0 {
+		if metrics == nil {
+			metrics = &model.HostMetrics{}
+		}
+		metrics.CPULogicalCount = &info.NCPU
+	}
 
 	// Cache image digests within this cycle so N containers of the same image
 	// cost one image inspect, not N.
@@ -56,7 +82,12 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 	}
 
 	return []agentkit.HostSnapshot{{
-		Host:     model.ReportHost{Hostname: hostname, Meta: meta},
+		Host: model.ReportHost{
+			Hostname:  hostname,
+			Condition: model.HostConditionNormal,
+			Metrics:   metrics,
+			Meta:      meta,
+		},
 		Services: services,
 	}}, nil
 }
@@ -65,12 +96,12 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 // hostname if the daemon info call fails. Meta keys use the dotted convention
 // (docker.version, docker.api_version, docker.os, docker.arch) matching the
 // Proxmox agent's proxmox.version pattern.
-func (c *collector) hostInfo(ctx context.Context) (string, map[string]string) {
+func (c *collector) hostInfo(ctx context.Context) (string, map[string]string, dockerInfo) {
 	info, err := c.cli.info(ctx)
 	if err != nil {
 		c.log.Debug("docker info failed; using OS hostname", "err", err)
 		h, _ := os.Hostname()
-		return h, nil
+		return h, nil, dockerInfo{}
 	}
 	hostname := info.Name
 	if hostname == "" {
@@ -79,6 +110,12 @@ func (c *collector) hostInfo(ctx context.Context) (string, map[string]string) {
 	meta := map[string]string{}
 	if info.ServerVersion != "" {
 		meta["docker.version"] = info.ServerVersion
+	}
+	if info.OperatingSystem != "" {
+		meta["docker.os_name"] = info.OperatingSystem
+	}
+	if info.KernelVersion != "" {
+		meta["docker.kernel"] = info.KernelVersion
 	}
 	// The /version endpoint carries API version and OS/arch details.
 	v, err := c.cli.version(ctx)
@@ -99,7 +136,7 @@ func (c *collector) hostInfo(ctx context.Context) (string, map[string]string) {
 			meta["docker.arch"] = info.Arch
 		}
 	}
-	return hostname, meta
+	return hostname, meta, info
 }
 
 // resolveDigest returns the registry manifest digest (sha256:...) for an image,

--- a/cmd/trove-agent-docker/collect_test.go
+++ b/cmd/trove-agent-docker/collect_test.go
@@ -1,12 +1,24 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/techdox/trove/pkg/model"
 )
+
+type stubMetricSampler struct {
+	metrics *model.HostMetrics
+	err     error
+}
+
+func (s stubMetricSampler) Collect() (*model.HostMetrics, error) { return s.metrics, s.err }
 
 func inspectFromJSON(t *testing.T, s string) dockerInspect {
 	t.Helper()
@@ -57,4 +69,57 @@ func TestHealthDetail(t *testing.T) {
 			t.Fatalf("truncated detail should end with ellipsis: %q", d)
 		}
 	})
+}
+
+func TestCollectReportsDockerHostConditionAndMetrics(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/containers/json":
+			_, _ = io.WriteString(w, `[]`)
+		case "/info":
+			_, _ = io.WriteString(w, `{"Name":"docker-host","ServerVersion":"28.1","NCPU":8,"OperatingSystem":"Debian 12","KernelVersion":"6.8.0"}`)
+		case "/version":
+			_, _ = io.WriteString(w, `{"Version":"28.1","ApiVersion":"1.49","Os":"linux","Arch":"amd64"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	ratio := 0.25
+	col := &collector{
+		cli: &dockerClient{http: api.Client(), base: api.URL},
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		metrics: stubMetricSampler{metrics: &model.HostMetrics{
+			CPUUsageRatio: &ratio,
+		}},
+	}
+	snaps, err := col.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].Host.Hostname != "docker-host" ||
+		snaps[0].Host.Condition != model.HostConditionNormal || snaps[0].Host.Metrics == nil ||
+		snaps[0].Host.Metrics.CPULogicalCount == nil || *snaps[0].Host.Metrics.CPULogicalCount != 8 ||
+		snaps[0].Host.Metrics.CPUUsageRatio == nil || *snaps[0].Host.Metrics.CPUUsageRatio != 0.25 {
+		t.Fatalf("docker snapshot = %+v", snaps)
+	}
+	if snaps[0].Host.Meta["docker.os_name"] != "Debian 12" || snaps[0].Host.Meta["docker.kernel"] != "6.8.0" {
+		t.Fatalf("docker metadata = %+v", snaps[0].Host.Meta)
+	}
+}
+
+func TestDockerClientOnlyTreatsUnixSocketAsLocalHost(t *testing.T) {
+	local, err := newDockerClient("unix:///var/run/docker.sock")
+	if err != nil {
+		t.Fatalf("local client: %v", err)
+	}
+	remote, err := newDockerClient("tcp://docker.example:2375")
+	if err != nil {
+		t.Fatalf("remote client: %v", err)
+	}
+	if !local.localHost || remote.localHost {
+		t.Fatalf("local flags = unix:%v remote:%v", local.localHost, remote.localHost)
+	}
 }

--- a/cmd/trove-agent-docker/docker.go
+++ b/cmd/trove-agent-docker/docker.go
@@ -18,8 +18,9 @@ import (
 // structurally rather than by convention. It speaks the daemon's default API
 // version (unversioned paths) for broad compatibility.
 type dockerClient struct {
-	http *http.Client
-	base string // scheme+host prefix, e.g. "http://docker" (unix) or "http://host:2375"
+	http      *http.Client
+	base      string // scheme+host prefix, e.g. "http://docker" (unix) or "http://host:2375"
+	localHost bool   // true only when procfs belongs to the daemon host
 }
 
 // newDockerClient connects using DOCKER_HOST, defaulting to the local unix
@@ -43,8 +44,9 @@ func newDockerClient(dockerHost string) (*dockerClient, error) {
 			},
 		}
 		return &dockerClient{
-			http: &http.Client{Transport: tr, Timeout: 30 * time.Second},
-			base: "http://docker", // host is ignored for unix transport
+			http:      &http.Client{Transport: tr, Timeout: 30 * time.Second},
+			base:      "http://docker", // host is ignored for unix transport
+			localHost: true,
 		}, nil
 	case "tcp", "http", "https":
 		scheme := "http"
@@ -127,10 +129,13 @@ type dockerImage struct {
 }
 
 type dockerInfo struct {
-	Name          string `json:"Name"`
-	ServerVersion string `json:"ServerVersion"`
-	OSType        string `json:"OSType"`
-	Arch          string `json:"Architecture"`
+	Name            string `json:"Name"`
+	ServerVersion   string `json:"ServerVersion"`
+	OSType          string `json:"OSType"`
+	Arch            string `json:"Architecture"`
+	NCPU            int    `json:"NCPU"`
+	OperatingSystem string `json:"OperatingSystem"`
+	KernelVersion   string `json:"KernelVersion"`
 }
 
 // dockerVersion is the response from /version. It carries the API version

--- a/cmd/trove-agent-docker/main.go
+++ b/cmd/trove-agent-docker/main.go
@@ -20,6 +20,7 @@ import (
 	"syscall"
 
 	"github.com/techdox/trove/internal/agentkit"
+	"github.com/techdox/trove/internal/hostmetrics"
 	"github.com/techdox/trove/pkg/model"
 )
 
@@ -50,6 +51,10 @@ func main() {
 		log.Warn("docker daemon not reachable yet; will retry", "err", err)
 	}
 
-	col := &collector{cli: cli, log: log}
+	var metrics metricSampler
+	if cli.localHost {
+		metrics = hostmetrics.NewLinuxSampler(false)
+	}
+	col := &collector{cli: cli, log: log, metrics: metrics}
 	agentkit.Run(ctx, cfg, model.PlatformDocker, version, col, log)
 }

--- a/cmd/trove-agent-k8s/collect.go
+++ b/cmd/trove-agent-k8s/collect.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/techdox/trove/internal/agentkit"
@@ -81,13 +83,194 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 		}
 	}
 
+	condition, metrics, nodeMeta := c.clusterHealth(ctx)
+	for key, value := range nodeMeta {
+		meta[key] = value
+	}
+
 	return []agentkit.HostSnapshot{{
 		Host: model.ReportHost{
-			Hostname: c.cfg.cluster,
-			Meta:     meta,
+			Hostname:  c.cfg.cluster,
+			Condition: condition,
+			Metrics:   metrics,
+			Meta:      meta,
 		},
 		Services: services,
 	}}, nil
+}
+
+// clusterHealth rolls node readiness into one cluster condition and, when the
+// optional Metrics API is installed, aggregates its current CPU and memory
+// usage. Both reads are best-effort so upgrading an existing deployment before
+// applying the expanded read-only RBAC cannot stop workload reports.
+func (c *collector) clusterHealth(ctx context.Context) (model.HostCondition, *model.HostMetrics, map[string]string) {
+	var nodes nodeList
+	if err := c.cli.get(ctx, "/api/v1/nodes", &nodes); err != nil {
+		c.log.Debug("kube nodes unavailable; host condition and capacity omitted", "err", err)
+		return model.HostConditionUnknown, nil, nil
+	}
+
+	condition, ready := nodeCondition(nodes.Items)
+	meta := map[string]string{
+		"kubernetes.nodes":       strconv.Itoa(len(nodes.Items)),
+		"kubernetes.ready_nodes": strconv.Itoa(ready),
+	}
+
+	var usage nodeMetricsList
+	if err := c.cli.get(ctx, "/apis/metrics.k8s.io/v1beta1/nodes", &usage); err != nil {
+		c.log.Debug("kube Metrics API unavailable; reporting node capacity without usage", "err", err)
+		meta["kubernetes.metrics_api"] = "unavailable"
+		return condition, aggregateNodeMetrics(nodes.Items, nil), meta
+	}
+	meta["kubernetes.metrics_api"] = "available"
+	return condition, aggregateNodeMetrics(nodes.Items, &usage), meta
+}
+
+func nodeCondition(nodes []kubeNode) (model.HostCondition, int) {
+	if len(nodes) == 0 {
+		return model.HostConditionUnknown, 0
+	}
+	ready, notReady := 0, 0
+	for i := range nodes {
+		status := ""
+		for _, condition := range nodes[i].Status.Conditions {
+			if condition.Type == "Ready" {
+				status = condition.Status
+				break
+			}
+		}
+		switch status {
+		case "True":
+			ready++
+		case "False":
+			notReady++
+		}
+	}
+	if ready == len(nodes) {
+		return model.HostConditionNormal, ready
+	}
+	if ready > 0 {
+		return model.HostConditionWarning, ready
+	}
+	if notReady > 0 {
+		return model.HostConditionCritical, ready
+	}
+	return model.HostConditionUnknown, ready
+}
+
+func aggregateNodeMetrics(nodes []kubeNode, usage *nodeMetricsList) *model.HostMetrics {
+	byName := make(map[string]kubeNode, len(nodes))
+	totalCores := 0.0
+	for _, node := range nodes {
+		byName[node.Metadata.Name] = node
+		if cores, ok := parseCPUQuantity(node.Status.Capacity["cpu"]); ok {
+			totalCores += cores
+		}
+	}
+
+	m := &model.HostMetrics{}
+	populated := false
+	if totalCores > 0 && totalCores <= float64(math.MaxInt) {
+		count := int(math.Round(totalCores))
+		if count > 0 {
+			m.CPULogicalCount = &count
+			populated = true
+		}
+	}
+	if usage == nil {
+		if populated {
+			return m
+		}
+		return nil
+	}
+
+	usedCPU, capacityCPU := 0.0, 0.0
+	var usedMemory, capacityMemory uint64
+	for _, item := range usage.Items {
+		node, ok := byName[item.Metadata.Name]
+		if !ok {
+			continue
+		}
+		if used, ok := parseCPUQuantity(item.Usage["cpu"]); ok {
+			if capacity, ok := parseCPUQuantity(node.Status.Capacity["cpu"]); ok && capacity > 0 {
+				usedCPU += used
+				capacityCPU += capacity
+			}
+		}
+		if used, ok := parseByteQuantity(item.Usage["memory"]); ok {
+			if capacity, ok := parseByteQuantity(node.Status.Capacity["memory"]); ok && capacity > 0 && used <= capacity {
+				if math.MaxUint64-usedMemory >= used && math.MaxUint64-capacityMemory >= capacity {
+					usedMemory += used
+					capacityMemory += capacity
+				}
+			}
+		}
+	}
+	if capacityCPU > 0 {
+		ratio := math.Min(usedCPU/capacityCPU, 1)
+		if ratio >= 0 && !math.IsNaN(ratio) && !math.IsInf(ratio, 0) {
+			m.CPUUsageRatio = &ratio
+			populated = true
+		}
+	}
+	if capacityMemory > 0 && usedMemory <= capacityMemory {
+		m.Memory = &model.HostResourceUsage{UsedBytes: usedMemory, TotalBytes: capacityMemory}
+		populated = true
+	}
+	if !populated {
+		return nil
+	}
+	return m
+}
+
+func parseCPUQuantity(raw string) (float64, bool) {
+	return parseScaledQuantity(raw, map[string]float64{
+		"n": 1e-9,
+		"u": 1e-6,
+		"m": 1e-3,
+		"":  1,
+	})
+}
+
+func parseByteQuantity(raw string) (uint64, bool) {
+	value, ok := parseScaledQuantity(raw, map[string]float64{
+		"Ki": 1 << 10,
+		"Mi": 1 << 20,
+		"Gi": 1 << 30,
+		"Ti": 1 << 40,
+		"Pi": 1 << 50,
+		"k":  1e3,
+		"K":  1e3,
+		"M":  1e6,
+		"G":  1e9,
+		"T":  1e12,
+		"P":  1e15,
+		"":   1,
+	})
+	if !ok || value < 0 || value > math.MaxUint64 {
+		return 0, false
+	}
+	return uint64(math.Round(value)), true
+}
+
+func parseScaledQuantity(raw string, scales map[string]float64) (float64, bool) {
+	raw = strings.TrimSpace(raw)
+	for _, suffix := range []string{"Pi", "Ti", "Gi", "Mi", "Ki", "n", "u", "m", "P", "T", "G", "M", "K", "k", ""} {
+		scale, supported := scales[suffix]
+		if !supported || !strings.HasSuffix(raw, suffix) {
+			continue
+		}
+		number := strings.TrimSuffix(raw, suffix)
+		if number == "" {
+			return 0, false
+		}
+		value, err := strconv.ParseFloat(number, 64)
+		if err != nil || math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+			return 0, false
+		}
+		return value * scale, true
+	}
+	return 0, false
 }
 
 func replicaCount(w *workload) int {

--- a/cmd/trove-agent-k8s/collect_test.go
+++ b/cmd/trove-agent-k8s/collect_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -15,6 +16,24 @@ func podFromJSON(t *testing.T, s string) pod {
 		t.Fatalf("unmarshal pod: %v", err)
 	}
 	return p
+}
+
+func nodeFromJSON(t *testing.T, s string) kubeNode {
+	t.Helper()
+	var node kubeNode
+	if err := json.Unmarshal([]byte(s), &node); err != nil {
+		t.Fatalf("unmarshal node: %v", err)
+	}
+	return node
+}
+
+func nodeMetricsFromJSON(t *testing.T, s string) nodeMetricsList {
+	t.Helper()
+	var metrics nodeMetricsList
+	if err := json.Unmarshal([]byte(s), &metrics); err != nil {
+		t.Fatalf("unmarshal node metrics: %v", err)
+	}
+	return metrics
 }
 
 func TestPodDetail(t *testing.T) {
@@ -50,4 +69,70 @@ func TestPodDetail(t *testing.T) {
 			t.Fatalf("pod-level detail = %q", d)
 		}
 	})
+}
+
+func TestNodeCondition(t *testing.T) {
+	ready := nodeFromJSON(t, `{"metadata":{"name":"ready"},"status":{"conditions":[{"type":"Ready","status":"True"}]}}`)
+	notReady := nodeFromJSON(t, `{"metadata":{"name":"down"},"status":{"conditions":[{"type":"Ready","status":"False"}]}}`)
+	unknown := nodeFromJSON(t, `{"metadata":{"name":"unknown"},"status":{"conditions":[{"type":"Ready","status":"Unknown"}]}}`)
+
+	tests := []struct {
+		name      string
+		nodes     []kubeNode
+		condition model.HostCondition
+		ready     int
+	}{
+		{name: "all ready", nodes: []kubeNode{ready, ready}, condition: model.HostConditionNormal, ready: 2},
+		{name: "partially ready", nodes: []kubeNode{ready, notReady}, condition: model.HostConditionWarning, ready: 1},
+		{name: "none ready", nodes: []kubeNode{notReady, unknown}, condition: model.HostConditionCritical},
+		{name: "unknown only", nodes: []kubeNode{unknown}, condition: model.HostConditionUnknown},
+		{name: "empty", condition: model.HostConditionUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition, count := nodeCondition(tt.nodes)
+			if condition != tt.condition || count != tt.ready {
+				t.Fatalf("node condition = (%q, %d), want (%q, %d)", condition, count, tt.condition, tt.ready)
+			}
+		})
+	}
+}
+
+func TestAggregateNodeMetrics(t *testing.T) {
+	nodes := []kubeNode{
+		nodeFromJSON(t, `{"metadata":{"name":"node-a"},"status":{"capacity":{"cpu":"4","memory":"8Gi"}}}`),
+		nodeFromJSON(t, `{"metadata":{"name":"node-b"},"status":{"capacity":{"cpu":"8","memory":"16Gi"}}}`),
+	}
+	usage := nodeMetricsFromJSON(t, `{"items":[
+		{"metadata":{"name":"node-a"},"usage":{"cpu":"500m","memory":"2Gi"}},
+		{"metadata":{"name":"node-b"},"usage":{"cpu":"1500000000n","memory":"4Gi"}}
+	]}`)
+
+	m := aggregateNodeMetrics(nodes, &usage)
+	if m == nil || m.CPULogicalCount == nil || *m.CPULogicalCount != 12 || m.CPUUsageRatio == nil ||
+		math.Abs(*m.CPUUsageRatio-(2.0/12.0)) > 0.0001 || m.Memory == nil ||
+		m.Memory.UsedBytes != 6*(1<<30) || m.Memory.TotalBytes != 24*(1<<30) {
+		t.Fatalf("aggregate metrics = %+v", m)
+	}
+
+	capacityOnly := aggregateNodeMetrics(nodes, nil)
+	if capacityOnly == nil || capacityOnly.CPULogicalCount == nil || *capacityOnly.CPULogicalCount != 12 ||
+		capacityOnly.CPUUsageRatio != nil || capacityOnly.Memory != nil {
+		t.Fatalf("capacity-only metrics = %+v", capacityOnly)
+	}
+}
+
+func TestKubernetesQuantityParsing(t *testing.T) {
+	for raw, want := range map[string]float64{"250m": 0.25, "123000000n": 0.123, "2": 2} {
+		got, ok := parseCPUQuantity(raw)
+		if !ok || math.Abs(got-want) > 0.000001 {
+			t.Errorf("cpu quantity %q = (%v, %v), want %v", raw, got, ok, want)
+		}
+	}
+	for raw, want := range map[string]uint64{"512Ki": 512 << 10, "2Gi": 2 << 30, "100M": 100_000_000} {
+		got, ok := parseByteQuantity(raw)
+		if !ok || got != want {
+			t.Errorf("byte quantity %q = (%d, %v), want %d", raw, got, ok, want)
+		}
+	}
 }

--- a/cmd/trove-agent-k8s/kube.go
+++ b/cmd/trove-agent-k8s/kube.go
@@ -212,6 +212,29 @@ type pod struct {
 	} `json:"status"`
 }
 
+type nodeList struct {
+	Items []kubeNode `json:"items"`
+}
+
+type kubeNode struct {
+	Metadata objectMeta `json:"metadata"`
+	Status   struct {
+		Capacity    map[string]string `json:"capacity"`
+		Allocatable map[string]string `json:"allocatable"`
+		Conditions  []struct {
+			Type   string `json:"type"`
+			Status string `json:"status"`
+		} `json:"conditions"`
+	} `json:"status"`
+}
+
+type nodeMetricsList struct {
+	Items []struct {
+		Metadata objectMeta        `json:"metadata"`
+		Usage    map[string]string `json:"usage"`
+	} `json:"items"`
+}
+
 // apiPath builds a list path, namespaced if configured.
 func (c *collector) apiPath(group, resource string) string {
 	if c.cfg.namespace != "" {

--- a/cmd/trove-agent-local/main.go
+++ b/cmd/trove-agent-local/main.go
@@ -19,10 +19,12 @@ import (
 	"os/exec"
 	"os/signal"
 	"path"
+	"runtime"
 	"strings"
 	"syscall"
 
 	"github.com/techdox/trove/internal/agentkit"
+	"github.com/techdox/trove/internal/hostmetrics"
 	"github.com/techdox/trove/pkg/model"
 )
 
@@ -43,11 +45,20 @@ type collector struct {
 	filter     string // optional glob
 	includeAll bool   // include inactive units
 	hostname   string
+	metrics    metricSampler
+	listUnits  func(context.Context) ([]byte, error)
+}
+
+type metricSampler interface {
+	Collect() (*model.HostMetrics, error)
 }
 
 func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error) {
-	out, err := exec.CommandContext(ctx, "systemctl",
-		"list-units", "--type=service", "--all", "--output=json", "--no-pager", "--no-legend").Output()
+	listUnits := c.listUnits
+	if listUnits == nil {
+		listUnits = systemdUnits
+	}
+	out, err := listUnits(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("systemctl list-units: %w", err)
 	}
@@ -83,10 +94,37 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 		})
 	}
 
+	var metrics *model.HostMetrics
+	if c.metrics != nil {
+		metrics, err = c.metrics.Collect()
+		if err != nil {
+			c.log.Debug("linux host metrics partially unavailable", "err", err)
+		}
+	}
+	if runtime.NumCPU() > 0 {
+		if metrics == nil {
+			metrics = &model.HostMetrics{}
+		}
+		count := runtime.NumCPU()
+		metrics.CPULogicalCount = &count
+	}
+	meta := hostmetrics.LinuxMetadata()
+	meta["platform"] = string(model.PlatformLocal)
+
 	return []agentkit.HostSnapshot{{
-		Host:     model.ReportHost{Hostname: c.hostname, Meta: map[string]string{"platform": string(model.PlatformLocal)}},
+		Host: model.ReportHost{
+			Hostname:  c.hostname,
+			Condition: model.HostConditionNormal,
+			Metrics:   metrics,
+			Meta:      meta,
+		},
 		Services: services,
 	}}, nil
+}
+
+func systemdUnits(ctx context.Context) ([]byte, error) {
+	return exec.CommandContext(ctx, "systemctl",
+		"list-units", "--type=service", "--all", "--output=json", "--no-pager", "--no-legend").Output()
 }
 
 // isInteresting keeps running/failed units by default and drops inactive noise.
@@ -129,6 +167,7 @@ func main() {
 		filter:     os.Getenv("TROVE_LOCAL_UNIT_FILTER"),
 		includeAll: includeAll,
 		hostname:   hostname,
+		metrics:    hostmetrics.NewLinuxSampler(true),
 	}
 	agentkit.Run(ctx, cfg, model.PlatformLocal, version, col, log)
 }

--- a/cmd/trove-agent-local/main_test.go
+++ b/cmd/trove-agent-local/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+type stubLocalMetricSampler struct {
+	metrics *model.HostMetrics
+	err     error
+}
+
+func (s stubLocalMetricSampler) Collect() (*model.HostMetrics, error) { return s.metrics, s.err }
+
+func TestCollectReportsLinuxHostConditionAndMetrics(t *testing.T) {
+	used, total := uint64(4<<30), uint64(16<<30)
+	col := &collector{
+		log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		hostname: "nas01",
+		metrics: stubLocalMetricSampler{metrics: &model.HostMetrics{
+			Memory: &model.HostResourceUsage{UsedBytes: used, TotalBytes: total},
+		}},
+		listUnits: func(context.Context) ([]byte, error) {
+			return []byte(`[{"unit":"docker.service","load":"loaded","active":"active","sub":"running","description":"Docker"}]`), nil
+		},
+	}
+
+	snaps, err := col.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].Host.Hostname != "nas01" ||
+		snaps[0].Host.Condition != model.HostConditionNormal || snaps[0].Host.Metrics == nil ||
+		snaps[0].Host.Metrics.Memory == nil || snaps[0].Host.Metrics.Memory.UsedBytes != used ||
+		snaps[0].Host.Metrics.CPULogicalCount == nil || *snaps[0].Host.Metrics.CPULogicalCount <= 0 ||
+		len(snaps[0].Services) != 1 || snaps[0].Services[0].Name != "docker" {
+		t.Fatalf("local snapshot = %+v", snaps)
+	}
+}

--- a/cmd/trove-agent-proxmox/proxmox.go
+++ b/cmd/trove-agent-proxmox/proxmox.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -79,7 +80,8 @@ func (c *proxmoxClient) get(ctx context.Context, path string, out any) error {
 
 // pveNode is an entry from /nodes.
 type pveNode struct {
-	Node string `json:"node"`
+	Node   string `json:"node"`
+	Status string `json:"status"`
 }
 
 // pveNodeVersion is returned by /nodes/{node}/version.
@@ -87,6 +89,42 @@ type pveNodeVersion struct {
 	Version string `json:"version"`
 	Release string `json:"release"`
 	RepoID  string `json:"repoid"`
+}
+
+// pveMetricFloat accepts the Proxmox API's numeric metrics in either their
+// number or quoted-number form. loadavg has used both representations across
+// API versions, so being liberal here keeps collection compatible without
+// weakening Trove's validated wire contract.
+type pveMetricFloat float64
+
+func (f *pveMetricFloat) UnmarshalJSON(data []byte) error {
+	raw := strings.TrimSpace(string(data))
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		raw = raw[1 : len(raw)-1]
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return fmt.Errorf("parse Proxmox metric %q: %w", raw, err)
+	}
+	*f = pveMetricFloat(v)
+	return nil
+}
+
+type pveNodeResourceUsage struct {
+	Used  uint64 `json:"used"`
+	Total uint64 `json:"total"`
+}
+
+// pveNodeStatus is the resource summary returned by /nodes/{node}/status.
+type pveNodeStatus struct {
+	CPU     *pveMetricFloat `json:"cpu"`
+	CPUInfo struct {
+		CPUs int `json:"cpus"`
+	} `json:"cpuinfo"`
+	LoadAvg []pveMetricFloat     `json:"loadavg"`
+	Memory  pveNodeResourceUsage `json:"memory"`
+	RootFS  pveNodeResourceUsage `json:"rootfs"`
+	Uptime  *uint64              `json:"uptime"`
 }
 
 // pveResource is a guest entry from /cluster/resources?type=vm.
@@ -173,12 +211,96 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 
 	snaps := make([]agentkit.HostSnapshot, 0, len(nodesResp.Data))
 	for _, n := range nodesResp.Data {
+		condition := proxmoxNodeCondition(n.Status)
+		var metrics *model.HostMetrics
+		meta := map[string]string{"platform": "proxmox"}
+		// Offline cluster members cannot answer their node-local status endpoint.
+		// Preserve the useful critical condition without logging expected 5xx
+		// responses from either node-local endpoint every collection interval.
+		if condition != model.HostConditionCritical {
+			metrics = c.nodeMetrics(ctx, n.Node)
+			meta = c.nodeMeta(ctx, n.Node)
+		}
 		snaps = append(snaps, agentkit.HostSnapshot{
-			Host:     model.ReportHost{Hostname: n.Node, Meta: c.nodeMeta(ctx, n.Node)},
+			Host: model.ReportHost{
+				Hostname:  n.Node,
+				Condition: condition,
+				Metrics:   metrics,
+				Meta:      meta,
+			},
 			Services: byNode[n.Node],
 		})
 	}
 	return snaps, nil
+}
+
+func proxmoxNodeCondition(status string) model.HostCondition {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "online":
+		return model.HostConditionNormal
+	case "offline":
+		return model.HostConditionCritical
+	default:
+		return model.HostConditionUnknown
+	}
+}
+
+func (c *collector) nodeMetrics(ctx context.Context, node string) *model.HostMetrics {
+	var resp struct {
+		Data pveNodeStatus `json:"data"`
+	}
+	path := fmt.Sprintf("/api2/json/nodes/%s/status", url.PathEscape(node))
+	if err := c.cli.get(ctx, path, &resp); err != nil {
+		c.log.Warn("proxmox: node metrics unavailable", "node", node, "err", err)
+		return nil
+	}
+
+	m := &model.HostMetrics{}
+	if resp.Data.CPU != nil {
+		if cpu := float64(*resp.Data.CPU); isRatio(cpu) {
+			m.CPUUsageRatio = &cpu
+		}
+	}
+	if resp.Data.CPUInfo.CPUs > 0 {
+		count := resp.Data.CPUInfo.CPUs
+		m.CPULogicalCount = &count
+	}
+	for i := 0; i < len(resp.Data.LoadAvg) && i < 3; i++ {
+		load := float64(resp.Data.LoadAvg[i])
+		if !isNonNegativeFinite(load) {
+			continue
+		}
+		switch i {
+		case 0:
+			m.Load1 = &load
+		case 1:
+			m.Load5 = &load
+		case 2:
+			m.Load15 = &load
+		}
+	}
+	m.Memory = resourceUsage(resp.Data.Memory)
+	m.RootDisk = resourceUsage(resp.Data.RootFS)
+	if resp.Data.Uptime != nil {
+		uptime := *resp.Data.Uptime
+		m.UptimeSeconds = &uptime
+	}
+	return m
+}
+
+func isRatio(v float64) bool {
+	return isNonNegativeFinite(v) && v <= 1
+}
+
+func isNonNegativeFinite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0
+}
+
+func resourceUsage(v pveNodeResourceUsage) *model.HostResourceUsage {
+	if v.Total == 0 || v.Used > v.Total {
+		return nil
+	}
+	return &model.HostResourceUsage{UsedBytes: v.Used, TotalBytes: v.Total}
 }
 
 func (c *collector) nodeMeta(ctx context.Context, node string) map[string]string {

--- a/cmd/trove-agent-proxmox/proxmox.go
+++ b/cmd/trove-agent-proxmox/proxmox.go
@@ -166,6 +166,10 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 	if err := c.cli.get(ctx, "/api2/json/nodes", &nodesResp); err != nil {
 		return nil, err
 	}
+	conditionByNode := make(map[string]model.HostCondition, len(nodesResp.Data))
+	for _, n := range nodesResp.Data {
+		conditionByNode[n.Node] = proxmoxNodeCondition(n.Status)
+	}
 	var resResp struct {
 		Data []pveResource `json:"data"`
 	}
@@ -191,7 +195,13 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 		if name == "" {
 			name = fmt.Sprintf("%s-%d", r.Type, r.VMID)
 		}
-		image, osType := c.guestImage(ctx, r)
+		var image, osType string
+		// Cluster resources can retain guests for an offline node. Keep those
+		// guests in the catalogue, but do not issue node-local config requests
+		// that are expected to fail or wait for the HTTP timeout while it is down.
+		if conditionByNode[r.Node] != model.HostConditionCritical {
+			image, osType = c.guestImage(ctx, r)
+		}
 		health, healthDetail := proxmoxGuestHealth(r)
 		labels := proxmoxLabels(r)
 		if osType != "" {
@@ -211,7 +221,7 @@ func (c *collector) Collect(ctx context.Context) ([]agentkit.HostSnapshot, error
 
 	snaps := make([]agentkit.HostSnapshot, 0, len(nodesResp.Data))
 	for _, n := range nodesResp.Data {
-		condition := proxmoxNodeCondition(n.Status)
+		condition := conditionByNode[n.Node]
 		var metrics *model.HostMetrics
 		meta := map[string]string{"platform": "proxmox"}
 		// Offline cluster members cannot answer their node-local status endpoint.

--- a/cmd/trove-agent-proxmox/proxmox_test.go
+++ b/cmd/trove-agent-proxmox/proxmox_test.go
@@ -15,14 +15,26 @@ import (
 
 func TestCollectSetsGuestImageFromOSType(t *testing.T) {
 	seen := map[string]bool{}
+	cpuUsage := pveMetricFloat(0.125)
+	uptime := uint64(90061)
+	nodeStatus := pveNodeStatus{
+		CPU:     &cpuUsage,
+		LoadAvg: []pveMetricFloat{0.5, 0.25, 0.125},
+		Memory:  pveNodeResourceUsage{Used: 8 * 1024 * 1024 * 1024, Total: 32 * 1024 * 1024 * 1024},
+		RootFS:  pveNodeResourceUsage{Used: 40 * 1024 * 1024 * 1024, Total: 100 * 1024 * 1024 * 1024},
+		Uptime:  &uptime,
+	}
+	nodeStatus.CPUInfo.CPUs = 16
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seen[r.URL.Path] = true
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api2/json/nodes":
-			writePVEResponse(t, w, []pveNode{{Node: "pve-a"}})
+			writePVEResponse(t, w, []pveNode{{Node: "pve-a", Status: "online"}})
 		case "/api2/json/nodes/pve-a/version":
 			writePVEResponse(t, w, pveNodeVersion{Version: "8.4.1", Release: "1", RepoID: "a2b3c4d5"})
+		case "/api2/json/nodes/pve-a/status":
+			writePVEResponse(t, w, nodeStatus)
 		case "/api2/json/cluster/resources":
 			if got := r.URL.Query().Get("type"); got != "vm" {
 				t.Fatalf("resources type query = %q, want vm", got)
@@ -64,6 +76,18 @@ func TestCollectSetsGuestImageFromOSType(t *testing.T) {
 	if got := snaps[0].Host.Meta["proxmox.repoid"]; got != "a2b3c4d5" {
 		t.Fatalf("host proxmox.repoid meta = %q, want a2b3c4d5", got)
 	}
+	if snaps[0].Host.Condition != model.HostConditionNormal {
+		t.Fatalf("host condition = %q, want normal", snaps[0].Host.Condition)
+	}
+	metrics := snaps[0].Host.Metrics
+	if metrics == nil || metrics.CPUUsageRatio == nil || *metrics.CPUUsageRatio != 0.125 ||
+		metrics.CPULogicalCount == nil || *metrics.CPULogicalCount != 16 ||
+		metrics.Load1 == nil || *metrics.Load1 != 0.5 ||
+		metrics.Memory == nil || metrics.Memory.UsedBytes != 8*1024*1024*1024 ||
+		metrics.RootDisk == nil || metrics.RootDisk.TotalBytes != 100*1024*1024*1024 ||
+		metrics.UptimeSeconds == nil || *metrics.UptimeSeconds != 90061 {
+		t.Fatalf("host metrics = %+v", metrics)
+	}
 	services := snaps[0].Services
 	if len(services) != 2 {
 		t.Fatalf("services = %d, want 2", len(services))
@@ -87,12 +111,85 @@ func TestCollectSetsGuestImageFromOSType(t *testing.T) {
 
 	for _, path := range []string{
 		"/api2/json/nodes/pve-a/version",
+		"/api2/json/nodes/pve-a/status",
 		"/api2/json/nodes/pve-a/qemu/101/config",
 		"/api2/json/nodes/pve-a/lxc/202/config",
 	} {
 		if !seen[path] {
 			t.Fatalf("expected config endpoint %s to be queried", path)
 		}
+	}
+}
+
+func TestCollectReportsOfflineNodeConditionWithoutMetricsRequest(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api2/json/nodes":
+			writePVEResponse(t, w, []pveNode{{Node: "pve-offline", Status: "offline"}})
+		case "/api2/json/cluster/resources":
+			writePVEResponse(t, w, []pveResource{})
+		case "/api2/json/nodes/pve-offline/version":
+			t.Fatal("offline node version endpoint must not be queried")
+		case "/api2/json/nodes/pve-offline/status":
+			t.Fatal("offline node status endpoint must not be queried")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	col := &collector{
+		cli: newProxmoxClient(proxmoxConfig{url: api.URL, token: "root@pam!trove=test"}),
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	snaps, err := col.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].Host.Condition != model.HostConditionCritical || snaps[0].Host.Metrics != nil {
+		t.Fatalf("offline snapshot = %+v", snaps)
+	}
+}
+
+func TestCollectKeepsOnlineNodeWhenMetricsUnavailable(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api2/json/nodes":
+			writePVEResponse(t, w, []pveNode{{Node: "pve-a", Status: "online"}})
+		case "/api2/json/cluster/resources":
+			writePVEResponse(t, w, []pveResource{})
+		case "/api2/json/nodes/pve-a/version":
+			writePVEResponse(t, w, pveNodeVersion{})
+		case "/api2/json/nodes/pve-a/status":
+			http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	col := &collector{
+		cli: newProxmoxClient(proxmoxConfig{url: api.URL, token: "root@pam!trove=test"}),
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	snaps, err := col.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	if len(snaps) != 1 || snaps[0].Host.Condition != model.HostConditionNormal || snaps[0].Host.Metrics != nil {
+		t.Fatalf("online snapshot with missing metrics = %+v", snaps)
+	}
+}
+
+func TestPVEMetricFloatAcceptsQuotedAndNumericValues(t *testing.T) {
+	var values []pveMetricFloat
+	if err := json.Unmarshal([]byte(`["0.25",0.5,"0"]`), &values); err != nil {
+		t.Fatalf("unmarshal metric values: %v", err)
+	}
+	if len(values) != 3 || values[0] != 0.25 || values[1] != 0.5 || values[2] != 0 {
+		t.Fatalf("metric values = %+v", values)
 	}
 }
 

--- a/cmd/trove-agent-proxmox/proxmox_test.go
+++ b/cmd/trove-agent-proxmox/proxmox_test.go
@@ -128,11 +128,15 @@ func TestCollectReportsOfflineNodeConditionWithoutMetricsRequest(t *testing.T) {
 		case "/api2/json/nodes":
 			writePVEResponse(t, w, []pveNode{{Node: "pve-offline", Status: "offline"}})
 		case "/api2/json/cluster/resources":
-			writePVEResponse(t, w, []pveResource{})
+			writePVEResponse(t, w, []pveResource{{
+				Type: "qemu", VMID: 101, Name: "offline-guest", Status: "running", Node: "pve-offline",
+			}})
 		case "/api2/json/nodes/pve-offline/version":
 			t.Fatal("offline node version endpoint must not be queried")
 		case "/api2/json/nodes/pve-offline/status":
 			t.Fatal("offline node status endpoint must not be queried")
+		case "/api2/json/nodes/pve-offline/qemu/101/config":
+			t.Fatal("offline guest config endpoint must not be queried")
 		default:
 			http.NotFound(w, r)
 		}
@@ -149,6 +153,10 @@ func TestCollectReportsOfflineNodeConditionWithoutMetricsRequest(t *testing.T) {
 	}
 	if len(snaps) != 1 || snaps[0].Host.Condition != model.HostConditionCritical || snaps[0].Host.Metrics != nil {
 		t.Fatalf("offline snapshot = %+v", snaps)
+	}
+	if len(snaps[0].Services) != 1 || snaps[0].Services[0].ExternalID != "qemu/101" ||
+		snaps[0].Services[0].Image != "" || snaps[0].Services[0].Health != model.HealthHealthy {
+		t.Fatalf("offline guest snapshot = %+v", snaps[0].Services)
 	}
 }
 

--- a/deploy/kubernetes/trove-agent.yaml
+++ b/deploy/kubernetes/trove-agent.yaml
@@ -1,7 +1,8 @@
 # Trove Kubernetes agent — in-cluster, strictly read-only.
 #
-# The ClusterRole grants only get/list on the workload and pod resources
-# the agent reads; it can never mutate anything. Trove is read-only by design.
+# The ClusterRole grants only get/list on the workload, pod, node, and optional
+# Metrics API resources the agent reads; it can never mutate anything. Trove
+# is read-only by design.
 #
 # Before applying:
 #   1. Create the token secret (get the token from `trove-server agent create`):
@@ -33,7 +34,10 @@ rules:
     resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/agents/docker.md
+++ b/docs/agents/docker.md
@@ -33,6 +33,18 @@ host (a LAN IP or hostname; `localhost` only if the server runs on this same
 box). The host and its containers appear on the dashboard within one push
 interval (30s by default).
 
+The host drawer also reports Docker daemon condition, logical CPUs, and the
+Linux kernel's CPU, load, memory, and uptime snapshot when the agent uses the
+local Unix socket (the default). These aggregate procfs values require no
+additional mount. Root-disk usage is intentionally omitted: inside the agent
+container, `/` is an overlay filesystem and presenting it as the host disk
+would be misleading.
+
+When `DOCKER_HOST` points to a remote daemon, the Docker API supplies logical
+CPU capacity but not live host usage. Trove labels that source as
+`capacity only (remote daemon)` rather than displaying metrics from the machine
+where the agent process happens to run.
+
 ## Configuration
 
 | Variable           | Default                       | Purpose                                            |

--- a/docs/agents/kubernetes.md
+++ b/docs/agents/kubernetes.md
@@ -49,7 +49,8 @@ kubectl apply -f trove-agent.yaml
 ```
 
 The manifest contains the ServiceAccount, a read-only ClusterRole
-(deployments/statefulsets/daemonsets/replicasets/pods; get/list only),
+(deployments/statefulsets/daemonsets/replicasets/pods/nodes and node metrics;
+get/list only),
 the binding, and the Deployment running
 `ghcr.io/techdox/trove-agent-k8s` as nonroot with a read-only filesystem. It
 also declares the `trove` namespace (harmless that step 2 created it too — we
@@ -66,7 +67,9 @@ cluster appears on the dashboard within ~30s. A `connection refused`/timeout
 means `TROVE_SERVER_URL` is wrong or unreachable from the cluster (see above); a
 `401` means the token in the Secret doesn't match the one minted in step 1.
 
-To upgrade the agent later: `kubectl -n trove rollout restart deploy/trove-agent`.
+To upgrade the agent later, re-apply the current manifest so image and read-only
+RBAC changes are both installed, then restart it:
+`kubectl apply -f trove-agent.yaml && kubectl -n trove rollout restart deploy/trove-agent`.
 
 ## Configuration
 
@@ -94,3 +97,12 @@ supported via `TROVE_KUBE_APISERVER`, `TROVE_KUBE_TOKEN`, `TROVE_KUBE_CA`, and
   reason (`OOMKilled`, exit code), falling back to the pod-level reason.
 - Pod image digests are captured, so image freshness works for cluster
   workloads just like containers.
+- The cluster host drawer rolls Kubernetes Node `Ready` conditions into one
+  condition: all ready is `normal`, a partially ready cluster is `warning`, and
+  no ready nodes is `critical`. It always reports node count and logical CPU
+  capacity when the node API is readable.
+- If [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) or
+  another `metrics.k8s.io` provider is installed, the drawer also shows
+  aggregate node CPU and memory usage. Metrics API is optional: without it,
+  workload discovery, node readiness, and capacity continue normally and the
+  drawer explains why usage is absent.

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -64,3 +64,9 @@ Each `.service` unit appears as a service with its systemd sub-state
 everything else is `unknown` health (systemd has no app-level healthcheck) with
 the state badge carrying the signal. By default only active/failed units are
 reported to keep the noise down — set `TROVE_LOCAL_ALL=true` for everything.
+
+Click **View host stats** to see current CPU, load average, memory, root-disk
+usage, uptime, logical CPU count, operating system, kernel, and architecture.
+The first report establishes the CPU counter baseline; current CPU usage appears
+from the next interval onward. All inputs are aggregate read-only procfs and
+filesystem-statistics reads—Trove does not inspect process contents.

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -156,8 +156,10 @@ agent reads it with `GET /api2/json/nodes/{node}/version` and stores it as host
 metadata (`proxmox.version`, `proxmox.release`, and `proxmox.repoid`) rather
 than repeating it on every VM/LXC.
 
-The same header shows the node's current CPU, load, memory, root-disk usage,
-and uptime. These come from the read-only
+The same header shows a compact snapshot of the node's current CPU, load,
+memory, root-disk usage, and uptime. Click **View host stats** on that host to
+open the full resource, condition, platform, inventory, and reporting details.
+These metrics come from the read-only
 `GET /api2/json/nodes/{node}/status` endpoint. Node availability remains a
 separate condition: `online` maps to `normal`, while an explicitly `offline`
 cluster member maps to `critical`. Trove does not treat a single high CPU or

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -169,6 +169,13 @@ After upgrading Trove, update and restart both the server and the Proxmox
 agent. An older agent can continue reporting its guests, but its reports do not
 contain the host condition or resource snapshot required by this view.
 
+For a branch preview, use the same branch tag for both images. For example,
+add `TROVE_VERSION=feat-host-health-metrics` to `.env`, then recreate both
+services with `docker compose -f docker-compose.proxmox.yml pull` followed by
+`docker compose -f docker-compose.proxmox.yml up -d`. The preview workflow
+stamps the branch and short commit SHA into each binary, which is shown as the
+agent version in Trove.
+
 If a node's status endpoint is temporarily unavailable, the rest of the
 cluster report is still sent and that host's metrics are cleared rather than
 leaving an old snapshot on screen. Offline nodes are still reported with their

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -165,6 +165,10 @@ separate condition: `online` maps to `normal`, while an explicitly `offline`
 cluster member maps to `critical`. Trove does not treat a single high CPU or
 memory sample as an alert-worthy failure.
 
+After upgrading Trove, update and restart both the server and the Proxmox
+agent. An older agent can continue reporting its guests, but its reports do not
+contain the host condition or resource snapshot required by this view.
+
 If a node's status endpoint is temporarily unavailable, the rest of the
 cluster report is still sent and that host's metrics are cleared rather than
 leaving an old snapshot on screen. Offline nodes are still reported with their

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -156,6 +156,19 @@ agent reads it with `GET /api2/json/nodes/{node}/version` and stores it as host
 metadata (`proxmox.version`, `proxmox.release`, and `proxmox.repoid`) rather
 than repeating it on every VM/LXC.
 
+The same header shows the node's current CPU, load, memory, root-disk usage,
+and uptime. These come from the read-only
+`GET /api2/json/nodes/{node}/status` endpoint. Node availability remains a
+separate condition: `online` maps to `normal`, while an explicitly `offline`
+cluster member maps to `critical`. Trove does not treat a single high CPU or
+memory sample as an alert-worthy failure.
+
+If a node's status endpoint is temporarily unavailable, the rest of the
+cluster report is still sent and that host's metrics are cleared rather than
+leaving an old snapshot on screen. Offline nodes are still reported with their
+critical condition, without repeatedly querying node-local endpoints that are
+expected to fail.
+
 Click a Proxmox guest in the dashboard to see its reported metrics: node, CPU,
 memory, disk, uptime, VMID, and OS type where available.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,40 @@ If OIDC is enabled, read APIs require either an authenticated dashboard session 
 
 By default, Trove returns all services grouped by agent and host for the dashboard. Reported hosts with no services are included with an empty `services` array so their liveness remains visible.
 
-Each host group includes its own derived `status` (`ok`, `stale`, `offline`, or `unknown`) and `last_seen_at`, plus `agent_status` for the owning agent. Host and agent status can differ when a multi-host agent continues reporting some hosts after another disappears.
+Each host group includes its own derived `status` (`ok`, `stale`, `offline`, or
+`unknown`) and `last_seen_at`, plus `agent_status` for the owning agent. Host
+and agent status can differ when a multi-host agent continues reporting some
+hosts after another disappears.
+
+`condition` is the platform's latest verdict (`normal`, `warning`, `critical`,
+or `unknown`). It is deliberately separate from reporting `status`: for
+example, a Proxmox agent can keep reporting normally while one cluster node is
+offline and therefore `critical`.
+
+`metrics` is the latest point-in-time resource snapshot reported for the host.
+Fields the platform cannot provide are omitted; an empty object means no host
+metrics are currently available. Trove stores only the latest snapshot and
+does not turn a brief resource spike into a health verdict.
+
+```json
+{
+  "agent": "proxmox",
+  "hostname": "pve-a",
+  "platform": "proxmox",
+  "status": "ok",
+  "condition": "normal",
+  "metrics": {
+    "cpu_usage_ratio": 0.125,
+    "cpu_logical_count": 16,
+    "load_1": 0.5,
+    "load_5": 0.25,
+    "load_15": 0.125,
+    "memory": { "used_bytes": 8589934592, "total_bytes": 34359738368 },
+    "root_disk": { "used_bytes": 42949672960, "total_bytes": 107374182400 },
+    "uptime_seconds": 90061
+  }
+}
+```
 
 Optional query parameters:
 
@@ -75,7 +108,7 @@ TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
   'https://trove.example/api/v1/events?kind=health&limit=50&offset=50'
 ```
 
-## Metrics
+## Prometheus metrics
 
 `GET /metrics` exposes Prometheus text format and is protected like the other read APIs when OIDC/API-token auth is enabled.
 

--- a/examples/docker-compose.proxmox.yml
+++ b/examples/docker-compose.proxmox.yml
@@ -1,5 +1,6 @@
 # Trove quickstart for Proxmox — the server plus a Proxmox agent that watches
 # your PVE cluster, using the published images. No cloning or building required.
+# Set TROVE_VERSION in .env to pin both services to one release or preview tag.
 #
 #   1. Create a read-only Proxmox API token (PVEAuditor role). See:
 #        https://github.com/techdox/trove/blob/main/docs/agents/proxmox.md
@@ -27,7 +28,7 @@
 
 services:
   server:
-    image: ghcr.io/techdox/trove-server:latest
+    image: ghcr.io/techdox/trove-server:${TROVE_VERSION:-latest}
     environment:
       TROVE_BOOTSTRAP_AGENT: "proxmox"
       TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
@@ -40,7 +41,7 @@ services:
   agent:
     # The Proxmox agent — NOT trove-agent-docker. It reads the PVE API only;
     # it needs no Docker socket.
-    image: ghcr.io/techdox/trove-agent-proxmox:latest
+    image: ghcr.io/techdox/trove-agent-proxmox:${TROVE_VERSION:-latest}
     environment:
       TROVE_SERVER_URL: "http://server:8080"
       TROVE_TOKEN: "${TROVE_TOKEN}"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,5 +1,6 @@
 # Trove quickstart — server + a Docker agent watching this host, using the
 # published images. No cloning or building required.
+# Set TROVE_VERSION in .env to pin both services to one release or preview tag.
 #
 #   1. Generate a token for this host's agent and save it to .env (Compose
 #      loads .env automatically, and it survives restarts/upgrades — an
@@ -19,7 +20,7 @@
 
 services:
   server:
-    image: ghcr.io/techdox/trove-server:latest
+    image: ghcr.io/techdox/trove-server:${TROVE_VERSION:-latest}
     environment:
       TROVE_BOOTSTRAP_AGENT: "docker-local"
       TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
@@ -30,7 +31,7 @@ services:
     restart: unless-stopped
 
   agent:
-    image: ghcr.io/techdox/trove-agent-docker:latest
+    image: ghcr.io/techdox/trove-agent-docker:${TROVE_VERSION:-latest}
     environment:
       TROVE_SERVER_URL: "http://server:8080"
       TROVE_TOKEN: "${TROVE_TOKEN}"

--- a/internal/hostmetrics/linux.go
+++ b/internal/hostmetrics/linux.go
@@ -1,0 +1,276 @@
+// Package hostmetrics collects read-only operating-system resource snapshots
+// shared by agents that run on the machine they report. It intentionally does
+// not inspect processes or files outside the small set of Linux virtual files
+// needed for aggregate host metrics.
+package hostmetrics
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+type cpuTimes struct {
+	total uint64
+	idle  uint64
+}
+
+// LinuxSampler reads aggregate metrics from procfs. CPU usage needs two
+// samples, so the first collection reports every other available metric and
+// establishes the baseline for the next interval.
+type LinuxSampler struct {
+	includeRootDisk bool
+	readFile        func(string) ([]byte, error)
+	diskUsage       func(string) (*model.HostResourceUsage, error)
+
+	mu       sync.Mutex
+	previous *cpuTimes
+}
+
+// NewLinuxSampler creates a sampler for the local Linux kernel. Root-disk
+// collection must be disabled inside ordinary containers because statfs("/")
+// describes their overlay filesystem, not the machine's root filesystem.
+func NewLinuxSampler(includeRootDisk bool) *LinuxSampler {
+	return &LinuxSampler{
+		includeRootDisk: includeRootDisk,
+		readFile:        os.ReadFile,
+		diskUsage:       statFSUsage,
+	}
+}
+
+// Collect returns every metric that could be read plus a joined diagnostic for
+// unavailable inputs. Callers should keep the partial snapshot and log the
+// error; one missing procfs file must not erase otherwise useful host data.
+func (s *LinuxSampler) Collect() (*model.HostMetrics, error) {
+	m := &model.HostMetrics{}
+	var errs []error
+	populated := false
+
+	if b, err := s.readFile("/proc/stat"); err != nil {
+		errs = append(errs, fmt.Errorf("cpu: %w", err))
+	} else if current, err := parseCPUTimes(b); err != nil {
+		errs = append(errs, fmt.Errorf("cpu: %w", err))
+	} else if ratio, ok := s.cpuRatio(current); ok {
+		m.CPUUsageRatio = &ratio
+		populated = true
+	}
+
+	if b, err := s.readFile("/proc/loadavg"); err != nil {
+		errs = append(errs, fmt.Errorf("load: %w", err))
+	} else if load1, load5, load15, err := parseLoadAverage(b); err != nil {
+		errs = append(errs, fmt.Errorf("load: %w", err))
+	} else {
+		m.Load1, m.Load5, m.Load15 = &load1, &load5, &load15
+		populated = true
+	}
+
+	if b, err := s.readFile("/proc/meminfo"); err != nil {
+		errs = append(errs, fmt.Errorf("memory: %w", err))
+	} else if memory, err := parseMemory(b); err != nil {
+		errs = append(errs, fmt.Errorf("memory: %w", err))
+	} else {
+		m.Memory = memory
+		populated = true
+	}
+
+	if b, err := s.readFile("/proc/uptime"); err != nil {
+		errs = append(errs, fmt.Errorf("uptime: %w", err))
+	} else if uptime, err := parseUptime(b); err != nil {
+		errs = append(errs, fmt.Errorf("uptime: %w", err))
+	} else {
+		m.UptimeSeconds = &uptime
+		populated = true
+	}
+
+	if s.includeRootDisk {
+		if usage, err := s.diskUsage("/"); err != nil {
+			errs = append(errs, fmt.Errorf("root disk: %w", err))
+		} else {
+			m.RootDisk = usage
+			populated = true
+		}
+	}
+
+	if !populated {
+		return nil, errors.Join(errs...)
+	}
+	return m, errors.Join(errs...)
+}
+
+// LinuxMetadata returns stable, non-sensitive platform facts for the host
+// details drawer. Missing files simply omit their fields.
+func LinuxMetadata() map[string]string {
+	meta := map[string]string{
+		"linux.arch": runtime.GOARCH,
+	}
+	if b, err := os.ReadFile("/proc/sys/kernel/osrelease"); err == nil {
+		if kernel := strings.TrimSpace(string(b)); kernel != "" {
+			meta["linux.kernel"] = kernel
+		}
+	}
+	if b, err := os.ReadFile("/etc/os-release"); err == nil {
+		if name := osReleaseName(b); name != "" {
+			meta["linux.os"] = name
+		}
+	}
+	return meta
+}
+
+func (s *LinuxSampler) cpuRatio(current cpuTimes) (float64, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous := s.previous
+	s.previous = &current
+	if previous == nil || current.total <= previous.total || current.idle < previous.idle {
+		return 0, false
+	}
+	totalDelta := current.total - previous.total
+	idleDelta := current.idle - previous.idle
+	if totalDelta == 0 || idleDelta > totalDelta {
+		return 0, false
+	}
+	return float64(totalDelta-idleDelta) / float64(totalDelta), true
+}
+
+func parseCPUTimes(b []byte) (cpuTimes, error) {
+	line, _, _ := strings.Cut(string(b), "\n")
+	fields := strings.Fields(line)
+	if len(fields) < 5 || fields[0] != "cpu" {
+		return cpuTimes{}, errors.New("missing aggregate cpu line")
+	}
+	values := make([]uint64, 0, len(fields)-1)
+	for _, field := range fields[1:] {
+		value, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return cpuTimes{}, fmt.Errorf("parse counter %q: %w", field, err)
+		}
+		values = append(values, value)
+	}
+	var total uint64
+	for _, value := range values {
+		if math.MaxUint64-total < value {
+			return cpuTimes{}, errors.New("counter overflow")
+		}
+		total += value
+	}
+	idle := values[3]
+	if len(values) > 4 {
+		idle += values[4] // iowait is idle time for utilization purposes
+	}
+	return cpuTimes{total: total, idle: idle}, nil
+}
+
+func parseLoadAverage(b []byte) (float64, float64, float64, error) {
+	fields := strings.Fields(string(b))
+	if len(fields) < 3 {
+		return 0, 0, 0, errors.New("expected three load averages")
+	}
+	values := [3]float64{}
+	for i := range values {
+		value, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil || math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+			return 0, 0, 0, fmt.Errorf("invalid load average %q", fields[i])
+		}
+		values[i] = value
+	}
+	return values[0], values[1], values[2], nil
+}
+
+func parseMemory(b []byte) (*model.HostResourceUsage, error) {
+	values := map[string]uint64{}
+	for _, line := range strings.Split(string(b), "\n") {
+		key, raw, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(raw)
+		if len(fields) == 0 {
+			continue
+		}
+		value, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		if len(fields) > 1 && strings.EqualFold(fields[1], "kB") {
+			if value > math.MaxUint64/1024 {
+				return nil, fmt.Errorf("%s overflows bytes", key)
+			}
+			value *= 1024
+		}
+		values[key] = value
+	}
+	total, ok := values["MemTotal"]
+	if !ok || total == 0 {
+		return nil, errors.New("MemTotal is missing or zero")
+	}
+	available, ok := values["MemAvailable"]
+	if !ok {
+		available = values["MemFree"] + values["Buffers"] + values["Cached"] + values["SReclaimable"]
+		if shmem := values["Shmem"]; shmem < available {
+			available -= shmem
+		}
+	}
+	if available > total {
+		return nil, errors.New("available memory exceeds total memory")
+	}
+	return &model.HostResourceUsage{UsedBytes: total - available, TotalBytes: total}, nil
+}
+
+func parseUptime(b []byte) (uint64, error) {
+	fields := strings.Fields(string(b))
+	if len(fields) == 0 {
+		return 0, errors.New("uptime is empty")
+	}
+	seconds, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || math.IsNaN(seconds) || math.IsInf(seconds, 0) || seconds < 0 || seconds > math.MaxUint64 {
+		return 0, fmt.Errorf("invalid uptime %q", fields[0])
+	}
+	return uint64(seconds), nil
+}
+
+func statFSUsage(path string) (*model.HostResourceUsage, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return nil, err
+	}
+	if stat.Bsize <= 0 {
+		return nil, errors.New("invalid filesystem block size")
+	}
+	blockSize := uint64(stat.Bsize)
+	blocks := uint64(stat.Blocks)
+	free := uint64(stat.Bfree)
+	if blocks == 0 || free > blocks || blocks > math.MaxUint64/blockSize {
+		return nil, errors.New("invalid filesystem counters")
+	}
+	return &model.HostResourceUsage{
+		UsedBytes:  (blocks - free) * blockSize,
+		TotalBytes: blocks * blockSize,
+	}, nil
+}
+
+func osReleaseName(b []byte) string {
+	values := map[string]string{}
+	for _, line := range strings.Split(string(b), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+		values[key] = value
+	}
+	if values["PRETTY_NAME"] != "" {
+		return values["PRETTY_NAME"]
+	}
+	return values["NAME"]
+}

--- a/internal/hostmetrics/linux_test.go
+++ b/internal/hostmetrics/linux_test.go
@@ -1,0 +1,83 @@
+package hostmetrics
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+func TestLinuxSamplerCollectsPartialThenIntervalCPU(t *testing.T) {
+	files := map[string][]byte{
+		"/proc/stat":    []byte("cpu  100 0 50 850 0 0 0 0\n"),
+		"/proc/loadavg": []byte("0.25 0.50 0.75 1/100 42\n"),
+		"/proc/meminfo": []byte("MemTotal: 1024 kB\nMemAvailable: 256 kB\n"),
+		"/proc/uptime":  []byte("90061.42 0.00\n"),
+	}
+	s := &LinuxSampler{
+		includeRootDisk: true,
+		readFile: func(path string) ([]byte, error) {
+			b, ok := files[path]
+			if !ok {
+				return nil, errors.New("not found")
+			}
+			return b, nil
+		},
+		diskUsage: func(string) (*model.HostResourceUsage, error) {
+			return &model.HostResourceUsage{UsedBytes: 40, TotalBytes: 100}, nil
+		},
+	}
+
+	first, err := s.Collect()
+	if err != nil {
+		t.Fatalf("first collect: %v", err)
+	}
+	if first.CPUUsageRatio != nil || first.Memory == nil || first.Memory.UsedBytes != 768*1024 ||
+		first.RootDisk == nil || first.UptimeSeconds == nil || *first.UptimeSeconds != 90061 ||
+		first.Load1 == nil || *first.Load1 != 0.25 {
+		t.Fatalf("first metrics = %+v", first)
+	}
+
+	files["/proc/stat"] = []byte("cpu  140 0 60 900 0 0 0 0\n")
+	second, err := s.Collect()
+	if err != nil {
+		t.Fatalf("second collect: %v", err)
+	}
+	if second.CPUUsageRatio == nil || math.Abs(*second.CPUUsageRatio-0.5) > 0.0001 {
+		t.Fatalf("cpu ratio = %v, want 0.5", second.CPUUsageRatio)
+	}
+}
+
+func TestLinuxSamplerKeepsPartialMetricsWithDiagnostics(t *testing.T) {
+	s := &LinuxSampler{
+		readFile: func(path string) ([]byte, error) {
+			if path == "/proc/loadavg" {
+				return []byte("1.00 2.00 3.00 1/1 1"), nil
+			}
+			return nil, errors.New("denied")
+		},
+	}
+	m, err := s.Collect()
+	if m == nil || m.Load1 == nil || *m.Load1 != 1 || err == nil {
+		t.Fatalf("partial collect = (%+v, %v)", m, err)
+	}
+}
+
+func TestParseMemoryFallsBackWithoutMemAvailable(t *testing.T) {
+	m, err := parseMemory([]byte("MemTotal: 1000 kB\nMemFree: 100 kB\nBuffers: 50 kB\nCached: 200 kB\nSReclaimable: 25 kB\nShmem: 10 kB\n"))
+	if err != nil {
+		t.Fatalf("parse memory: %v", err)
+	}
+	wantUsed := uint64(635 * 1024)
+	if m.UsedBytes != wantUsed || m.TotalBytes != 1000*1024 {
+		t.Fatalf("memory = %+v, want used %d", m, wantUsed)
+	}
+}
+
+func TestOSReleaseNamePrefersPrettyName(t *testing.T) {
+	b := []byte("NAME=Debian\nPRETTY_NAME=\"Debian GNU/Linux 12 (bookworm)\"\n")
+	if got := osReleaseName(b); got != "Debian GNU/Linux 12 (bookworm)" {
+		t.Fatalf("os name = %q", got)
+	}
+}

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -42,6 +42,8 @@ type hostGroupDTO struct {
 	Status      string          `json:"status"`
 	LastSeenAt  *string         `json:"last_seen_at"`
 	AgentStatus string          `json:"agent_status"`
+	Condition   string          `json:"condition"`
+	Metrics     json.RawMessage `json:"metrics"`
 	Meta        json.RawMessage `json:"meta"`
 	Services    []serviceDTO    `json:"services"`
 }
@@ -139,6 +141,8 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 				Status:      string(heartbeatStatus(host.LastSeenAt, host.AgentIntervalSeconds, now)),
 				LastSeenAt:  rfc3339Ptr(host.LastSeenAt),
 				AgentStatus: string(heartbeatStatus(host.AgentLastSeenAt, host.AgentIntervalSeconds, now)),
+				Condition:   host.Condition,
+				Metrics:     rawJSON(host.MetricsJSON, "{}"),
 				Meta:        rawJSON(host.MetaJSON, "{}"),
 				Services:    []serviceDTO{},
 			})
@@ -155,6 +159,8 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 				Status:      string(heartbeatStatus(row.HostLastSeenAt, row.AgentIntervalSeconds, now)),
 				LastSeenAt:  rfc3339Ptr(row.HostLastSeenAt),
 				AgentStatus: string(heartbeatStatus(row.AgentLastSeenAt, row.AgentIntervalSeconds, now)),
+				Condition:   row.HostCondition,
+				Metrics:     rawJSON(row.HostMetricsJSON, "{}"),
 				Meta:        rawJSON(row.HostMetaJSON, "{}"),
 				Services:    []serviceDTO{},
 			})

--- a/internal/server/read_test.go
+++ b/internal/server/read_test.go
@@ -26,9 +26,17 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	report := func(state string) *model.Report {
+		cpuUsage := 0.25
 		return &model.Report{
 			Agent: model.ReportAgent{Name: "docker-a", Platform: model.PlatformDocker, Version: "test"},
-			Host:  model.ReportHost{Hostname: "host-a"},
+			Host: model.ReportHost{
+				Hostname:  "host-a",
+				Condition: model.HostConditionNormal,
+				Metrics: &model.HostMetrics{
+					CPUUsageRatio: &cpuUsage,
+					Memory:        &model.HostResourceUsage{UsedBytes: 4, TotalBytes: 8},
+				},
+			},
 			Services: []model.ReportService{{
 				ExternalID: "container-1", Name: "web", Kind: model.KindContainer,
 				State: state, Health: model.HealthHealthy,
@@ -51,8 +59,10 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 	}
 	var services struct {
 		Hosts []struct {
-			Status     string  `json:"status"`
-			LastSeenAt *string `json:"last_seen_at"`
+			Status     string            `json:"status"`
+			LastSeenAt *string           `json:"last_seen_at"`
+			Condition  string            `json:"condition"`
+			Metrics    model.HostMetrics `json:"metrics"`
 			Services   []struct {
 				ID int64 `json:"id"`
 			} `json:"services"`
@@ -66,6 +76,10 @@ func TestReadAPIsExposeStableServiceIdentity(t *testing.T) {
 	}
 	if services.Hosts[0].Status != "ok" || services.Hosts[0].LastSeenAt == nil {
 		t.Fatalf("services response omitted host liveness: %+v", services.Hosts[0])
+	}
+	if services.Hosts[0].Condition != "normal" || services.Hosts[0].Metrics.CPUUsageRatio == nil ||
+		*services.Hosts[0].Metrics.CPUUsageRatio != 0.25 || services.Hosts[0].Metrics.Memory == nil {
+		t.Fatalf("services response omitted host condition/metrics: %+v", services.Hosts[0])
 	}
 	serviceID := services.Hosts[0].Services[0].ID
 

--- a/internal/store/hosts.go
+++ b/internal/store/hosts.go
@@ -13,6 +13,8 @@ type Host struct {
 	AgentID              int64
 	Hostname             string
 	MetaJSON             string
+	Condition            string
+	MetricsJSON          string
 	AgentName            string
 	AgentPlatform        string
 	AgentIntervalSeconds int
@@ -25,7 +27,8 @@ type Host struct {
 // Host status is derived by callers from LastSeenAt and that interval.
 func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT h.id, h.agent_id, h.hostname, h.platform_meta_json, h.last_seen_at, h.last_status,
+		SELECT h.id, h.agent_id, h.hostname, h.platform_meta_json, h.condition, h.metrics_json,
+		       h.last_seen_at, h.last_status,
 		       a.name, a.platform, a.report_interval_seconds, a.last_seen_at
 		  FROM hosts h
 		  JOIN agents a ON a.id = h.agent_id
@@ -39,7 +42,8 @@ func (s *Store) ListHosts(ctx context.Context) ([]Host, error) {
 	for rows.Next() {
 		var h Host
 		if err := rows.Scan(
-			&h.ID, &h.AgentID, &h.Hostname, &h.MetaJSON, &h.LastSeenAt, &h.LastStatus,
+			&h.ID, &h.AgentID, &h.Hostname, &h.MetaJSON, &h.Condition, &h.MetricsJSON,
+			&h.LastSeenAt, &h.LastStatus,
 			&h.AgentName, &h.AgentPlatform, &h.AgentIntervalSeconds, &h.AgentLastSeenAt,
 		); err != nil {
 			return nil, err

--- a/internal/store/ingest.go
+++ b/internal/store/ingest.go
@@ -54,12 +54,20 @@ func (s *Store) ApplyReport(ctx context.Context, agentID int64, r *model.Report)
 
 	// 2. Upsert host, resolve host_id.
 	metaJSON := mustJSONObject(r.Host.Meta)
+	metricsJSON := mustHostMetrics(r.Host.Metrics)
+	condition := r.Host.Condition
+	if condition == "" {
+		condition = model.HostConditionUnknown
+	}
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO hosts(agent_id, hostname, platform_meta_json, last_seen_at) VALUES (?, ?, ?, ?)
+		`INSERT INTO hosts(agent_id, hostname, platform_meta_json, condition, metrics_json, last_seen_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(agent_id, hostname) DO UPDATE SET
 		     platform_meta_json = excluded.platform_meta_json,
+		     condition = excluded.condition,
+		     metrics_json = excluded.metrics_json,
 		     last_seen_at = excluded.last_seen_at`,
-		agentID, r.Host.Hostname, metaJSON, now,
+		agentID, r.Host.Hostname, metaJSON, string(condition), metricsJSON, now,
 	); err != nil {
 		return fmt.Errorf("upsert host: %w", err)
 	}
@@ -230,6 +238,20 @@ func insertEvent(ctx context.Context, tx *sql.Tx, kind string, serviceID int64, 
 // literal ("{}" when empty) so the column never holds SQL NULL or "null".
 func mustJSONObject(m map[string]string) string {
 	if len(m) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// mustHostMetrics marshals the typed host snapshot to a JSON object. A missing
+// snapshot clears previously reported metrics, rather than leaving stale
+// values that the current report no longer supports.
+func mustHostMetrics(m *model.HostMetrics) string {
+	if m == nil {
 		return "{}"
 	}
 	b, err := json.Marshal(m)

--- a/internal/store/migrations/0009_host_metrics.sql
+++ b/internal/store/migrations/0009_host_metrics.sql
@@ -1,0 +1,6 @@
+-- Persist the latest platform-reported host condition and resource snapshot.
+-- Heartbeat status remains server-derived from last_seen_at; condition is a
+-- separate platform verdict and metrics are informational point-in-time data.
+
+ALTER TABLE hosts ADD COLUMN condition TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE hosts ADD COLUMN metrics_json TEXT NOT NULL DEFAULT '{}';

--- a/internal/store/migrations_test.go
+++ b/internal/store/migrations_test.go
@@ -66,8 +66,10 @@ func TestHostLivenessMigrationBackfillsExistingHosts(t *testing.T) {
 
 	var got sql.NullInt64
 	var status string
+	var condition, metricsJSON string
 	if err := st.DB().QueryRowContext(ctx,
-		`SELECT last_seen_at, last_status FROM hosts WHERE hostname = 'node-a'`).Scan(&got, &status); err != nil {
+		`SELECT last_seen_at, last_status, condition, metrics_json FROM hosts WHERE hostname = 'node-a'`).
+		Scan(&got, &status, &condition, &metricsJSON); err != nil {
 		t.Fatalf("read migrated host heartbeat: %v", err)
 	}
 	if !got.Valid || got.Int64 != lastSeen {
@@ -75,5 +77,8 @@ func TestHostLivenessMigrationBackfillsExistingHosts(t *testing.T) {
 	}
 	if status != "ok" {
 		t.Fatalf("migrated last_status = %q, want ok", status)
+	}
+	if condition != "unknown" || metricsJSON != "{}" {
+		t.Fatalf("migrated host condition/metrics = %q/%q, want unknown/{}", condition, metricsJSON)
 	}
 }

--- a/internal/store/queries.go
+++ b/internal/store/queries.go
@@ -26,10 +26,12 @@ type ServiceRow struct {
 	LastSeenAt   int64
 	UpdatedAt    int64
 
-	HostID         int64
-	Hostname       string
-	HostMetaJSON   string
-	HostLastSeenAt sql.NullInt64
+	HostID          int64
+	Hostname        string
+	HostMetaJSON    string
+	HostCondition   string
+	HostMetricsJSON string
+	HostLastSeenAt  sql.NullInt64
 
 	AgentID              int64
 	AgentName            string
@@ -101,7 +103,7 @@ func (s *Store) ListServicesPage(ctx context.Context, opts ServiceListOptions) (
 		SELECT s.id, s.external_id, s.name, s.kind, s.image, s.image_digest, s.state, s.health,
 		       s.health_detail,
 		       s.ports_json, s.labels_json, s.first_seen_at, s.last_seen_at, s.updated_at,
-		       h.id, h.hostname, h.platform_meta_json, h.last_seen_at,
+		       h.id, h.hostname, h.platform_meta_json, h.condition, h.metrics_json, h.last_seen_at,
 		       a.id, a.name, a.platform, a.report_interval_seconds, a.last_seen_at,
 		       p.external_id AS parent_external_id,
 		       c.latest_digest, c.status, c.checked_at
@@ -140,7 +142,7 @@ func (s *Store) ListServicesPage(ctx context.Context, opts ServiceListOptions) (
 			&r.ID, &r.ExternalID, &r.Name, &r.Kind, &r.Image, &r.ImageDigest, &r.State, &r.Health,
 			&r.HealthDetail,
 			&r.PortsJSON, &r.LabelsJSON, &r.FirstSeenAt, &r.LastSeenAt, &r.UpdatedAt,
-			&r.HostID, &r.Hostname, &r.HostMetaJSON, &r.HostLastSeenAt,
+			&r.HostID, &r.Hostname, &r.HostMetaJSON, &r.HostCondition, &r.HostMetricsJSON, &r.HostLastSeenAt,
 			&r.AgentID, &r.AgentName, &r.AgentPlatform, &r.AgentIntervalSeconds, &r.AgentLastSeenAt,
 			&r.ParentExternalID,
 			&r.LatestDigest, &r.FreshnessStatus, &r.FreshnessCheckedAt,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -37,6 +38,8 @@ func svc(id, state string, health model.Health) model.ReportService {
 		Image: "img/" + id + ":1", State: state, Health: health,
 	}
 }
+
+func pointer[T any](v T) *T { return &v }
 
 func TestImagesDueForCheckRequiresRunningDigest(t *testing.T) {
 	st, _ := newTestStore(t)
@@ -153,6 +156,52 @@ func TestApplyReportUpsertAndEvents(t *testing.T) {
 	// Denormalized display context survives without joins.
 	if evs[0].Service != "c1" || evs[0].Hostname != "host-a" || evs[0].Agent != "docker-a" {
 		t.Fatalf("event context = %q@%q by %q, want c1@host-a by docker-a", evs[0].Service, evs[0].Hostname, evs[0].Agent)
+	}
+}
+
+func TestApplyReportReplacesHostConditionAndMetrics(t *testing.T) {
+	st, clock := newTestStore(t)
+	ctx := context.Background()
+	_, agent, _ := st.CreateAgent(ctx, "proxmox-a")
+
+	first := report()
+	first.Agent.Platform = model.PlatformProxmox
+	first.Host.Condition = model.HostConditionWarning
+	first.Host.Metrics = &model.HostMetrics{
+		CPUUsageRatio: pointer(0.25),
+		Memory:        &model.HostResourceUsage{UsedBytes: 4, TotalBytes: 8},
+	}
+	if err := st.ApplyReport(ctx, agent.ID, first); err != nil {
+		t.Fatalf("apply metrics: %v", err)
+	}
+
+	hosts, err := st.ListHosts(ctx)
+	if err != nil || len(hosts) != 1 {
+		t.Fatalf("list hosts: hosts=%+v err=%v", hosts, err)
+	}
+	if hosts[0].Condition != string(model.HostConditionWarning) {
+		t.Fatalf("condition = %q, want warning", hosts[0].Condition)
+	}
+	var got model.HostMetrics
+	if err := json.Unmarshal([]byte(hosts[0].MetricsJSON), &got); err != nil {
+		t.Fatalf("decode metrics: %v", err)
+	}
+	if got.CPUUsageRatio == nil || *got.CPUUsageRatio != 0.25 || got.Memory == nil || got.Memory.TotalBytes != 8 {
+		t.Fatalf("stored metrics = %+v", got)
+	}
+
+	*clock = clock.Add(30 * time.Second)
+	second := report()
+	second.Agent.Platform = model.PlatformProxmox
+	if err := st.ApplyReport(ctx, agent.ID, second); err != nil {
+		t.Fatalf("clear metrics: %v", err)
+	}
+	hosts, err = st.ListHosts(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts[0].Condition != string(model.HostConditionUnknown) || hosts[0].MetricsJSON != "{}" {
+		t.Fatalf("cleared host = condition %q metrics %q", hosts[0].Condition, hosts[0].MetricsJSON)
 	}
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -7,6 +7,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -111,12 +112,61 @@ type ReportAgent struct {
 	IntervalSeconds int `json:"interval_seconds,omitempty"`
 }
 
+// HostCondition is the platform-reported condition of a host. It is separate
+// from the server-derived heartbeat status: a host can be reporting on time
+// while its platform says it is degraded, or stop reporting while its last
+// known platform condition was normal.
+type HostCondition string
+
+const (
+	HostConditionNormal   HostCondition = "normal"
+	HostConditionWarning  HostCondition = "warning"
+	HostConditionCritical HostCondition = "critical"
+	HostConditionUnknown  HostCondition = "unknown"
+)
+
+// Valid reports whether c is a recognized platform condition.
+func (c HostCondition) Valid() bool {
+	switch c {
+	case HostConditionNormal, HostConditionWarning, HostConditionCritical, HostConditionUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+// HostResourceUsage is a current used/total capacity sample. It deliberately
+// carries bytes rather than a percentage so API clients can choose their own
+// display precision without losing the original values.
+type HostResourceUsage struct {
+	UsedBytes  uint64 `json:"used_bytes"`
+	TotalBytes uint64 `json:"total_bytes"`
+}
+
+// HostMetrics is a current point-in-time resource snapshot. Pointer scalars
+// preserve the difference between a real zero (for example an idle CPU) and a
+// metric the platform did not provide. Trove stores only the latest snapshot;
+// it is not intended to replace a time-series monitoring system.
+type HostMetrics struct {
+	CPUUsageRatio   *float64           `json:"cpu_usage_ratio,omitempty"`
+	CPULogicalCount *int               `json:"cpu_logical_count,omitempty"`
+	Load1           *float64           `json:"load_1,omitempty"`
+	Load5           *float64           `json:"load_5,omitempty"`
+	Load15          *float64           `json:"load_15,omitempty"`
+	Memory          *HostResourceUsage `json:"memory,omitempty"`
+	RootDisk        *HostResourceUsage `json:"root_disk,omitempty"`
+	UptimeSeconds   *uint64            `json:"uptime_seconds,omitempty"`
+}
+
 // ReportHost describes the machine the agent runs on. Meta carries
 // platform-specific facts (e.g. docker.version) that are useful to surface but
-// not worth first-class columns.
+// not worth first-class columns. Condition and Metrics are typed because they
+// have shared meaning across platforms and are rendered consistently.
 type ReportHost struct {
-	Hostname string            `json:"hostname"`
-	Meta     map[string]string `json:"meta,omitempty"`
+	Hostname  string            `json:"hostname"`
+	Condition HostCondition     `json:"condition,omitempty"`
+	Metrics   *HostMetrics      `json:"metrics,omitempty"`
+	Meta      map[string]string `json:"meta,omitempty"`
 }
 
 // ReportService is one catalog entry: a container now, a pod/vm/lxc later.
@@ -167,6 +217,12 @@ func (r *Report) Validate() error {
 	if strings.TrimSpace(r.Host.Hostname) == "" {
 		return errors.New("host.hostname is required")
 	}
+	if r.Host.Condition != "" && !r.Host.Condition.Valid() {
+		return fmt.Errorf("host.condition %q is not a recognized condition", r.Host.Condition)
+	}
+	if err := validateHostMetrics(r.Host.Metrics); err != nil {
+		return err
+	}
 	seen := make(map[string]struct{}, len(r.Services))
 	for i, s := range r.Services {
 		if strings.TrimSpace(s.ExternalID) == "" {
@@ -188,6 +244,54 @@ func (r *Report) Validate() error {
 		if !s.Health.Valid() {
 			return fmt.Errorf("services[%d].health %q is not an agent-reportable health value", i, s.Health)
 		}
+	}
+	return nil
+}
+
+func validateHostMetrics(m *HostMetrics) error {
+	if m == nil {
+		return nil
+	}
+	if m.CPUUsageRatio != nil {
+		v := *m.CPUUsageRatio
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 || v > 1 {
+			return errors.New("host.metrics.cpu_usage_ratio must be a finite value between 0 and 1")
+		}
+	}
+	if m.CPULogicalCount != nil && *m.CPULogicalCount < 1 {
+		return errors.New("host.metrics.cpu_logical_count must be positive")
+	}
+	if err := validateNonNegativeMetric("load_1", m.Load1); err != nil {
+		return err
+	}
+	if err := validateNonNegativeMetric("load_5", m.Load5); err != nil {
+		return err
+	}
+	if err := validateNonNegativeMetric("load_15", m.Load15); err != nil {
+		return err
+	}
+	if err := validateResourceUsage("memory", m.Memory); err != nil {
+		return err
+	}
+	return validateResourceUsage("root_disk", m.RootDisk)
+}
+
+func validateNonNegativeMetric(name string, value *float64) error {
+	if value != nil && (math.IsNaN(*value) || math.IsInf(*value, 0) || *value < 0) {
+		return fmt.Errorf("host.metrics.%s must be a finite non-negative value", name)
+	}
+	return nil
+}
+
+func validateResourceUsage(name string, usage *HostResourceUsage) error {
+	if usage == nil {
+		return nil
+	}
+	if usage.TotalBytes == 0 {
+		return fmt.Errorf("host.metrics.%s.total_bytes must be positive", name)
+	}
+	if usage.UsedBytes > usage.TotalBytes {
+		return fmt.Errorf("host.metrics.%s.used_bytes must not exceed total_bytes", name)
 	}
 	return nil
 }

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -1,6 +1,10 @@
 package model
 
-import "testing"
+import (
+	"math"
+	"strings"
+	"testing"
+)
 
 func baseReport() *Report {
 	return &Report{
@@ -25,6 +29,28 @@ func TestReportValidate(t *testing.T) {
 		{"missing agent name", func(r *Report) { r.Agent.Name = "" }},
 		{"missing platform", func(r *Report) { r.Agent.Platform = "" }},
 		{"missing hostname", func(r *Report) { r.Host.Hostname = "" }},
+		{"bad host condition", func(r *Report) { r.Host.Condition = "busy" }},
+		{"cpu ratio below zero", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{CPUUsageRatio: pointer(-0.1)}
+		}},
+		{"cpu ratio above one", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{CPUUsageRatio: pointer(1.1)}
+		}},
+		{"cpu ratio nan", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{CPUUsageRatio: pointer(math.NaN())}
+		}},
+		{"zero logical CPUs", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{CPULogicalCount: pointer(0)}
+		}},
+		{"negative load", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{Load1: pointer(-0.1)}
+		}},
+		{"memory without capacity", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{Memory: &HostResourceUsage{}}
+		}},
+		{"memory used above capacity", func(r *Report) {
+			r.Host.Metrics = &HostMetrics{Memory: &HostResourceUsage{UsedBytes: 11, TotalBytes: 10}}
+		}},
 		{"missing external id", func(r *Report) { r.Services[0].ExternalID = "" }},
 		{"bad kind", func(r *Report) { r.Services[0].Kind = "widget" }},
 		{"missing service state", func(r *Report) { r.Services[0].State = " 	" }},
@@ -45,6 +71,33 @@ func TestReportValidate(t *testing.T) {
 	}
 }
 
+func TestReportValidateAcceptsHostConditionAndMetrics(t *testing.T) {
+	r := baseReport()
+	r.Host.Condition = HostConditionNormal
+	r.Host.Metrics = &HostMetrics{
+		CPUUsageRatio:   pointer(0.0),
+		CPULogicalCount: pointer(8),
+		Load1:           pointer(0.0),
+		Load5:           pointer(0.25),
+		Load15:          pointer(0.5),
+		Memory:          &HostResourceUsage{UsedBytes: 0, TotalBytes: 16 * 1024},
+		RootDisk:        &HostResourceUsage{UsedBytes: 80, TotalBytes: 100},
+		UptimeSeconds:   pointer(uint64(0)),
+	}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("valid host metrics rejected: %v", err)
+	}
+}
+
+func TestHostMetricsValidationErrorNamesField(t *testing.T) {
+	r := baseReport()
+	r.Host.Metrics = &HostMetrics{RootDisk: &HostResourceUsage{UsedBytes: 2, TotalBytes: 1}}
+	err := r.Validate()
+	if err == nil || !strings.Contains(err.Error(), "host.metrics.root_disk.used_bytes") {
+		t.Fatalf("validation error = %v, want root_disk field path", err)
+	}
+}
+
 func TestHealthValid(t *testing.T) {
 	for _, h := range []Health{HealthHealthy, HealthUnhealthy, HealthUnknown} {
 		if !h.Valid() {
@@ -55,3 +108,18 @@ func TestHealthValid(t *testing.T) {
 		t.Error("stale is server-derived and must not be agent-reportable")
 	}
 }
+
+func TestHostConditionValid(t *testing.T) {
+	for _, condition := range []HostCondition{
+		HostConditionNormal, HostConditionWarning, HostConditionCritical, HostConditionUnknown,
+	} {
+		if !condition.Valid() {
+			t.Errorf("%q should be a valid host condition", condition)
+		}
+	}
+	if HostCondition("busy").Valid() {
+		t.Error("unrecognized host condition must be rejected")
+	}
+}
+
+func pointer[T any](v T) *T { return &v }

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -152,14 +152,36 @@ func TestDashboardShowsIndependentHostLiveness(t *testing.T) {
 		`if (h.status === "offline" && h.agent_status !== "offline") c.offlineHosts++;`,
 		`item("offline-hosts"`,
 		`item("stale-hosts"`,
-		`if (key === "offline-hosts" || key === "stale-hosts") {`,
+		`["offline-hosts", "stale-hosts", "critical-hosts", "warning-hosts"].includes(key)`,
 		"last report ${esc(relTime(h.last_seen_at))}",
-		"`host ${st}`",
+		"`reporting ${st}`",
 		`case "host":`,
 		`e.kind === "agent" || e.kind === "host"`,
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard host liveness is missing %q", marker)
+		}
+	}
+}
+
+func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
+	t.Parallel()
+
+	app, err := fs.ReadFile(FS(), "app.js")
+	if err != nil {
+		t.Fatalf("read embedded app: %v", err)
+	}
+
+	for _, marker := range []string{
+		"function hostMetricItems(metrics)",
+		"function hostMetricsHTML(metrics)",
+		`item("critical-hosts"`,
+		`item("warning-hosts"`,
+		"`condition ${condition}`",
+		"hostMetricsHTML(h.metrics)",
+	} {
+		if !strings.Contains(string(app), marker) {
+			t.Errorf("dashboard host metrics are missing %q", marker)
 		}
 	}
 }

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -211,3 +211,31 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 		}
 	}
 }
+
+func TestDashboardHostNavigationAndPlatformMarks(t *testing.T) {
+	t.Parallel()
+
+	app, err := fs.ReadFile(FS(), "app.js")
+	if err != nil {
+		t.Fatalf("read embedded app: %v", err)
+	}
+
+	for _, marker := range []string{
+		"function platformIdentity(platform)",
+		"function platformIconHTML(platform)",
+		"function openAgentDestination(name)",
+		"function openHostDrawerFromAgent(key, returnAgent)",
+		`data-agent-destination="${esc(a.name)}"`,
+		`class="host-name" data-host-details`,
+		`openHostDrawerFromAgent(hostKey(hosts[0]), name)`,
+		`state.q = name;`,
+		`case "docker":`,
+		`case "proxmox":`,
+		`case "kubernetes":`,
+		`case "linux":`,
+	} {
+		if !strings.Contains(string(app), marker) {
+			t.Errorf("dashboard host navigation is missing %q", marker)
+		}
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -174,11 +174,18 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 
 	for _, marker := range []string{
 		"function hostMetricItems(metrics)",
+		"function hostMetricRows(metrics)",
 		"function hostMetricsHTML(metrics)",
+		"function findHost(key)",
+		"function hostMetaLabel(key)",
+		"function openHostDrawer(key)",
 		`item("critical-hosts"`,
 		`item("warning-hosts"`,
 		"`condition ${condition}`",
 		"hostMetricsHTML(h.metrics)",
+		"data-host-details",
+		"View host stats",
+		"state.drawerKey || state.hostDrawerKey",
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard host metrics are missing %q", marker)

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -239,3 +239,30 @@ func TestDashboardHostNavigationAndPlatformMarks(t *testing.T) {
 		}
 	}
 }
+
+func TestDashboardEnterShortcutDefersToNativeControls(t *testing.T) {
+	t.Parallel()
+
+	app, err := fs.ReadFile(FS(), "app.js")
+	if err != nil {
+		t.Fatalf("read embedded app: %v", err)
+	}
+
+	source := string(app)
+	enter := strings.Index(source, `if (e.key === "Enter") {`)
+	if enter == -1 {
+		t.Fatal("dashboard Enter shortcut is missing")
+	}
+	shortcut := source[enter:]
+	guard := strings.Index(shortcut, `if (e.target.closest?.("button, a, [role='button'], [role='link']")) return;`)
+	fallback := strings.Index(shortcut, `if (state.cursorKey) openDrawer(state.cursorKey);`)
+	if guard == -1 {
+		t.Fatal("dashboard Enter shortcut does not defer to native controls")
+	}
+	if fallback == -1 {
+		t.Fatal("dashboard Enter shortcut cursor fallback is missing")
+	}
+	if guard > fallback {
+		t.Fatal("dashboard Enter shortcut checks the stale row cursor before native controls")
+	}
+}

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -180,6 +180,8 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 		"function findHost(key)",
 		"function findAgent(name)",
 		"function hostMetaLabel(key)",
+		"function hostMetricsNoticeHTML(host)",
+		"function agentVersionLabel(version)",
 		"function missingHostMetricsHTML(host, agent)",
 		"function openHostDrawer(key)",
 		`item("critical-hosts"`,
@@ -190,6 +192,8 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 		"View host stats",
 		"No host metrics reported",
 		"agent version",
+		"docker.host_metrics",
+		"kubernetes.metrics_api",
 		"state.drawerKey || state.hostDrawerKey",
 	} {
 		if !strings.Contains(string(app), marker) {

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -57,6 +57,7 @@ func TestDashboardAttentionHierarchyIsEmbedded(t *testing.T) {
 			t.Errorf("dashboard focus target is missing %q", marker)
 		}
 	}
+
 }
 
 func TestDashboardBrandAssetsAreEmbedded(t *testing.T) {
@@ -177,7 +178,9 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 		"function hostMetricRows(metrics)",
 		"function hostMetricsHTML(metrics)",
 		"function findHost(key)",
+		"function findAgent(name)",
 		"function hostMetaLabel(key)",
+		"function missingHostMetricsHTML(host, agent)",
 		"function openHostDrawer(key)",
 		`item("critical-hosts"`,
 		`item("warning-hosts"`,
@@ -185,10 +188,22 @@ func TestDashboardShowsHostConditionAndMetrics(t *testing.T) {
 		"hostMetricsHTML(h.metrics)",
 		"data-host-details",
 		"View host stats",
+		"No host metrics reported",
+		"agent version",
 		"state.drawerKey || state.hostDrawerKey",
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard host metrics are missing %q", marker)
+		}
+	}
+
+	for _, duplicate := range []string{
+		`<span class="d-detail-label">Snapshot</span>`,
+		"No host resource metrics were included in the latest report.",
+		"Waiting for a compatible agent to report CPU, load, memory, disk, and uptime.",
+	} {
+		if strings.Contains(string(app), duplicate) {
+			t.Errorf("dashboard host drawer repeats its metrics state with %q", duplicate)
 		}
 	}
 }

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1252,7 +1252,9 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "j" || e.key === "ArrowDown") { e.preventDefault(); moveCursor(1); return; }
   if (e.key === "k" || e.key === "ArrowUp") { e.preventDefault(); moveCursor(-1); return; }
   if (e.key === "Enter") {
-    if (e.target.closest?.(".host-toggle, .host-details")) return;
+    // Native controls own Enter. Let their click behavior run instead of
+    // opening a service left behind by the j/k row cursor.
+    if (e.target.closest?.("button, a, [role='button'], [role='link']")) return;
     const focused = document.activeElement?.closest?.("#hosts tr[data-ext]");
     if (focused) { openDrawer(rowKey(focused)); return; }
     if (state.cursorKey) openDrawer(state.cursorKey);

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -21,6 +21,7 @@ const state = {
   collapsed: new Set(),  // collapsed host keys
   drawerKey: null,       // key of the service open in the drawer
   hostDrawerKey: null,   // key of the host open in the drawer
+  hostDrawerReturnAgent: null, // agent card to refocus when it opened a host
   cursorKey: null,       // key of the keyboard-cursor row
   data: { services: null, agents: null, events: null },
 };
@@ -80,6 +81,45 @@ function absTime(iso) {
 function agentVersionLabel(version) {
   if (!version) return "";
   return /^\d/.test(version) ? `v${version}` : version;
+}
+
+function platformIdentity(platform) {
+  switch (String(platform || "").toLowerCase()) {
+    case "docker": return { key: "docker", label: "Docker" };
+    case "proxmox":
+    case "pve": return { key: "proxmox", label: "Proxmox VE" };
+    case "kubernetes":
+    case "k8s": return { key: "kubernetes", label: "Kubernetes" };
+    case "local":
+    case "linux":
+    case "systemd": return { key: "linux", label: "Linux" };
+    default: return { key: "unknown", label: platform || "Unknown platform" };
+  }
+}
+
+// Small inline marks keep the dashboard self-contained while making each
+// platform immediately scannable. The SVGs are decorative because the nearby
+// platform text and host/agent name carry the accessible label.
+function platformIconHTML(platform) {
+  const identity = platformIdentity(platform);
+  let art;
+  switch (identity.key) {
+    case "docker":
+      art = `<path d="M3 9h3v3H3zm4 0h3v3H7zm4 0h3v3h-3zM7 5h3v3H7zm4 0h3v3h-3zm4 4h3v3h-3z"/><path d="M2 13h15.3c.9 0 1.7-.2 2.3-.5-.2-1.1.1-2 .9-2.8.4-.4.8-.6 1.3-.8.5 1 .6 2.1.2 3.1.7.1 1.4.3 2 .8-.7.9-1.7 1.3-2.9 1.3h-.7C19.2 18 16 20 10.9 20 6.3 20 3.3 17.7 2 13z"/>`;
+      break;
+    case "proxmox":
+      art = `<path d="M1.5 5.2h4.2l6.3 6.7-6.3 6.9H1.5l6.4-6.9z"/><path d="M22.5 5.2h-4.2L12 11.9l6.3 6.9h4.2l-6.4-6.9z" opacity=".72"/>`;
+      break;
+    case "kubernetes":
+      art = `<path d="M12 2.2 20.4 7v10L12 21.8 3.6 17V7z" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="12" cy="12" r="2.4" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="M12 5.8v3.7m0 5v3.7M5.8 12h3.7m5 0h3.7M7.6 7.6l2.6 2.6m3.6 3.6 2.6 2.6m0-8.8-2.6 2.6m-3.6 3.6-2.6 2.6" fill="none" stroke="currentColor" stroke-width="1.65" stroke-linecap="round"/>`;
+      break;
+    case "linux":
+      art = `<rect x="2.5" y="4" width="19" height="16" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/><path d="m6.5 9 3 3-3 3m6 0h5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>`;
+      break;
+    default:
+      art = `<rect x="3" y="4" width="18" height="6" rx="2" fill="none" stroke="currentColor" stroke-width="1.8"/><rect x="3" y="14" width="18" height="6" rx="2" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="7" cy="7" r="1"/><circle cx="7" cy="17" r="1"/>`;
+  }
+  return `<span class="platform-mark platform-${identity.key}" title="${esc(identity.label)}"><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">${art}</svg></span>`;
 }
 
 // ---------------------------------------------------------- badge maps ----
@@ -526,14 +566,19 @@ function renderAgents() {
   }
   el.innerHTML = agents.map((a) => {
     const st = a.status || "unknown";
-    return `<div class="agent-card ${esc(st)}">
+    const hosts = (state.data.services?.hosts || []).filter((host) => host.agent === a.name);
+    const destination = hosts.length === 1 ? "Open host"
+      : (hosts.length > 1 ? `Filter ${hosts.length} hosts` : "Filter catalogue");
+    const ariaLabel = hosts.length === 1 ? `View host ${hosts[0].hostname} reported by ${a.name}`
+      : (hosts.length > 1 ? `Show ${hosts.length} hosts reported by ${a.name}` : `Filter catalogue by agent ${a.name}`);
+    return `<button type="button" class="agent-card ${esc(st)}" data-agent-destination="${esc(a.name)}" aria-label="${esc(ariaLabel)}">
       <div class="row">
-        <span class="name">${esc(a.name)}</span>
+        <span class="agent-identity">${platformIconHTML(a.platform)}<span class="name">${esc(a.name)}</span></span>
         ${badge(AGENT_CLASS[st] || "b-gray", st)}
       </div>
       <div class="meta">${esc(a.platform || "—")}${a.version ? " · " + esc(agentVersionLabel(a.version)) : ""}</div>
-      <div class="meta">last push: ${esc(relTime(a.last_seen_at))}</div>
-    </div>`;
+      <div class="agent-foot"><span class="meta">last push: ${esc(relTime(a.last_seen_at))}</span><span class="agent-action">${esc(destination)} <span aria-hidden="true">→</span></span></div>
+    </button>`;
   }).join("");
 }
 
@@ -616,9 +661,11 @@ function renderHosts() {
 
     sections.push(`<div class="host${collapsed ? " collapsed" : ""}" data-hostkey="${esc(hostKey(h))}">
       <div class="host-head">
-        <button type="button" class="host-toggle" data-host-toggle aria-expanded="${!collapsed}" aria-label="${collapsed ? "Expand" : "Collapse"} ${esc(h.hostname)} services">
+        <button type="button" class="host-toggle" data-host-toggle aria-expanded="${!collapsed}" aria-label="${collapsed ? "Expand" : "Collapse"} ${esc(h.hostname)} services" title="${collapsed ? "Expand" : "Collapse"} services">
           <span class="chev" aria-hidden="true">${collapsed ? "▸" : "▾"}</span>
-          <span class="hostname">${esc(h.hostname)}</span>
+        </button>
+        <button type="button" class="host-name" data-host-details data-hostkey="${esc(hostKey(h))}" aria-label="View ${esc(h.hostname)} host stats">
+          ${platformIconHTML(h.platform)}<span class="hostname">${esc(h.hostname)}</span>
         </button>
         <span class="sub">${esc(hostPlatformLine(h))}</span>
         <span class="sub">last report ${esc(relTime(h.last_seen_at))}</span>
@@ -872,6 +919,7 @@ function renderDrawer() {
       return;
     }
     state.hostDrawerKey = null;
+    state.hostDrawerReturnAgent = null;
   }
   if (!state.drawerKey) {
     el.hidden = true;
@@ -982,6 +1030,7 @@ function moveCursor(delta) {
 
 function openDrawer(key) {
   state.hostDrawerKey = null;
+  state.hostDrawerReturnAgent = null;
   state.drawerKey = key;
   state.cursorKey = key;
   render();
@@ -989,19 +1038,53 @@ function openDrawer(key) {
 }
 
 function openHostDrawer(key) {
+  openHostDrawerFromAgent(key, null);
+}
+
+function openHostDrawerFromAgent(key, returnAgent) {
   state.drawerKey = null;
   state.hostDrawerKey = key;
+  state.hostDrawerReturnAgent = returnAgent;
   render();
   requestAnimationFrame(() => document.querySelector(".d-close")?.focus({ preventScroll: true }));
+}
+
+function openAgentDestination(name) {
+  const hosts = (state.data.services?.hosts || []).filter((host) => host.agent === name);
+  if (hosts.length === 1) {
+    openHostDrawerFromAgent(hostKey(hosts[0]), name);
+    return;
+  }
+
+  state.q = name;
+  $("q").value = name;
+  state.chips.clear();
+  state.showRemoved = false;
+  state.removedOnly = false;
+  state.drawerKey = null;
+  state.hostDrawerKey = null;
+  state.hostDrawerReturnAgent = null;
+  render();
+  requestAnimationFrame(() => {
+    $("inventory-title")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    focusInvestigationTarget("inventory-title");
+  });
 }
 
 function closeDrawer() {
   const serviceKey = state.drawerKey;
   const hostKeyToRestore = state.hostDrawerKey;
+  const agentToRestore = state.hostDrawerReturnAgent;
   state.drawerKey = null;
   state.hostDrawerKey = null;
+  state.hostDrawerReturnAgent = null;
   render();
   requestAnimationFrame(() => {
+    if (agentToRestore) {
+      Array.from(document.querySelectorAll("[data-agent-destination]"))
+        .find((button) => button.dataset.agentDestination === agentToRestore)?.focus({ preventScroll: true });
+      return;
+    }
     if (hostKeyToRestore) {
       Array.from(document.querySelectorAll("[data-host-details]"))
         .find((button) => button.dataset.hostkey === hostKeyToRestore)?.focus({ preventScroll: true });
@@ -1127,6 +1210,9 @@ document.addEventListener("click", (e) => {
 
   const chip = e.target.closest("[data-chip]");
   if (chip) { toggleChip(chip.dataset.chip); return; }
+
+  const agentDestination = e.target.closest("[data-agent-destination]");
+  if (agentDestination) { openAgentDestination(agentDestination.dataset.agentDestination); return; }
 
   if (e.target.closest(".d-close")) { closeDrawer(); return; }
   if (e.target.closest("#drawer")) return; // clicks inside the drawer stay put

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -751,6 +751,10 @@ function findHost(key) {
   return (state.data.services?.hosts || []).find((host) => hostKey(host) === key) || null;
 }
 
+function findAgent(name) {
+  return (state.data.agents?.agents || []).find((agent) => agent.name === name) || null;
+}
+
 function drawerSection(title, body) {
   return body ? `<div class="d-sec">${title}</div>${body}` : "";
 }
@@ -765,10 +769,28 @@ function hostMetaLabel(key) {
   }[key] || key;
 }
 
+function missingHostMetricsHTML(host, agent) {
+  const isProxmox = host.platform === "proxmox" || host.platform === "pve";
+  const version = agent?.version ? ` (${esc(agent.version)})` : "";
+  let detail;
+  if (isProxmox && (host.condition || "unknown") === "unknown") {
+    detail = `The connected Proxmox agent${version} appears to be using the older host report. ` +
+      "Update and restart the Proxmox agent from the same Trove build as the server, then wait for its next report.";
+  } else if (isProxmox) {
+    detail = "The latest report did not contain a node resource snapshot. Check the Proxmox agent logs for node status API errors or permission problems.";
+  } else {
+    detail = "This platform did not include CPU, load, memory, disk, or uptime in its latest report.";
+  }
+  return `<div class="d-empty"><strong>No host metrics reported</strong><span>${detail}</span></div>`;
+}
+
 function renderHostDrawer(el, host) {
   const metrics = hostMetricRows(host.metrics);
+  const agent = findAgent(host.agent);
   const meta = host.meta && typeof host.meta === "object"
-    ? Object.entries(host.meta).sort(([a], [b]) => a.localeCompare(b)) : [];
+    ? Object.entries(host.meta)
+      .filter(([key]) => key !== "platform")
+      .sort(([a], [b]) => a.localeCompare(b)) : [];
   const live = (host.services || []).filter((s) => s.state !== "removed");
   const inventory = [
     ["Services", String(live.length)],
@@ -793,17 +815,8 @@ function renderHostDrawer(el, host) {
       ${badge(AGENT_CLASS[status] || "b-gray", `reporting ${status}`)}
       ${badge(HOST_CONDITION_CLASS[condition] || "b-gray", `condition ${condition}`)}
     </div>
-    <div class="d-detail">
-      <span class="d-detail-label">Snapshot</span>
-      ${metrics.length > 0
-        ? "Latest point-in-time host data reported by the agent."
-        : "No host resource metrics were included in the latest report."}
-    </div>
-    <div class="d-mono">
-      <span class="lbl">agent</span> ${esc(host.agent)} · <span class="lbl">platform</span> ${esc(host.platform || "—")}
-    </div>
 
-    ${drawerSection("Host resources", metrics.length ? kv(metrics, "metrics") : `<div class="d-empty">Waiting for a compatible agent to report CPU, load, memory, disk, and uptime.</div>`)}
+    ${drawerSection("Host resources", metrics.length ? kv(metrics, "metrics") : missingHostMetricsHTML(host, agent))}
     ${drawerSection("Platform details", meta.length ? kv(meta.map(([k, v]) => [hostMetaLabel(k), metaValue(v)])) : "")}
     ${drawerSection("Inventory", kv(inventory))}
 
@@ -811,6 +824,7 @@ function renderHostDrawer(el, host) {
     <div class="kv">
       <span class="k">last report</span><span class="v">${esc(absTime(host.last_seen_at))} (${esc(relTime(host.last_seen_at))})</span>
       <span class="k">agent</span><span class="v">${esc(host.agent)}</span>
+      <span class="k">agent version</span><span class="v">${esc(agent?.version || "not reported")}</span>
       <span class="k">platform</span><span class="v">${esc(host.platform || "—")}</span>
     </div>
   `;

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -86,6 +86,7 @@ const HEALTH_CLASS = {
 };
 
 const AGENT_CLASS = { ok: "b-green", stale: "b-yellow", offline: "b-red", unknown: "b-gray" };
+const HOST_CONDITION_CLASS = { normal: "b-green", warning: "b-yellow", critical: "b-red", unknown: "b-gray" };
 
 function stateClass(state) {
   // K8s parents report "ready/desired" (e.g. "2/2").
@@ -178,6 +179,88 @@ function hostPlatformLine(host) {
   return parts.filter(Boolean).join(" · ");
 }
 
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatBytes(bytes) {
+  const n = finiteNumber(bytes);
+  if (n === null || n < 0) return "—";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+  let value = n;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  const precision = value >= 10 || unit === 0 ? 0 : 1;
+  return `${value.toFixed(precision)} ${units[unit]}`;
+}
+
+function formatUptime(seconds) {
+  const total = finiteNumber(seconds);
+  if (total === null || total < 0) return "—";
+  const days = Math.floor(total / 86400);
+  const hours = Math.floor((total % 86400) / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+function resourceMetric(label, usage) {
+  if (!usage || typeof usage !== "object") return null;
+  const used = finiteNumber(usage.used_bytes);
+  const total = finiteNumber(usage.total_bytes);
+  if (used === null || total === null || total <= 0 || used < 0 || used > total) return null;
+  const percent = Math.round((used / total) * 100);
+  return {
+    label,
+    value: `${percent}%`,
+    title: `${label}: ${formatBytes(used)} / ${formatBytes(total)}`,
+  };
+}
+
+function hostMetricItems(metrics) {
+  if (!metrics || typeof metrics !== "object") return [];
+  const items = [];
+  const cpu = finiteNumber(metrics.cpu_usage_ratio);
+  if (cpu !== null && cpu >= 0 && cpu <= 1) {
+    const cores = finiteNumber(metrics.cpu_logical_count);
+    items.push({
+      label: "CPU",
+      value: `${Math.round(cpu * 100)}%`,
+      title: `CPU: ${Math.round(cpu * 100)}%${cores && cores > 0 ? ` · ${cores} logical CPUs` : ""}`,
+    });
+  }
+  const memory = resourceMetric("RAM", metrics.memory);
+  if (memory) items.push(memory);
+  const rootDisk = resourceMetric("Root", metrics.root_disk);
+  if (rootDisk) items.push(rootDisk);
+  const load1 = finiteNumber(metrics.load_1);
+  const load5 = finiteNumber(metrics.load_5);
+  const load15 = finiteNumber(metrics.load_15);
+  if ([load1, load5, load15].some((n) => n !== null && n >= 0)) {
+    const values = [load1, load5, load15].map((n) => n === null || n < 0 ? "—" : n.toFixed(2));
+    items.push({ label: "Load", value: values[0], title: `Load average: ${values.join(" · ")} (1m · 5m · 15m)` });
+  }
+  const uptime = finiteNumber(metrics.uptime_seconds);
+  if (uptime !== null && uptime >= 0) {
+    items.push({ label: "Up", value: formatUptime(uptime), title: `Uptime: ${formatUptime(uptime)}` });
+  }
+  return items;
+}
+
+function hostMetricsHTML(metrics) {
+  const items = hostMetricItems(metrics);
+  if (items.length === 0) return "";
+  return `<span class="host-metrics" aria-label="Host resource metrics">${items.map((item) =>
+    `<span class="host-metric" title="${esc(item.title)}"><span class="metric-label">${esc(item.label)}</span> ${esc(item.value)}</span>`
+  ).join("")}</span>`;
+}
+
 // ------------------------------------------------------- cell rendering ----
 
 // splitImage separates "registry/namespace/name:tag" so the prefix can
@@ -243,7 +326,7 @@ function matchesFilters(s, host) {
   const q = state.q.trim().toLowerCase();
   if (!q) return true;
   const hay = [s.name, s.external_id, s.image, s.kind, s.state, s.health, s.freshness,
-    host.hostname, host.agent];
+    host.hostname, host.agent, host.platform, host.condition];
   if (s.labels && typeof s.labels === "object") {
     for (const [k, v] of Object.entries(s.labels)) hay.push(k, v);
   }
@@ -257,13 +340,15 @@ function filterActive() {
 // counts over the full dataset (independent of the active filter)
 function computeCounts() {
   const c = {
-    hosts: 0, staleHosts: 0, offlineHosts: 0,
+    hosts: 0, staleHosts: 0, offlineHosts: 0, warningHosts: 0, criticalHosts: 0,
     services: 0, running: 0, unhealthy: 0, stopped: 0, outdated: 0, stale: 0, removed: 0,
   };
   for (const h of state.data.services?.hosts || []) {
     c.hosts++;
     if (h.status === "stale" && h.agent_status !== "stale" && h.agent_status !== "offline") c.staleHosts++;
     if (h.status === "offline" && h.agent_status !== "offline") c.offlineHosts++;
+    if (h.status === "ok" && h.condition === "warning") c.warningHosts++;
+    if (h.status === "ok" && h.condition === "critical") c.criticalHosts++;
     for (const s of h.services || []) {
       if (s.state === "removed") { c.removed++; continue; }
       c.services++;
@@ -292,9 +377,11 @@ function attentionItems() {
   return [
     item("offline-agents", "critical", offline, "Offline agent", "Trove is no longer receiving reports from this source.", "Review agents"),
     item("offline-hosts", "critical", c.offlineHosts, "Offline host", "This host has missed its own reporting window and its inventory is stale.", "Review hosts"),
+    item("critical-hosts", "critical", c.criticalHosts, "Critical host condition", "The platform reports that this host needs attention.", "Review hosts"),
     item("unhealthy", "critical", c.unhealthy, "Unhealthy service", "A platform health check or readiness signal is failing.", "Show services"),
     item("stale-agents", "warning", staleAgents, "Stale agent", "This source has missed its expected reporting interval.", "Review agents"),
     item("stale-hosts", "warning", c.staleHosts, "Stale host", "This host has stopped reporting even if another host from the same agent is still active.", "Review hosts"),
+    item("warning-hosts", "warning", c.warningHosts, "Host condition warning", "The platform reports a degraded host condition.", "Review hosts"),
     item("stopped", "info", c.stopped, "Stopped workload", "A discovered workload is not running. It may be intentional.", "Show services"),
     item("removed", "info", c.removed, "Recently disappeared service", "A service is absent from its latest full-state report.", "Show services"),
     item("outdated", "info", c.outdated, "Outdated image", "The running image digest is behind the current tag.", "Show services"),
@@ -307,7 +394,7 @@ function renderAttention() {
   if (items.length === 0) {
     el.innerHTML = `<div class="attention-healthy">
       <span class="attention-icon" aria-hidden="true">✓</span>
-      <div><strong>Nothing needs attention right now.</strong><span>All reporting agents are online and discovered services have no current health, state, or image-freshness warnings.</span></div>
+      <div><strong>Nothing needs attention right now.</strong><span>All reporting agents and hosts are online, and discovered services have no current health, state, or image-freshness warnings.</span></div>
     </div>`;
     return;
   }
@@ -325,7 +412,7 @@ function showAttention(key) {
     focusInvestigationTarget("infrastructure-title");
     return;
   }
-  if (key === "offline-hosts" || key === "stale-hosts") {
+  if (["offline-hosts", "stale-hosts", "critical-hosts", "warning-hosts"].includes(key)) {
     $("inventory-title").scrollIntoView({ behavior: "smooth", block: "start" });
     focusInvestigationTarget("inventory-title");
     return;
@@ -483,6 +570,9 @@ function renderHosts() {
       (nOutdated ? badge("b-peach", `${nOutdated} outdated`, "mini") : "");
 
     const st = h.status || "unknown";
+    const condition = h.condition || "unknown";
+    const conditionBadge = condition !== "unknown"
+      ? badge(HOST_CONDITION_CLASS[condition] || "b-gray", `condition ${condition}`) : "";
     const collapsed = state.collapsed.has(hostKey(h));
     const countLabel = filterActive() && visible.length !== total
       ? `${visible.length}/${total} service(s)` : `${total} service(s)`;
@@ -493,7 +583,9 @@ function renderHosts() {
         <span class="hostname">${esc(h.hostname)}</span>
         <span class="sub">${esc(hostPlatformLine(h))}</span>
         <span class="sub">last report ${esc(relTime(h.last_seen_at))}</span>
-        ${badge(AGENT_CLASS[st] || "b-gray", `host ${st}`)}
+        ${badge(AGENT_CLASS[st] || "b-gray", `reporting ${st}`)}
+        ${conditionBadge}
+        ${hostMetricsHTML(h.metrics)}
         <span class="rollup">${rollup}</span>
         <span class="count">${countLabel}</span>
       </button>

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -20,6 +20,7 @@ const state = {
   removedOnly: false,    // limit the catalogue to soft-removed services
   collapsed: new Set(),  // collapsed host keys
   drawerKey: null,       // key of the service open in the drawer
+  hostDrawerKey: null,   // key of the host open in the drawer
   cursorKey: null,       // key of the keyboard-cursor row
   data: { services: null, agents: null, events: null },
 };
@@ -259,6 +260,37 @@ function hostMetricsHTML(metrics) {
   return `<span class="host-metrics" aria-label="Host resource metrics">${items.map((item) =>
     `<span class="host-metric" title="${esc(item.title)}"><span class="metric-label">${esc(item.label)}</span> ${esc(item.value)}</span>`
   ).join("")}</span>`;
+}
+
+function resourceMetricDetail(usage) {
+  if (!usage || typeof usage !== "object") return "";
+  const used = finiteNumber(usage.used_bytes);
+  const total = finiteNumber(usage.total_bytes);
+  if (used === null || total === null || total <= 0 || used < 0 || used > total) return "";
+  return `${formatBytes(used)} / ${formatBytes(total)} · ${Math.round((used / total) * 100)}%`;
+}
+
+function hostMetricRows(metrics) {
+  if (!metrics || typeof metrics !== "object") return [];
+  const rows = [];
+  const cpu = finiteNumber(metrics.cpu_usage_ratio);
+  const cores = finiteNumber(metrics.cpu_logical_count);
+  if (cpu !== null && cpu >= 0 && cpu <= 1) {
+    rows.push(["CPU usage", `${Math.round(cpu * 100)}%${cores && cores > 0 ? ` · ${cores} logical CPUs` : ""}`]);
+  } else if (cores && cores > 0) {
+    rows.push(["Logical CPUs", String(cores)]);
+  }
+  const load = [metrics.load_1, metrics.load_5, metrics.load_15].map(finiteNumber);
+  if (load.some((n) => n !== null && n >= 0)) {
+    rows.push(["Load average", `${load.map((n) => n === null || n < 0 ? "—" : n.toFixed(2)).join(" · ")} (1m · 5m · 15m)`]);
+  }
+  const memory = resourceMetricDetail(metrics.memory);
+  if (memory) rows.push(["Memory", memory]);
+  const rootDisk = resourceMetricDetail(metrics.root_disk);
+  if (rootDisk) rows.push(["Root disk", rootDisk]);
+  const uptime = finiteNumber(metrics.uptime_seconds);
+  if (uptime !== null && uptime >= 0) rows.push(["Uptime", formatUptime(uptime)]);
+  return rows;
 }
 
 // ------------------------------------------------------- cell rendering ----
@@ -578,9 +610,11 @@ function renderHosts() {
       ? `${visible.length}/${total} service(s)` : `${total} service(s)`;
 
     sections.push(`<div class="host${collapsed ? " collapsed" : ""}" data-hostkey="${esc(hostKey(h))}">
-      <button type="button" class="host-head" aria-expanded="${!collapsed}" aria-label="${collapsed ? "Expand" : "Collapse"} ${esc(h.hostname)}">
-        <span class="chev">${collapsed ? "▸" : "▾"}</span>
-        <span class="hostname">${esc(h.hostname)}</span>
+      <div class="host-head">
+        <button type="button" class="host-toggle" data-host-toggle aria-expanded="${!collapsed}" aria-label="${collapsed ? "Expand" : "Collapse"} ${esc(h.hostname)} services">
+          <span class="chev" aria-hidden="true">${collapsed ? "▸" : "▾"}</span>
+          <span class="hostname">${esc(h.hostname)}</span>
+        </button>
         <span class="sub">${esc(hostPlatformLine(h))}</span>
         <span class="sub">last report ${esc(relTime(h.last_seen_at))}</span>
         ${badge(AGENT_CLASS[st] || "b-gray", `reporting ${st}`)}
@@ -588,7 +622,10 @@ function renderHosts() {
         ${hostMetricsHTML(h.metrics)}
         <span class="rollup">${rollup}</span>
         <span class="count">${countLabel}</span>
-      </button>
+        <button type="button" class="host-details" data-host-details data-hostkey="${esc(hostKey(h))}" aria-label="View ${esc(h.hostname)} host stats">
+          View host stats <span aria-hidden="true">→</span>
+        </button>
+      </div>
       <p class="table-scroll-hint">Swipe or scroll horizontally to see all service details <span aria-hidden="true">→</span></p>
       <div class="host-body">
         <table>
@@ -710,8 +747,86 @@ function findService(key) {
   return null;
 }
 
+function findHost(key) {
+  return (state.data.services?.hosts || []).find((host) => hostKey(host) === key) || null;
+}
+
+function drawerSection(title, body) {
+  return body ? `<div class="d-sec">${title}</div>${body}` : "";
+}
+
+function hostMetaLabel(key) {
+  return {
+    "proxmox.version": "Proxmox version",
+    "proxmox.release": "Proxmox release",
+    "proxmox.repoid": "Proxmox repository ID",
+    "docker.version": "Docker version",
+    "kubernetes.version": "Kubernetes version",
+  }[key] || key;
+}
+
+function renderHostDrawer(el, host) {
+  const metrics = hostMetricRows(host.metrics);
+  const meta = host.meta && typeof host.meta === "object"
+    ? Object.entries(host.meta).sort(([a], [b]) => a.localeCompare(b)) : [];
+  const live = (host.services || []).filter((s) => s.state !== "removed");
+  const inventory = [
+    ["Services", String(live.length)],
+    ["Running", String(live.filter((s) => s.state === "running").length)],
+    ["Stopped", String(live.filter((s) => STOPPED_STATES.has(s.state)).length)],
+    ["Unhealthy", String(live.filter((s) => s.health === "unhealthy").length)],
+    ["Outdated", String(live.filter((s) => s.freshness === "outdated").length)],
+  ];
+  const metaValue = (value) => typeof value === "object" ? JSON.stringify(value) : String(value);
+  const kv = (rows, cls = "") => `<div class="kv${cls ? ` ${cls}` : ""}">${rows.map(([k, v]) =>
+    `<span class="k">${esc(k)}</span><span class="v">${esc(v)}</span>`).join("")}</div>`;
+  const status = host.status || "unknown";
+  const condition = host.condition || "unknown";
+
+  el.innerHTML = `
+    <div class="d-head">
+      <span class="d-name">${esc(host.hostname)}</span>
+      <span class="kind">host</span>
+      <button class="d-close" aria-label="Close host stats" title="close (esc)">✕</button>
+    </div>
+    <div class="d-badges">
+      ${badge(AGENT_CLASS[status] || "b-gray", `reporting ${status}`)}
+      ${badge(HOST_CONDITION_CLASS[condition] || "b-gray", `condition ${condition}`)}
+    </div>
+    <div class="d-detail">
+      <span class="d-detail-label">Snapshot</span>
+      ${metrics.length > 0
+        ? "Latest point-in-time host data reported by the agent."
+        : "No host resource metrics were included in the latest report."}
+    </div>
+    <div class="d-mono">
+      <span class="lbl">agent</span> ${esc(host.agent)} · <span class="lbl">platform</span> ${esc(host.platform || "—")}
+    </div>
+
+    ${drawerSection("Host resources", metrics.length ? kv(metrics, "metrics") : `<div class="d-empty">Waiting for a compatible agent to report CPU, load, memory, disk, and uptime.</div>`)}
+    ${drawerSection("Platform details", meta.length ? kv(meta.map(([k, v]) => [hostMetaLabel(k), metaValue(v)])) : "")}
+    ${drawerSection("Inventory", kv(inventory))}
+
+    <div class="d-sec">Reporting</div>
+    <div class="kv">
+      <span class="k">last report</span><span class="v">${esc(absTime(host.last_seen_at))} (${esc(relTime(host.last_seen_at))})</span>
+      <span class="k">agent</span><span class="v">${esc(host.agent)}</span>
+      <span class="k">platform</span><span class="v">${esc(host.platform || "—")}</span>
+    </div>
+  `;
+  el.hidden = false;
+}
+
 function renderDrawer() {
   const el = $("drawer");
+  if (state.hostDrawerKey) {
+    const host = findHost(state.hostDrawerKey);
+    if (host) {
+      renderHostDrawer(el, host);
+      return;
+    }
+    state.hostDrawerKey = null;
+  }
   if (!state.drawerKey) {
     el.hidden = true;
     el.innerHTML = "";
@@ -744,8 +859,6 @@ function renderDrawer() {
   const ports = Array.isArray(s.ports)
     ? [...s.ports].sort((a, b) => (a.host || a.container) - (b.host || b.container)) : [];
 
-  const sec = (title, body) => body ? `<div class="d-sec">${title}</div>${body}` : "";
-
   el.innerHTML = `
     <div class="d-head">
       <span class="d-name">${esc(s.name || s.external_id)}</span>
@@ -765,21 +878,21 @@ function renderDrawer() {
     </div>
     ${parent ? `<div class="d-mono"><span class="lbl">part of</span> ${esc(parent.name)} <span class="kind">${esc(parent.kind)}</span></div>` : ""}
 
-    ${sec("Image", s.image ? `
+    ${drawerSection("Image", s.image ? `
       <div class="d-mono">${esc(s.image)}</div>
       ${s.image_digest ? `<div class="d-mono"><span class="lbl">running</span> ${esc(s.image_digest)}</div>` : ""}
       ${s.latest_digest ? `<div class="d-mono"><span class="lbl">latest&nbsp;</span> ${esc(s.latest_digest)}</div>` : ""}` : "")}
 
-    ${sec("Ports", ports.length ? `<div class="pchips">${ports.map((p) => `<span class="pchip">${esc(fmtPort(p))}</span>`).join("")}</div>` : "")}
+    ${drawerSection("Ports", ports.length ? `<div class="pchips">${ports.map((p) => `<span class="pchip">${esc(fmtPort(p))}</span>`).join("")}</div>` : "")}
 
-    ${sec("Metrics", metricRows.length ? `<div class="kv metrics">${metricRows.map(([k, v]) =>
+    ${drawerSection("Metrics", metricRows.length ? `<div class="kv metrics">${metricRows.map(([k, v]) =>
       `<span class="k">${esc(k)}</span><span class="v">${esc(v)}</span>`).join("")}</div>` : "")}
 
-    ${sec(`Instances (${children.length})`, children.length ? `<div class="d-kids">${children.map((k) => `
+    ${drawerSection(`Instances (${children.length})`, children.length ? `<div class="d-kids">${children.map((k) => `
       <div class="krow">${badge(HEALTH_CLASS[k.health] || "b-gray", k.health, "mini")} ${esc(k.name)}
         <span class="muted">${esc(k.state)}</span></div>`).join("")}</div>` : "")}
 
-    ${sec("Labels", labels.length ? `<div class="kv">${labels.map(([k, v]) =>
+    ${drawerSection("Labels", labels.length ? `<div class="kv">${labels.map(([k, v]) =>
       `<span class="k">${esc(k)}</span><span class="v">${esc(v)}</span>`).join("")}</div>` : "")}
 
     <div class="d-sec">Seen</div>
@@ -789,7 +902,7 @@ function renderDrawer() {
       <span class="k">external id</span><span class="v">${esc(s.external_id)}</span>
     </div>
 
-    ${sec("Recent events", events.length ? `<div class="d-events">${events.map(eventRowHTML).join("")}</div>` : "")}
+    ${drawerSection("Recent events", events.length ? `<div class="d-events">${events.map(eventRowHTML).join("")}</div>` : "")}
   `;
   el.hidden = false;
 }
@@ -822,17 +935,34 @@ function moveCursor(delta) {
 }
 
 function openDrawer(key) {
+  state.hostDrawerKey = null;
   state.drawerKey = key;
   state.cursorKey = key;
   render();
   requestAnimationFrame(() => document.querySelector(".d-close")?.focus({ preventScroll: true }));
 }
 
-function closeDrawer() {
-  const key = state.drawerKey;
+function openHostDrawer(key) {
   state.drawerKey = null;
+  state.hostDrawerKey = key;
   render();
-  requestAnimationFrame(() => visibleRows().find((tr) => rowKey(tr) === key)?.focus({ preventScroll: true }));
+  requestAnimationFrame(() => document.querySelector(".d-close")?.focus({ preventScroll: true }));
+}
+
+function closeDrawer() {
+  const serviceKey = state.drawerKey;
+  const hostKeyToRestore = state.hostDrawerKey;
+  state.drawerKey = null;
+  state.hostDrawerKey = null;
+  render();
+  requestAnimationFrame(() => {
+    if (hostKeyToRestore) {
+      Array.from(document.querySelectorAll("[data-host-details]"))
+        .find((button) => button.dataset.hostkey === hostKeyToRestore)?.focus({ preventScroll: true });
+      return;
+    }
+    visibleRows().find((tr) => rowKey(tr) === serviceKey)?.focus({ preventScroll: true });
+  });
 }
 
 // -------------------------------------------------------------- render ----
@@ -955,9 +1085,12 @@ document.addEventListener("click", (e) => {
   if (e.target.closest(".d-close")) { closeDrawer(); return; }
   if (e.target.closest("#drawer")) return; // clicks inside the drawer stay put
 
-  const head = e.target.closest(".host-head");
-  if (head) {
-    const key = head.parentElement.dataset.hostkey;
+  const hostDetails = e.target.closest("[data-host-details]");
+  if (hostDetails) { openHostDrawer(hostDetails.dataset.hostkey); return; }
+
+  const hostToggle = e.target.closest("[data-host-toggle]");
+  if (hostToggle) {
+    const key = hostToggle.closest(".host").dataset.hostkey;
     if (state.collapsed.has(key)) state.collapsed.delete(key);
     else state.collapsed.add(key);
     render();
@@ -978,7 +1111,7 @@ document.addEventListener("keydown", (e) => {
   }
   if (e.key === "Escape") {
     if (typing) { e.target.blur(); return; }
-    if (state.drawerKey) { closeDrawer(); return; }
+    if (state.drawerKey || state.hostDrawerKey) { closeDrawer(); return; }
     if (filterActive()) clearFilters();
     return;
   }
@@ -987,7 +1120,7 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "j" || e.key === "ArrowDown") { e.preventDefault(); moveCursor(1); return; }
   if (e.key === "k" || e.key === "ArrowUp") { e.preventDefault(); moveCursor(-1); return; }
   if (e.key === "Enter") {
-    if (e.target.closest?.(".host-head")) return;
+    if (e.target.closest?.(".host-toggle, .host-details")) return;
     const focused = document.activeElement?.closest?.("#hosts tr[data-ext]");
     if (focused) { openDrawer(rowKey(focused)); return; }
     if (state.cursorKey) openDrawer(state.cursorKey);

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -77,6 +77,11 @@ function absTime(iso) {
   return Number.isNaN(d.getTime()) ? "—" : d.toLocaleString();
 }
 
+function agentVersionLabel(version) {
+  if (!version) return "";
+  return /^\d/.test(version) ? `v${version}` : version;
+}
+
 // ---------------------------------------------------------- badge maps ----
 
 const HEALTH_CLASS = {
@@ -526,7 +531,7 @@ function renderAgents() {
         <span class="name">${esc(a.name)}</span>
         ${badge(AGENT_CLASS[st] || "b-gray", st)}
       </div>
-      <div class="meta">${esc(a.platform || "—")}${a.version ? " · v" + esc(a.version) : ""}</div>
+      <div class="meta">${esc(a.platform || "—")}${a.version ? " · " + esc(agentVersionLabel(a.version)) : ""}</div>
       <div class="meta">last push: ${esc(relTime(a.last_seen_at))}</div>
     </div>`;
   }).join("");
@@ -765,8 +770,29 @@ function hostMetaLabel(key) {
     "proxmox.release": "Proxmox release",
     "proxmox.repoid": "Proxmox repository ID",
     "docker.version": "Docker version",
+    "docker.api_version": "Docker API version",
+    "docker.os": "Docker OS",
+    "docker.arch": "Docker architecture",
+    "docker.os_name": "Operating system",
+    "docker.kernel": "Kernel",
+    "docker.host_metrics": "Host metrics source",
     "kubernetes.version": "Kubernetes version",
+    "kubernetes.platform": "Kubernetes platform",
+    "kubernetes.nodes": "Nodes",
+    "kubernetes.ready_nodes": "Ready nodes",
+    "kubernetes.metrics_api": "Metrics API",
+    "linux.os": "Operating system",
+    "linux.kernel": "Kernel",
+    "linux.arch": "Architecture",
   }[key] || key;
+}
+
+function hostMetricsNoticeHTML(host) {
+  const meta = host.meta && typeof host.meta === "object" ? host.meta : {};
+  if ((host.platform === "kubernetes") && meta["kubernetes.metrics_api"] === "unavailable") {
+    return `<div class="d-note">CPU and memory usage require the optional Kubernetes Metrics API. Node capacity and readiness are still reported.</div>`;
+  }
+  return "";
 }
 
 function missingHostMetricsHTML(host, agent) {
@@ -778,6 +804,12 @@ function missingHostMetricsHTML(host, agent) {
       "Update and restart the Proxmox agent from the same Trove build as the server, then wait for its next report.";
   } else if (isProxmox) {
     detail = "The latest report did not contain a node resource snapshot. Check the Proxmox agent logs for node status API errors or permission problems.";
+  } else if (host.platform === "kubernetes") {
+    detail = "Apply the current read-only node RBAC. CPU and memory usage also require metrics-server or another metrics.k8s.io provider.";
+  } else if (host.platform === "docker") {
+    detail = "Live Docker host usage is available when the agent runs beside the daemon through its local Unix socket. Remote Docker APIs expose capacity but not host usage.";
+  } else if (host.platform === "local") {
+    detail = "The Linux agent could not read the aggregate procfs metrics for this host. Check its logs and /proc access.";
   } else {
     detail = "This platform did not include CPU, load, memory, disk, or uptime in its latest report.";
   }
@@ -816,7 +848,7 @@ function renderHostDrawer(el, host) {
       ${badge(HOST_CONDITION_CLASS[condition] || "b-gray", `condition ${condition}`)}
     </div>
 
-    ${drawerSection("Host resources", metrics.length ? kv(metrics, "metrics") : missingHostMetricsHTML(host, agent))}
+    ${drawerSection("Host resources", metrics.length ? kv(metrics, "metrics") + hostMetricsNoticeHTML(host) : missingHostMetricsHTML(host, agent))}
     ${drawerSection("Platform details", meta.length ? kv(meta.map(([k, v]) => [hostMetaLabel(k), metaValue(v)])) : "")}
     ${drawerSection("Inventory", kv(inventory))}
 

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -86,7 +86,7 @@
     </footer>
   </div>
 
-  <aside id="drawer" class="drawer" hidden aria-label="Service details"></aside>
+  <aside id="drawer" class="drawer" hidden aria-label="Details panel"></aside>
 
   <script src="app.js"></script>
 </body>

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -377,15 +377,9 @@ header h1 {
   align-items: center;
   gap: 11px;
   padding: 13px 16px;
-  color: inherit;
-  font: inherit;
-  text-align: left;
   background: rgba(15, 14, 25, 0.5);
-  border: 0;
   border-bottom: 1px solid var(--border);
   flex-wrap: wrap;
-  cursor: pointer;
-  user-select: none;
   position: sticky;
   top: 0;
   z-index: 5;
@@ -393,8 +387,23 @@ header h1 {
 }
 .host.collapsed .host-head { border-bottom: none; }
 .host.collapsed .host-body { display: none; }
-.host-head .chev { color: var(--subtle); font-size: 10px; width: 11px; }
-.host-head .hostname { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
+.host-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 4px;
+  margin: -3px -4px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.host-toggle:hover .hostname { color: var(--purple); }
+.host-toggle .chev { color: var(--subtle); font-size: 10px; width: 11px; }
+.host-toggle .hostname { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
 .host-head .sub { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
 .host-head .rollup { display: inline-flex; gap: 6px; }
 .host-metrics {
@@ -418,6 +427,25 @@ header h1 {
 }
 .host-metric .metric-label { color: var(--blue); }
 .host-head .count { margin-left: auto; color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
+.host-details {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid rgba(139, 112, 255, 0.48);
+  border-radius: 9px;
+  background: rgba(139, 112, 255, 0.11);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.host-details:hover {
+  border-color: var(--purple);
+  background: rgba(139, 112, 255, 0.2);
+}
 .table-scroll-hint { display: none; }
 .host-body { overflow-x: auto; }
 
@@ -652,6 +680,15 @@ tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
 }
 .d-events .event-row { padding: 6px 0; border-bottom: 1px solid rgba(59, 54, 85, 0.45); }
 .d-kids .krow { display: flex; gap: 8px; align-items: center; padding: 4px 0; font-size: 12.5px; color: var(--muted); }
+.d-empty {
+  padding: 12px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  color: var(--subtle);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.6;
+}
 
 /* ---- misc ---- */
 .empty { color: var(--subtle); padding: 30px 14px; text-align: center; font-style: italic; }
@@ -690,6 +727,8 @@ footer kbd {
   .section-heading p { text-align: left; }
   .attention-card { grid-template-columns: auto minmax(0, 1fr); }
   .attention-action { grid-column: 2; }
+  .host-head .count { margin-left: 0; }
+  .host-details { margin-left: auto; }
   .table-scroll-hint {
     display: block;
     margin: 0;

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -397,6 +397,26 @@ header h1 {
 .host-head .hostname { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
 .host-head .sub { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
 .host-head .rollup { display: inline-flex; gap: 6px; }
+.host-metrics {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.host-metric {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 3px 7px;
+  border: 1px solid rgba(116, 186, 255, 0.22);
+  border-radius: 7px;
+  background: rgba(116, 186, 255, 0.06);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+.host-metric .metric-label { color: var(--blue); }
 .host-head .count { margin-left: auto; color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
 .table-scroll-hint { display: none; }
 .host-body { overflow-x: auto; }

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -689,6 +689,14 @@ tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
   font-size: 11.5px;
   line-height: 1.6;
 }
+.d-empty strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: 12.5px;
+}
+.d-empty span { display: block; }
 
 /* ---- misc ---- */
 .empty { color: var(--subtle); padding: 30px 14px; text-align: center; font-style: italic; }

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -341,12 +341,24 @@ header h1 {
   gap: 12px;
 }
 .agent-card {
+  display: block;
+  width: 100%;
   position: relative;
   overflow: hidden;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   background: linear-gradient(180deg, rgba(36, 34, 56, 0.92), rgba(26, 24, 40, 0.92));
   border: 1px solid var(--border);
   border-radius: 22px;
   padding: 15px 16px 15px 18px;
+  cursor: pointer;
+  transition: transform .15s ease, border-color .15s ease, background .15s ease;
+}
+.agent-card:hover {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  background: linear-gradient(180deg, rgba(48, 43, 60, 0.98), rgba(29, 26, 39, 0.98));
 }
 .agent-card::before {
   content: "";
@@ -362,6 +374,27 @@ header h1 {
 .agent-card .name { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
 .agent-card .meta { color: var(--muted); font-family: var(--font-mono); font-size: 11.5px; margin-top: 6px; }
 .agent-card .row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.agent-identity { display: inline-flex; align-items: center; min-width: 0; gap: 9px; }
+.agent-foot { display: grid; gap: 3px; margin-top: 6px; }
+.agent-foot .meta { margin-top: 0; }
+.agent-action { color: var(--purple); font-family: var(--font-mono); font-size: 10px; font-weight: 700; white-space: nowrap; }
+
+.platform-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  color: var(--muted);
+  border: 1px solid currentColor;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.035);
+}
+.platform-mark svg { display: block; width: 15px; height: 15px; fill: currentColor; }
+.platform-docker { color: #5eb6f2; background: rgba(36, 150, 237, 0.1); }
+.platform-proxmox { color: #f28b37; background: rgba(229, 112, 0, 0.1); }
+.platform-kubernetes { color: #75a0f4; background: rgba(50, 108, 229, 0.11); }
+.platform-linux { color: var(--green); background: rgba(114, 217, 135, 0.08); }
 
 /* ---- host sections ---- */
 .host {
@@ -388,22 +421,37 @@ header h1 {
 .host.collapsed .host-head { border-bottom: none; }
 .host.collapsed .host-body { display: none; }
 .host-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 3px 4px;
-  margin: -3px -4px;
-  color: inherit;
-  font: inherit;
-  text-align: left;
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  color: var(--subtle);
   background: transparent;
   border: 0;
-  border-radius: 7px;
+  border-radius: 6px;
   cursor: pointer;
 }
-.host-toggle:hover .hostname { color: var(--purple); }
-.host-toggle .chev { color: var(--subtle); font-size: 10px; width: 11px; }
-.host-toggle .hostname { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
+.host-toggle:hover { color: var(--purple); background: rgba(139, 112, 255, 0.1); }
+.host-toggle .chev { font-size: 10px; }
+.host-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: -4px;
+  padding: 3px 5px;
+  color: inherit;
+  font: inherit;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+}
+.host-name:hover { background: rgba(139, 112, 255, 0.09); }
+.host-name:hover .hostname { color: var(--purple); }
+.host-name .platform-mark { width: 20px; height: 20px; flex-basis: 20px; border-radius: 6px; }
+.host-name .platform-mark svg { width: 13px; height: 13px; }
+.host-name .hostname { font-family: var(--font-display); font-weight: 700; font-size: 15px; color: var(--text); }
 .host-head .sub { color: var(--subtle); font-family: var(--font-mono); font-size: 11.5px; }
 .host-head .rollup { display: inline-flex; gap: 6px; }
 .host-metrics {

--- a/web/public/styles.css
+++ b/web/public/styles.css
@@ -697,6 +697,16 @@ tbody tr[data-ext]:hover td.seen::after { color: var(--text); }
   font-size: 12.5px;
 }
 .d-empty span { display: block; }
+.d-note {
+  margin-top: 10px;
+  padding: 9px 10px;
+  border-left: 2px solid var(--blue);
+  background: rgba(116, 186, 255, 0.05);
+  color: var(--subtle);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+}
 
 /* ---- misc ---- */
 .empty { color: var(--subtle); padding: 30px 14px; text-align: center; font-style: italic; }


### PR DESCRIPTION
## Summary

- add a typed host condition and point-in-time resource metrics contract shared by agents and the server
- persist the latest host snapshot and expose it through the services API
- collect Proxmox node CPU, logical CPU count, load averages, memory, root-disk usage, uptime, and online/offline condition
- surface host condition and resource metrics in the dashboard and needs-attention queue
- document the API contract and Proxmox behaviour

## Why

Trove already showed whether an agent or host was still reporting, but it could not show the operating condition or resource state of the host itself. This adds a focused host-level view without turning Trove into a time-series monitoring platform.

Reporting status remains separate from platform condition:

- `status` answers whether Trove is receiving current reports
- `condition` carries the platform verdict: `normal`, `warning`, `critical`, or `unknown`
- `metrics` carries the latest informational resource snapshot

A brief CPU or memory spike does not become an unhealthy verdict or alert.

## Proxmox behaviour

- online nodes report a `normal` condition and current node metrics
- explicitly offline nodes report a `critical` condition without repeatedly calling node-local endpoints that are expected to fail
- a temporary failure of `/nodes/{node}/status` does not drop the cluster report; unavailable metrics are cleared so stale readings are not left on screen
- numeric load values are accepted in both quoted and JSON-number forms for API compatibility

## Data and API

Migration `0009_host_metrics.sql` adds the latest host condition and metrics JSON snapshot. Existing hosts upgrade to `condition: unknown` with an empty metrics object.

`GET /api/v1/services` host groups now include `condition` and `metrics`.

## Validation

- [x] gofmt and JavaScript syntax
- [x] `go vet ./...`
- [x] `go test -covermode=atomic ./...`
- [x] `go test -race ./...`
- [x] golangci-lint v2.12.2 — 0 issues
- [x] govulncheck v1.5.0 — no vulnerabilities
- [x] linux/amd64 and linux/arm64 cross-builds
- [x] GoReleaser v2.17.0 configuration check
- [x] release-surface check
- [x] Dockerfile drift check
- [x] desktop and 390px mobile browser review with no page overflow or console errors
