### PR TITLE
fix(security): remediate Codex security findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
       - name: go vet
         run: go vet ./...
       - name: Dockerfile drift check
-        run: ./scripts/check-dockerfile-drift.sh
+        run: |
+          ./scripts/check-dockerfile-drift_test.sh
+          ./scripts/check-dockerfile-drift.sh
       - name: GitHub Actions lint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10
       - name: Release surface check

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,6 +16,7 @@ jobs:
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      # amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -12,9 +12,11 @@ name: Preview images
 # contract is older. The local/systemd agent has no container image. Docs-only
 # branches/changes deliberately do not publish preview images.
 #
-# Images are tagged with a sanitized branch name. On main, the tag is
-# "main" (overwritten on every push). Tags are never published to
-# "latest" — that stays on goreleaser's release flow.
+# Images are tagged with a sanitized branch name plus a hash of the original
+# branch, preventing distinct names from collapsing to the same Docker tag.
+# Every build also gets an immutable sha-<commit> tag. On main, the moving tag
+# remains "main". Tags are never published to "latest" — that stays on
+# goreleaser's release flow.
 #
 # Package visibility note: the first push of a NEW package to GHCR
 # inherits the repo's visibility at push time. If the package doesn't
@@ -56,20 +58,35 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      sha_tag: ${{ steps.tag.outputs.sha_tag }}
       version: ${{ steps.tag.outputs.version }}
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Derive image tag and runtime version
         id: tag
         shell: bash
         run: |
+          set -euo pipefail
           raw="${GITHUB_REF#refs/heads/}"
-          tag=$(echo "$raw" | sed 's|/|-|g' | tr -cd '[:alnum:]._-')
-          short_sha="${GITHUB_SHA:0:7}"
+          short_sha="${GITHUB_SHA:0:12}"
+          sha_tag="sha-${short_sha}"
+          if [ "$raw" = "main" ]; then
+            tag=main
+          else
+            slug=$(printf '%s' "$raw" | sed 's|/|-|g' | tr -cd '[:alnum:]._-')
+            branch_hash=$(printf '%s' "$raw" | sha256sum | cut -c1-12)
+            if [[ -z "$slug" || ! "$slug" =~ ^[[:alnum:]_] ]]; then
+              slug="branch-${slug}"
+            fi
+            slug=${slug:0:100}
+            tag="${slug}-${branch_hash}"
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=$sha_tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag}-${short_sha}" >> "$GITHUB_OUTPUT"
-          echo "Building preview tag $tag from $short_sha"
+          printf 'Building preview tags %s and %s\n' "$tag" "$sha_tag"
 
   build-preview:
     name: Build ${{ matrix.image }} preview image
@@ -92,21 +109,26 @@ jobs:
             dockerfile: Dockerfile.agents
             extra_build_args: CMD=trove-agent-proxmox
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-      - uses: docker/setup-qemu-action@v4
+      # docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
 
-      - uses: docker/setup-buildx-action@v4
+      # docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        # docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v7
+        # docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -114,6 +136,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/techdox/${{ matrix.image }}:${{ needs.metadata.outputs.tag }}
+            ghcr.io/techdox/${{ matrix.image }}:${{ needs.metadata.outputs.sha_tag }}
           build-args: |
             VERSION=${{ needs.metadata.outputs.version }}
             ${{ matrix.extra_build_args }}

--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -83,9 +83,11 @@ jobs:
             slug=${slug:0:100}
             tag="${slug}-${branch_hash}"
           fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "sha_tag=$sha_tag" >> "$GITHUB_OUTPUT"
-          echo "version=${tag}-${short_sha}" >> "$GITHUB_OUTPUT"
+          {
+            echo "tag=$tag"
+            echo "sha_tag=$sha_tag"
+            echo "version=${tag}-${short_sha}"
+          } >> "$GITHUB_OUTPUT"
           printf 'Building preview tags %s and %s\n' "$tag" "$sha_tag"
 
   build-preview:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,8 +5,10 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  # Mutations use the explicitly supplied, narrowly scoped PAT below. Keep the
+  # ambient GITHUB_TOKEN read-only so a compromised step does not gain a second
+  # write credential.
+  contents: read
 
 jobs:
   release-please:
@@ -46,7 +48,8 @@ jobs:
       # GitHub refuses to trigger other workflows (i.e. CI) on PRs opened by
       # the built-in token, which would leave the release PR permanently
       # unable to satisfy main's required "test" check. See CONTRIBUTING.md.
-      - uses: googleapis/release-please-action@v5
+      # googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@0dfd8538845b8e92600d271a895a5372865d4062
         if: steps.release_merge.outputs.skip != 'true'
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,7 +12,8 @@ jobs:
     name: tag release from release-please manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -37,10 +38,35 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Parse repository-controlled data before any release credential is
+      # present. Isolated mode prevents imports from the checked-out tree.
+      - name: Read release version
+        id: version
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+
+          version=$(python3 -I - <<'PY'
+          import json
+          with open('.release-please-manifest.json', 'r', encoding='utf-8') as f:
+              manifest = json.load(f)
+          version = manifest.get('.')
+          if not isinstance(version, str):
+              raise SystemExit('manifest does not contain package "."')
+          print(version)
+          PY
+          )
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release manifest contains an invalid version."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Create release tag
         if: steps.changed.outputs.changed == 'true'
         env:
           RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -49,17 +75,7 @@ jobs:
             exit 1
           fi
 
-          version=$(python3 - <<'PY'
-          import json
-          with open('.release-please-manifest.json', 'r', encoding='utf-8') as f:
-              manifest = json.load(f)
-          version = manifest.get('.')
-          if not version:
-              raise SystemExit('manifest does not contain package "."')
-          print(version)
-          PY
-          )
-          tag="v${version}"
+          tag="v${VERSION}"
 
           git fetch origin "refs/tags/${tag}:refs/tags/${tag}" 2>/dev/null || true
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,32 +58,40 @@ jobs:
 
       - name: Existing release is already complete
         if: steps.existing_release.outputs.skip == 'true'
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
-          echo "${{ github.ref_name }} is already published; no duplicate release work needed."
+          printf '%s\n' "$TAG is already published; no duplicate release work needed."
 
-      - uses: actions/checkout@v7
+      # actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         if: steps.existing_release.outputs.skip != 'true'
         with:
           fetch-depth: 0 # goreleaser needs tags/history for the changelog
-      - uses: actions/setup-go@v6
+      # actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         if: steps.existing_release.outputs.skip != 'true'
         with:
           go-version-file: go.mod
           cache: true
-      - uses: docker/setup-qemu-action@v4
+      # docker/setup-qemu-action@v4
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
         if: steps.existing_release.outputs.skip != 'true'
-      - uses: docker/setup-buildx-action@v4
+      # docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c
         if: steps.existing_release.outputs.skip != 'true'
       - name: Log in to GHCR
         if: steps.existing_release.outputs.skip != 'true'
-        uses: docker/login-action@v4
+        # docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run goreleaser
         if: steps.existing_release.outputs.skip != 'true'
-        uses: goreleaser/goreleaser-action@v7
+        # goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94
         with:
           version: "~> v2"
           args: release --clean

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker
 # Save the agent's token to .env — Compose loads it automatically and it
 # survives restarts and upgrades. (Don't just `export` it: a new shell would
 # lose it, and re-running with a fresh token silently breaks the agent.)
+umask 077
 echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
 docker compose up -d
 ```
@@ -99,11 +100,15 @@ curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker
 # Save settings to .env (Compose loads it automatically; it persists across
 # restarts). TROVE_TOKEN is Trove's own agent token; TROVE_PROXMOX_TOKEN is
 # your Proxmox API token — two different credentials.
+umask 077
 {
   echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
   echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
   echo "TROVE_PROXMOX_TOKEN=trove@pve!trove-agent=YOUR-TOKEN-SECRET"
 } > .env
+chmod 600 .env
+# If PVE uses its default private CA, copy /etc/pve/pve-root-ca.pem from a node
+# to ./pve-root-ca.pem and uncomment the CA lines in the Compose file.
 # now edit .env to fill in your real PVE host and API token, then:
 docker compose -f docker-compose.proxmox.yml up -d
 ```
@@ -240,6 +245,8 @@ go install github.com/techdox/trove/cmd/trove-server@latest
 | `TROVE_FRESHNESS_INTERVAL` | `5m`       | How often to scan for images due a check.                              |
 | `TROVE_FRESHNESS_TTL`      | `6h`       | How long a resolved digest counts as fresh before rechecking.          |
 | `TROVE_REGISTRY_AUTHS`     | _(unset)_  | Credentials for private registries — see below.                        |
+| `TROVE_REGISTRY_PRIVATE_HOSTS` | _(unset)_ | Comma-separated private registry `host[:port]` allowlist. Hosts in `TROVE_REGISTRY_AUTHS` are allowed automatically. |
+| `TROVE_HEALTH_DETAILS_ENABLED` | `false` | Explicitly retain and display bounded, redacted platform health messages. |
 | `TROVE_EVENT_RETENTION`    | `720h` (30d) | How long events (activity feed / alert stream) are kept.             |
 | `TROVE_REMOVED_RETENTION`  | `24h`      | How long removed services linger before being purged.                  |
 | `TROVE_HOST_RETENTION`     | `720h` (30d) | How long a silent host and its remaining inventory are retained.     |
@@ -260,7 +267,7 @@ Dex, etc.):
 | `TROVE_OIDC_CLIENT_ID` | OAuth2 client ID registered with your IdP |
 | `TROVE_OIDC_CLIENT_SECRET` | OAuth2 client secret |
 | `TROVE_OIDC_REDIRECT_URL` | Callback URL, e.g. `https://trove.example/oauth2/callback` |
-| `TROVE_API_TOKEN` | _(optional)_ Bearer token for programmatic API access (bypasses OIDC) |
+| `TROVE_API_TOKEN` | _(optional)_ Random bearer token of at least 32 characters for programmatic API access (bypasses OIDC) |
 | `TROVE_OIDC_SESSION_MAX_AGE` | _(optional)_ Session duration (default `8h`) |
 
 OIDC is enabled only when all four required `TROVE_OIDC_*` settings are
@@ -274,6 +281,8 @@ your IdP's login page. After login, Trove sets a signed session cookie. API
 requests with a bearer token matching `TROVE_API_TOKEN` bypass OIDC for script
 access. See the safe, copyable example in
 [docs/authentication.md](docs/authentication.md#programmatic-api-access).
+Generate this optional token with `openssl rand -hex 32`; Trove rejects short
+tokens and known documentation placeholders at startup.
 
 Logout clears Trove's local session cookie and, when the provider exposes an
 OIDC `end_session_endpoint`, redirects through provider logout so users are not
@@ -303,8 +312,18 @@ in [docs/authentication.md](docs/authentication.md).
 Private registry / Docker Hub credentials for freshness checks:
 
 ```sh
-TROVE_REGISTRY_AUTHS='{"docker.io":{"username":"me","password":"dckr_pat_..."},"gitea.example.com":{"username":"me","password":"..."}}'
+TROVE_REGISTRY_AUTHS='{"docker.io":{"username":"me","password":"dckr_pat_..."},"gitea.example.com":{"username":"me","password":"...","auth_realm_hosts":["sso.example.com"]}}'
 ```
+
+Private IP ranges are denied by default. A host configured in
+`TROVE_REGISTRY_AUTHS` is an explicit private-network allowlist entry. For an
+anonymous private registry, set its exact endpoint separately, for example
+`TROVE_REGISTRY_PRIVATE_HOSTS=registry.lan:5000`. Loopback, link-local/cloud
+metadata, unspecified, and multicast destinations remain blocked even when
+listed. Registry credentials are sent to a separate bearer-token realm only
+when that realm is the registry itself, Docker Hub's standard auth service, or
+an exact `auth_realm_hosts` entry. Those explicitly trusted realm hosts are
+also eligible to resolve to a private address.
 
 Docker Hub's anonymous rate limits are generous for Trove's batched, cached
 checks at homelab scale, but if you run many distinct Hub images, adding a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,19 +29,28 @@ Trove's security posture is deliberately simple in the current phase:
 - The Docker agent needs the Docker socket mounted read-only; note that socket
   access is inherently sensitive — the agent's own API usage is GET-only, and
   the code is small enough to audit quickly (`cmd/trove-agent-docker`).
-- **Image-freshness requests are guarded against SSRF, with an intentional
-  carve-out for LAN registries.** The `Image` field in an agent's report
+- **Image-freshness requests are guarded against SSRF, with an explicit
+  allowlist for LAN registries.** The `Image` field in an agent's report
   drives an outbound registry request (`internal/registry`); a malicious
   agent token or an image pulled from an attacker-run registry could
   otherwise steer that request anywhere. The server refuses to connect to
   loopback, link-local (which covers every cloud metadata endpoint —
   169.254.169.254 on AWS/GCP/Azure alike), and unspecified/multicast
-  addresses, including through the bearer-auth token endpoint's
-  attacker-influenced redirect. **RFC1918 private ranges are deliberately
-  still reachable** — self-hosted registries on your LAN are a supported,
-  documented use case (`TROVE_REGISTRY_AUTHS`) — so a compromised token can
-  still cause the server to probe other hosts on its own local network.
-  Treat agent tokens accordingly: they are not fully untrusted input.
+  addresses, including through the bearer-auth token endpoint and redirects.
+  RFC1918 and IPv6 ULA destinations are denied unless their exact
+  `host[:port]` is configured in `TROVE_REGISTRY_AUTHS` or
+  `TROVE_REGISTRY_PRIVATE_HOSTS`; loopback and link-local destinations cannot
+  be allowlisted. DNS answers are checked and then dialled directly to prevent
+  rebinding between validation and connection. Registry credentials are not
+  forwarded to an attacker-selected bearer realm; cross-host realms require an
+  explicit `auth_realm_hosts` entry, except for Docker Hub's standard auth
+  endpoint.
+- **Free-form platform health messages are opt-in.** By default the server
+  discards `health_detail` values before persistence and omits historical
+  values from the services API. Setting `TROVE_HEALTH_DETAILS_ENABLED=true`
+  retains the diagnostic feature, but Trove still collapses control/whitespace,
+  redacts common bearer token and named-secret forms, and caps the stored value.
+  Structured health/state/exit-code fields remain available without this flag.
 
 ## Reporting a vulnerability
 

--- a/cmd/trove-agent-proxmox/main.go
+++ b/cmd/trove-agent-proxmox/main.go
@@ -10,6 +10,7 @@
 //	TROVE_AGENT_NAME     name reported to the server (default: hostname)
 //	TROVE_PROXMOX_URL    Proxmox API base, e.g. https://pve.example:8006 (required)
 //	TROVE_PROXMOX_TOKEN  Proxmox API token: USER@REALM!TOKENID=SECRET (required)
+//	TROVE_PROXMOX_CA_FILE  PEM CA bundle for private/self-signed PVE certificates
 //	TROVE_PROXMOX_INSECURE  "true" to skip TLS verification (self-signed certs)
 package main
 

--- a/cmd/trove-agent-proxmox/proxmox.go
+++ b/cmd/trove-agent-proxmox/proxmox.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -24,6 +25,7 @@ type proxmoxConfig struct {
 	url      string // e.g. https://pve.example:8006
 	token    string // USER@REALM!TOKENID=SECRET
 	insecure bool   // skip TLS verification (common for self-signed homelab certs)
+	rootCAs  *x509.CertPool
 }
 
 func loadProxmoxConfig() (proxmoxConfig, error) {
@@ -32,11 +34,33 @@ func loadProxmoxConfig() (proxmoxConfig, error) {
 	if c.url == "" {
 		return c, fmt.Errorf("TROVE_PROXMOX_URL is required (e.g. https://pve.example:8006)")
 	}
+	parsedURL, err := url.Parse(c.url)
+	if err != nil || parsedURL.Scheme != "https" || parsedURL.Host == "" {
+		return c, fmt.Errorf("TROVE_PROXMOX_URL must be an absolute HTTPS URL")
+	}
 	c.token = os.Getenv("TROVE_PROXMOX_TOKEN")
 	if c.token == "" {
 		return c, fmt.Errorf("TROVE_PROXMOX_TOKEN is required (format USER@REALM!TOKENID=SECRET)")
 	}
 	c.insecure, _ = strconv.ParseBool(os.Getenv("TROVE_PROXMOX_INSECURE"))
+	caFile := strings.TrimSpace(os.Getenv("TROVE_PROXMOX_CA_FILE"))
+	if c.insecure && caFile != "" {
+		return c, fmt.Errorf("TROVE_PROXMOX_CA_FILE and TROVE_PROXMOX_INSECURE cannot be used together")
+	}
+	if caFile != "" {
+		pemData, err := os.ReadFile(caFile)
+		if err != nil {
+			return c, fmt.Errorf("read TROVE_PROXMOX_CA_FILE: %w", err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(pemData) {
+			return c, fmt.Errorf("TROVE_PROXMOX_CA_FILE contains no valid PEM certificates")
+		}
+		c.rootCAs = pool
+	}
 	return c, nil
 }
 
@@ -49,10 +73,11 @@ type proxmoxClient struct {
 }
 
 func newProxmoxClient(cfg proxmoxConfig) *proxmoxClient {
-	tr := &http.Transport{}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: cfg.rootCAs}
 	if cfg.insecure {
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // opt-in for homelab self-signed certs
+		tlsConfig.InsecureSkipVerify = true //nolint:gosec // explicit legacy opt-in; secure verification is the default
 	}
+	tr := &http.Transport{TLSClientConfig: tlsConfig}
 	return &proxmoxClient{
 		http:  &http.Client{Timeout: 20 * time.Second, Transport: tr},
 		base:  cfg.url,

--- a/cmd/trove-agent-proxmox/proxmox_test.go
+++ b/cmd/trove-agent-proxmox/proxmox_test.go
@@ -3,15 +3,78 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"encoding/pem"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 
 	"github.com/techdox/trove/pkg/model"
 )
+
+func TestLoadProxmoxConfigRequiresHTTPS(t *testing.T) {
+	t.Setenv("TROVE_PROXMOX_URL", "http://pve.example:8006")
+	t.Setenv("TROVE_PROXMOX_TOKEN", "root@pam!trove=test")
+	t.Setenv("TROVE_PROXMOX_CA_FILE", "")
+	t.Setenv("TROVE_PROXMOX_INSECURE", "")
+
+	if _, err := loadProxmoxConfig(); err == nil {
+		t.Fatal("loadProxmoxConfig accepted an HTTP URL")
+	}
+}
+
+func TestProxmoxClientTrustsConfiguredCAFile(t *testing.T) {
+	api := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "PVEAPIToken=root@pam!trove=test" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		writePVEResponse(t, w, []pveNode{{Node: "pve-a", Status: "online"}})
+	}))
+	defer api.Close()
+
+	caPath := filepath.Join(t.TempDir(), "pve-root-ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: api.Certificate().Raw})
+	if err := os.WriteFile(caPath, caPEM, 0o600); err != nil {
+		t.Fatalf("write CA file: %v", err)
+	}
+	t.Setenv("TROVE_PROXMOX_URL", api.URL)
+	t.Setenv("TROVE_PROXMOX_TOKEN", "root@pam!trove=test")
+	t.Setenv("TROVE_PROXMOX_CA_FILE", caPath)
+	t.Setenv("TROVE_PROXMOX_INSECURE", "")
+
+	cfg, err := loadProxmoxConfig()
+	if err != nil {
+		t.Fatalf("loadProxmoxConfig: %v", err)
+	}
+	var response struct {
+		Data []pveNode `json:"data"`
+	}
+	if err := newProxmoxClient(cfg).get(context.Background(), "/api2/json/nodes", &response); err != nil {
+		t.Fatalf("GET with configured CA: %v", err)
+	}
+	if len(response.Data) != 1 || response.Data[0].Node != "pve-a" {
+		t.Fatalf("response = %+v", response)
+	}
+}
+
+func TestLoadProxmoxConfigRejectsCAWithInsecureMode(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "pve-root-ca.pem")
+	if err := os.WriteFile(caPath, []byte("unused"), 0o600); err != nil {
+		t.Fatalf("write CA file: %v", err)
+	}
+	t.Setenv("TROVE_PROXMOX_URL", "https://pve.example:8006")
+	t.Setenv("TROVE_PROXMOX_TOKEN", "root@pam!trove=test")
+	t.Setenv("TROVE_PROXMOX_CA_FILE", caPath)
+	t.Setenv("TROVE_PROXMOX_INSECURE", "true")
+
+	if _, err := loadProxmoxConfig(); err == nil {
+		t.Fatal("loadProxmoxConfig accepted both CA_FILE and INSECURE")
+	}
+}
 
 func TestCollectSetsGuestImageFromOSType(t *testing.T) {
 	seen := map[string]bool{}

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -96,6 +96,7 @@ Environment:
   TROVE_OIDC_CLIENT_SECRET  OAuth2 client secret
   TROVE_OIDC_REDIRECT_URL   OAuth2 callback URL
   TROVE_API_TOKEN         Bearer token for programmatic API access (with OIDC)
+  TROVE_HEALTH_DETAILS_ENABLED  true to retain/display redacted platform health messages (default false)
   TROVE_HOST_RETENTION    Retain silent hosts before pruning (default "720h")
 `)
 }
@@ -141,6 +142,7 @@ func runServe() error {
 
 	addr := envOr("TROVE_ADDR", ":8080")
 	srv := server.New(st, logger)
+	srv.ConfigureHealthDetails(server.LoadHealthDetailsEnabledFromEnv())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -235,7 +237,7 @@ func runBackup(args []string) error {
 		return fmt.Errorf("stat backup path: %w", err)
 	}
 	if dir := filepath.Dir(dst); dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("create backup directory: %w", err)
 		}
 	}

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -49,9 +49,14 @@ trove@pve!trove-agent=<the-secret-uuid>
 trap above in seconds (run it from wherever the agent will run):
 
 ```sh
-curl -sk -H "Authorization: PVEAPIToken=trove@pve!trove-agent=<secret>" \
+curl --cacert ./pve-root-ca.pem \
+  -H "Authorization: PVEAPIToken=trove@pve!trove-agent=<secret>" \
   https://YOUR-PVE-HOST:8006/api2/json/nodes
 ```
+
+For the default Proxmox certificate, first copy `/etc/pve/pve-root-ca.pem`
+from a PVE node to the machine running the agent. If the API uses a certificate
+issued by a public CA, omit `--cacert`.
 
 You should get a JSON list of your nodes. `{"data":[]}` means the token
 authenticated but has no permission — recheck the `aclmod` and `--privsep 0`
@@ -83,11 +88,16 @@ curl -fsSLO https://raw.githubusercontent.com/techdox/trove/main/examples/docker
 
 # Save settings to .env (Compose loads it automatically; it persists across
 # restarts). Then edit .env to fill in your real PVE host and API token.
+umask 077
 {
   echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
   echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
   echo "TROVE_PROXMOX_TOKEN=trove@pve!trove-agent=YOUR-TOKEN-SECRET"
 } > .env
+chmod 600 .env
+# For Proxmox's default private CA, also copy /etc/pve/pve-root-ca.pem from a
+# PVE node to ./pve-root-ca.pem, then uncomment the CA environment and volume
+# lines in docker-compose.proxmox.yml.
 docker compose -f docker-compose.proxmox.yml up -d
 docker compose -f docker-compose.proxmox.yml logs -f agent   # watch it connect
 ```
@@ -106,7 +116,8 @@ docker run -d --name trove-agent-proxmox --restart unless-stopped \
   -e TROVE_TOKEN=trove_xxxxxxxx \
   -e TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006 \
   -e TROVE_PROXMOX_TOKEN='trove@pve!trove-agent=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' \
-  -e TROVE_PROXMOX_INSECURE=true \
+  -e TROVE_PROXMOX_CA_FILE=/etc/trove/pve-root-ca.pem \
+  -v "$PWD/pve-root-ca.pem:/etc/trove/pve-root-ca.pem:ro" \
   ghcr.io/techdox/trove-agent-proxmox:latest
 ```
 
@@ -114,22 +125,26 @@ docker run -d --name trove-agent-proxmox --restart unless-stopped \
 > agent token (format `trove_…`, from step 2). `TROVE_PROXMOX_TOKEN` is your
 > Proxmox API token (format `user@realm!tokenid=secret`, from step 1).
 
-`TROVE_PROXMOX_INSECURE=true` skips TLS verification — needed for Proxmox's
-default self-signed certificate. Drop it if your PVE API has a real cert.
+TLS verification is always enabled by default. `TROVE_PROXMOX_CA_FILE` adds a
+PEM CA bundle for Proxmox's default private CA. The legacy
+`TROVE_PROXMOX_INSECURE=true` escape hatch disables verification and should
+only be used briefly to diagnose certificate problems; it cannot be combined
+with `TROVE_PROXMOX_CA_FILE`.
 
 Replace `YOUR-SERVER` and `YOUR-PVE-HOST` with addresses reachable from where
 the agent runs (not `localhost` unless the agent shares that host).
 
 ## Configuration
 
-| Variable                 | Default      | Purpose                                          |
-| ------------------------ | ------------ | ------------------------------------------------ |
-| `TROVE_SERVER_URL`       | _(required)_ | Base URL of the Trove server.                    |
-| `TROVE_TOKEN`            | _(required)_ | Trove agent token (`trove_…`), from step 2.      |
-| `TROVE_PROXMOX_URL`      | _(required)_ | PVE API base, e.g. `https://pve.lan:8006`.       |
-| `TROVE_PROXMOX_TOKEN`    | _(required)_ | `USER@REALM!TOKENID=SECRET` from step 1.         |
-| `TROVE_PROXMOX_INSECURE` | `false`      | `true` to accept self-signed certificates.       |
-| `TROVE_INTERVAL`         | `30s`        | Push interval.                                   |
+| Variable                  | Default      | Purpose                                                   |
+| ------------------------- | ------------ | --------------------------------------------------------- |
+| `TROVE_SERVER_URL`        | _(required)_ | Base URL of the Trove server.                             |
+| `TROVE_TOKEN`             | _(required)_ | Trove agent token (`trove_…`), from step 2.               |
+| `TROVE_PROXMOX_URL`       | _(required)_ | HTTPS PVE API base, e.g. `https://pve.lan:8006`.           |
+| `TROVE_PROXMOX_TOKEN`     | _(required)_ | `USER@REALM!TOKENID=SECRET` from step 1.                  |
+| `TROVE_PROXMOX_CA_FILE`   | _(none)_     | PEM CA bundle for a private/self-signed PVE certificate.  |
+| `TROVE_PROXMOX_INSECURE`  | `false`      | Legacy diagnostic opt-out from TLS verification.          |
+| `TROVE_INTERVAL`          | `30s`        | Push interval.                                            |
 
 ## What you'll see
 
@@ -192,8 +207,9 @@ agent`, or `docker logs trove-agent-proxmox`):
 
 - **`collect failed` with an auth/connection error** — the agent can't reach or
   authenticate to the PVE API. Check `TROVE_PROXMOX_URL` is reachable from the
-  agent's host and `TROVE_PROXMOX_TOKEN` is correct (and `TROVE_PROXMOX_INSECURE=true`
-  for a self-signed cert).
+  agent's host and `TROVE_PROXMOX_TOKEN` is correct. For a certificate signed
+  by Proxmox's private CA, mount its root certificate and set
+  `TROVE_PROXMOX_CA_FILE` as shown above.
 - **`collected 0 hosts …` warning** — the token authenticated but returned no
   nodes: it's missing the `PVEAuditor` role or was created with privilege
   separation. Re-run the step-1 `aclmod` / `--privsep 0` commands, or use the

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,7 @@
 
 Trove's API is read-mostly by design. Agents push full-state reports into the server, and humans or automation read catalog state back out.
 
-If OIDC is enabled, read APIs require either an authenticated dashboard session or `Authorization: Bearer TROVE_API_TOKEN_VALUE` when `TROVE_API_TOKEN` is configured. Agent ingest always uses the agent token and is never gated by OIDC.
+If OIDC is enabled, read APIs require either an authenticated dashboard session or `Authorization: Bearer $TROVE_API_TOKEN` when a securely generated `TROVE_API_TOKEN` is configured. Agent ingest always uses the agent token and is never gated by OIDC.
 
 ## Endpoints
 
@@ -26,6 +26,11 @@ Each host group includes its own derived `status` (`ok`, `stale`, `offline`, or
 `unknown`) and `last_seen_at`, plus `agent_status` for the owning agent. Host
 and agent status can differ when a multi-host agent continues reporting some
 hosts after another disappears.
+
+The optional `health_detail` field is omitted by default because upstream
+Docker/Kubernetes messages can contain application output. Operators may opt
+in with `TROVE_HEALTH_DETAILS_ENABLED=true`; enabled values are normalized,
+redacted for common secret forms, and length-limited before storage and output.
 
 `condition` is the platform's latest verdict (`normal`, `warning`, `critical`,
 or `unknown`). It is deliberately separate from reporting `status`: for
@@ -66,8 +71,7 @@ Optional query parameters:
 Example:
 
 ```sh
-TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
-  curl --oauth2-bearer "$TROVE_API_TOKEN" \
+curl --oauth2-bearer "$TROVE_API_TOKEN" \
   'https://trove.example/api/v1/services?limit=100&offset=0&since=2026-07-01T00:00:00Z'
 ```
 
@@ -103,8 +107,7 @@ soft historical references and remain in the feed after their subject is pruned.
 Example:
 
 ```sh
-TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \
-  curl --oauth2-bearer "$TROVE_API_TOKEN" \
+curl --oauth2-bearer "$TROVE_API_TOKEN" \
   'https://trove.example/api/v1/events?kind=health&limit=50&offset=50'
 ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -45,7 +45,7 @@ Optional:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `TROVE_API_TOKEN` | unset | Static bearer token for scripts/API clients that cannot use browser OIDC. |
+| `TROVE_API_TOKEN` | unset | Static bearer token for scripts/API clients that cannot use browser OIDC. Must be at least 32 characters and randomly generated. |
 | `TROVE_OIDC_SESSION_MAX_AGE` | `8h` | Signed dashboard session lifetime. Uses Go duration syntax such as `4h`, `12h`, or `30m`. |
 
 Example:
@@ -55,9 +55,18 @@ TROVE_OIDC_ISSUER=https://auth.example.com/application/o/trove/
 TROVE_OIDC_CLIENT_ID=trove
 TROVE_OIDC_CLIENT_SECRET=OIDC_CLIENT_SECRET_VALUE
 TROVE_OIDC_REDIRECT_URL=https://trove.example.com/oauth2/callback
-TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE
 TROVE_OIDC_SESSION_MAX_AGE=8h
 ```
+
+Only configure programmatic API access when it is needed. Generate its token
+instead of inventing or copying one:
+
+```sh
+openssl rand -hex 32
+```
+
+Store that command's output in `TROVE_API_TOKEN`. Trove rejects short tokens,
+leading/trailing whitespace, and known documentation placeholders at startup.
 
 The session cookie is signed using the OIDC client secret. It is `HttpOnly`, `SameSite=Lax`, and marked `Secure` when the configured redirect URL is HTTPS.
 
@@ -121,8 +130,7 @@ After the provider logout finishes, the user lands back at the dashboard root an
 If OIDC is enabled and you want scripts to query read APIs, set `TROVE_API_TOKEN` and send it as a bearer token:
 
 ```sh
-TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \\
-  curl --oauth2-bearer "$TROVE_API_TOKEN" \\
+curl --oauth2-bearer "$TROVE_API_TOKEN" \\
   https://trove.example.com/api/v1/services
 ```
 
@@ -151,8 +159,7 @@ curl -i https://trove.example.com/api/v1/services
 API requests with `TROVE_API_TOKEN` should return JSON:
 
 ```sh
-TROVE_API_TOKEN=TROVE_API_TOKEN_VALUE \\
-  curl --oauth2-bearer "$TROVE_API_TOKEN" \\
+curl --oauth2-bearer "$TROVE_API_TOKEN" \\
   https://trove.example.com/api/v1/services
 ```
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -89,7 +89,9 @@ docker compose cp server:/data/backups/trove-$(date +%F).db ./backups/
 ```
 
 `trove-server backup` uses SQLite's online `VACUUM INTO` path and refuses to
-overwrite an existing destination file. If you prefer SQLite's own CLI, this is
+overwrite an existing destination file. It creates new parent directories as
+`0700` and the backup itself as `0600`, independent of the caller's normal
+umask. If you prefer SQLite's own CLI, this is
 equivalent:
 
 ```sh

--- a/examples/docker-compose.proxmox.yml
+++ b/examples/docker-compose.proxmox.yml
@@ -6,6 +6,7 @@
 #        https://github.com/techdox/trove/blob/main/docs/agents/proxmox.md
 #   2. Save a Trove token and your Proxmox connection details to .env (Compose
 #      loads .env automatically and it persists across restarts/upgrades):
+#        umask 077
 #        {
 #          echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)"
 #          echo "TROVE_PROXMOX_URL=https://YOUR-PVE-HOST:8006"
@@ -31,7 +32,7 @@ services:
     image: ghcr.io/techdox/trove-server:${TROVE_VERSION:-latest}
     environment:
       TROVE_BOOTSTRAP_AGENT: "proxmox"
-      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first with a restrictive umask; see the file header}"
     ports:
       - "8080:8080"
     volumes:
@@ -47,9 +48,12 @@ services:
       TROVE_TOKEN: "${TROVE_TOKEN}"
       TROVE_PROXMOX_URL: "${TROVE_PROXMOX_URL:?set your Proxmox API URL, e.g. https://192.168.1.10:8006}"
       TROVE_PROXMOX_TOKEN: "${TROVE_PROXMOX_TOKEN:?set your Proxmox API token in the form USER@REALM!TOKENID=SECRET}"
-      # Proxmox ships a self-signed cert by default; "true" accepts it. Set to
-      # "false" (or remove) once your PVE API has a trusted certificate.
-      TROVE_PROXMOX_INSECURE: "true"
+      # TLS verification is enabled by default. For Proxmox's private CA,
+      # uncomment this and the read-only volume below after copying
+      # /etc/pve/pve-root-ca.pem from a PVE node into this directory.
+      # TROVE_PROXMOX_CA_FILE: "/etc/trove/pve-root-ca.pem"
+    # volumes:
+    #   - "./pve-root-ca.pem:/etc/trove/pve-root-ca.pem:ro"
     depends_on:
       server:
         condition: service_healthy

--- a/examples/docker-compose.server.yml
+++ b/examples/docker-compose.server.yml
@@ -4,6 +4,7 @@
 #
 #   1. Save a token for your first agent to .env (Compose loads it automatically
 #      and it persists across restarts/upgrades):
+#        umask 077
 #        echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
 #   2. Start the server:
 #        docker compose -f docker-compose.server.yml up -d
@@ -26,7 +27,7 @@ services:
     image: ghcr.io/techdox/trove-server:latest
     environment:
       TROVE_BOOTSTRAP_AGENT: "first-agent"
-      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first with a restrictive umask; see the file header}"
     ports:
       - "8080:8080"
     volumes:

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -5,6 +5,7 @@
 #   1. Generate a token for this host's agent and save it to .env (Compose
 #      loads .env automatically, and it survives restarts/upgrades — an
 #      `export` would be lost in a new shell):
+#        umask 077
 #        echo "TROVE_TOKEN=trove_$(openssl rand -hex 24)" > .env
 #   2. Start the stack:
 #        docker compose up -d
@@ -23,7 +24,7 @@ services:
     image: ghcr.io/techdox/trove-server:${TROVE_VERSION:-latest}
     environment:
       TROVE_BOOTSTRAP_AGENT: "docker-local"
-      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first:  echo \"TROVE_TOKEN=trove_$(openssl rand -hex 24)\" > .env}"
+      TROVE_BOOTSTRAP_TOKEN: "${TROVE_TOKEN:?generate one first with a restrictive umask; see the file header}"
     ports:
       - "8080:8080"
     volumes:

--- a/internal/alert/dispatch.go
+++ b/internal/alert/dispatch.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,6 +44,23 @@ type Dispatcher interface {
 	Send(ctx context.Context, n Notification) error
 }
 
+type permanentDeliveryError struct{ err error }
+
+func (e *permanentDeliveryError) Error() string { return e.err.Error() }
+func (e *permanentDeliveryError) Unwrap() error { return e.err }
+
+func permanentDelivery(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &permanentDeliveryError{err: err}
+}
+
+func isPermanentDelivery(err error) bool {
+	var target *permanentDeliveryError
+	return errors.As(err, &target)
+}
+
 // Dispatchers builds the set of configured channel dispatchers.
 func Dispatchers(cfg Config) []Dispatcher {
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -72,7 +90,7 @@ func post(ctx context.Context, client *http.Client, build func() (*http.Request,
 		}
 		req, err := build()
 		if err != nil {
-			return err
+			return permanentDelivery(err)
 		}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -87,7 +105,7 @@ func post(ctx context.Context, client *http.Client, build func() (*http.Request,
 		lastErr = fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		// Client errors won't improve on retry.
 		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != 429 {
-			return lastErr
+			return permanentDelivery(lastErr)
 		}
 	}
 	return lastErr
@@ -151,8 +169,8 @@ var discordColors = map[string]int{
 
 func (d *discordDispatcher) Send(ctx context.Context, n Notification) error {
 	embed := map[string]any{
-		"title":       n.Title,
-		"description": n.Body,
+		"title":       truncateRunes(n.Title, 256),
+		"description": truncateRunes(n.Body, 4096),
 		"color":       discordColors[n.Level],
 		"timestamp":   n.At.UTC().Format(time.RFC3339),
 		"footer":      map[string]any{"text": "trove"},
@@ -196,12 +214,17 @@ var ntfyTags = map[string]string{
 }
 
 func (d *ntfyDispatcher) Send(ctx context.Context, n Notification) error {
+	title := truncateRunes(n.Title, 256)
+	body := truncateRunes(n.Body, 4096)
+	if !validHeaderValue(title) {
+		return permanentDelivery(errors.New("ntfy title contains an invalid HTTP header character"))
+	}
 	return post(ctx, d.client, func() (*http.Request, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, strings.NewReader(n.Body))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, d.url, strings.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Title", n.Title)
+		req.Header.Set("Title", title)
 		req.Header.Set("Priority", ntfyPriority[n.Level])
 		req.Header.Set("Tags", ntfyTags[n.Level])
 		if d.token != "" {
@@ -209,4 +232,24 @@ func (d *ntfyDispatcher) Send(ctx context.Context, n Notification) error {
 		}
 		return req, nil
 	})
+}
+
+func validHeaderValue(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] == '\r' || value[i] == '\n' || value[i] == 0x7f || (value[i] < 0x20 && value[i] != '\t') {
+			return false
+		}
+	}
+	return true
+}
+
+func truncateRunes(value string, max int) string {
+	runes := []rune(value)
+	if len(runes) <= max {
+		return value
+	}
+	if max <= 1 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-1]) + "…"
 }

--- a/internal/alert/dispatch_test.go
+++ b/internal/alert/dispatch_test.go
@@ -42,3 +42,34 @@ func TestWebhookDispatcherSignsPayload(t *testing.T) {
 		t.Fatalf("signature = %q, want %q", gotSignature, wantSig)
 	}
 }
+
+func TestPostClassifiesNonRetryable4xxAsPermanent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "payload rejected", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	err := post(context.Background(), srv.Client(), func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL, nil)
+	})
+	if err == nil || !isPermanentDelivery(err) {
+		t.Fatalf("post error = %v, want permanent delivery error", err)
+	}
+}
+
+func TestNtfyRejectsInvalidTitleWithoutSending(t *testing.T) {
+	d := &ntfyDispatcher{client: http.DefaultClient, url: "https://ntfy.example/topic"}
+	err := d.Send(context.Background(), Notification{Title: "bad\nheader", Body: "body"})
+	if err == nil || !isPermanentDelivery(err) {
+		t.Fatalf("ntfy error = %v, want permanent delivery error", err)
+	}
+}
+
+func TestTruncateRunesPreservesUTF8(t *testing.T) {
+	if got := truncateRunes("abcd", 3); got != "ab…" {
+		t.Fatalf("truncateRunes = %q, want %q", got, "ab…")
+	}
+	if got := truncateRunes("éclair", 4); got != "écl…" {
+		t.Fatalf("unicode truncateRunes = %q", got)
+	}
+}

--- a/internal/alert/engine.go
+++ b/internal/alert/engine.go
@@ -473,6 +473,18 @@ func (e *Engine) send(ctx context.Context, key string, n Notification) bool {
 			continue
 		}
 		if err := d.Send(ctx, n); err != nil {
+			if isPermanentDelivery(err) {
+				e.log.Error("alert: permanent channel rejection; dropping for this channel", "channel", d.Name(), "title", n.Title, "err", err)
+				// Treat a channel-specific permanent rejection as consumed. Healthy
+				// channels have already received the event, and retrying this exact
+				// payload can never succeed; pinning the global event cursor here
+				// would suppress every later notification.
+				if markErr := e.store.MarkChannelDelivered(ctx, key, d.Name()); markErr != nil {
+					e.log.Error("alert: record permanent channel rejection", "channel", d.Name(), "title", n.Title, "err", markErr)
+					allDelivered = false
+				}
+				continue
+			}
 			e.log.Error("alert: send failed", "channel", d.Name(), "title", n.Title, "err", err)
 			allDelivered = false
 			continue

--- a/internal/alert/engine_test.go
+++ b/internal/alert/engine_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -29,6 +31,31 @@ type sink struct {
 type namedDispatcher struct {
 	name string
 	Dispatcher
+}
+
+type poisonDispatcher struct {
+	name     string
+	poison   string
+	mu       sync.Mutex
+	accepted []string
+}
+
+func (d *poisonDispatcher) Name() string { return d.name }
+
+func (d *poisonDispatcher) Send(_ context.Context, n Notification) error {
+	if strings.Contains(n.Title, d.poison) {
+		return permanentDelivery(errors.New("payload rejected"))
+	}
+	d.mu.Lock()
+	d.accepted = append(d.accepted, n.Title)
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *poisonDispatcher) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.accepted)
 }
 
 func (d namedDispatcher) Name() string { return d.name }
@@ -316,6 +343,47 @@ func TestEngineRetriesOnlyFailedChannelAfterPartialFanout(t *testing.T) {
 	}
 	if flaky.count() != 4 {
 		t.Fatalf("failed channel was not retried after recovery: %d sends", flaky.count())
+	}
+}
+
+func TestPermanentChannelRejectionDoesNotBlockLaterEvents(t *testing.T) {
+	e, st, good, _ := newTestEngine(t)
+	ctx := context.Background()
+	poison := &poisonDispatcher{name: "payload-sensitive", poison: "poison"}
+	e.dispatchers = []Dispatcher{
+		namedDispatcher{name: "good", Dispatcher: &webhookDispatcher{client: good.srv.Client(), url: good.srv.URL}},
+		poison,
+	}
+	_, agent, _ := st.CreateAgent(ctx, "docker-a")
+	service := func(id, name string, health model.Health) model.ReportService {
+		return model.ReportService{ExternalID: id, Name: name, Kind: model.KindContainer, State: "running", Health: health}
+	}
+
+	_ = st.ApplyReport(ctx, agent.ID, testReport(
+		service("poison", "poison", model.HealthHealthy),
+		service("safe", "safe", model.HealthHealthy),
+	))
+	e.Sweep(ctx) // seed cursor
+
+	_ = st.ApplyReport(ctx, agent.ID, testReport(
+		service("poison", "poison", model.HealthUnhealthy),
+		service("safe", "safe", model.HealthHealthy),
+	))
+	e.Sweep(ctx)
+	if good.count() != 1 || poison.count() != 0 {
+		t.Fatalf("poison event fanout good=%d payload-sensitive=%d, want 1/0", good.count(), poison.count())
+	}
+
+	_ = st.ApplyReport(ctx, agent.ID, testReport(
+		service("poison", "poison", model.HealthUnhealthy),
+		service("safe", "safe", model.HealthUnhealthy),
+	))
+	e.Sweep(ctx)
+	if good.count() != 2 {
+		t.Fatalf("later healthy-channel notification blocked: good sends=%d", good.count())
+	}
+	if poison.count() != 1 {
+		t.Fatalf("later acceptable payload was not delivered: sends=%d", poison.count())
 	}
 }
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -27,8 +26,17 @@ var ErrRateLimited = errors.New("registry rate limited")
 
 // Cred is a username/password for a registry host.
 type Cred struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username       string   `json:"username"`
+	Password       string   `json:"password"`
+	AuthRealmHosts []string `json:"auth_realm_hosts,omitempty"`
+}
+
+// Options controls the registry client's outbound network boundary.
+type Options struct {
+	// AllowedPrivateRegistries contains exact host[:port] endpoints that may
+	// resolve to RFC1918 or IPv6 ULA addresses. Loopback, link-local,
+	// unspecified, and multicast addresses are always rejected.
+	AllowedPrivateRegistries []string
 }
 
 // Client resolves image digests. Safe for concurrent use.
@@ -38,61 +46,144 @@ type Client struct {
 }
 
 // New builds a client with optional per-host credentials.
-func New(creds map[string]Cred) *Client {
+func New(creds map[string]Cred, options ...Options) *Client {
+	privateEndpoints := make(map[string]struct{})
+	for host, cred := range creds {
+		if endpoint, ok := canonicalEndpoint(host); ok {
+			privateEndpoints[endpoint] = struct{}{}
+		}
+		for _, realmHost := range cred.AuthRealmHosts {
+			if endpoint, ok := canonicalEndpoint(realmHost); ok {
+				privateEndpoints[endpoint] = struct{}{}
+			}
+		}
+	}
+	for _, option := range options {
+		for _, host := range option.AllowedPrivateRegistries {
+			if endpoint, ok := canonicalEndpoint(host); ok {
+				privateEndpoints[endpoint] = struct{}{}
+			}
+		}
+	}
+	transport := &http.Transport{
+		DialContext:           newSSRFGuardedDialer(privateEndpoints),
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
 	return &Client{
-		http:  &http.Client{Timeout: 20 * time.Second, Transport: &http.Transport{DialContext: dialSSRFGuard}},
+		http: &http.Client{
+			Timeout:       20 * time.Second,
+			Transport:     transport,
+			CheckRedirect: checkRegistryRedirect,
+		},
 		creds: normalizeCreds(creds),
 	}
 }
 
-// registryDialer rejects connections to network ranges no legitimate
-// registry (or its WWW-Authenticate token endpoint) has any business being
-// on. Both the image reference and the bearer-challenge "realm" URL that
-// drive these requests are attacker-influenced — an agent token or a
-// maliciously published image can set either — so the guard sits at the dial
-// layer, where it also covers HTTP redirects (the stdlib client reuses this
-// same Transport when following one).
-//
-// Control receives the address net/dial has already resolved DNS for, right
-// before connecting — checking here (rather than resolving and checking
-// separately beforehand) means there's no TOCTOU gap for a DNS answer to
-// change between the check and the actual connection.
-//
-// RFC1918 private ranges are deliberately NOT blocked: this project's
-// homelab audience runs self-hosted registries on the LAN
-// (TROVE_REGISTRY_AUTHS exists specifically for that), so blocking private
-// space would break a documented, legitimate use case. What IS blocked —
-// loopback, link-local (which also covers every cloud metadata endpoint;
-// AWS/GCP/Azure all serve theirs from 169.254.169.254), and
-// unspecified/multicast — has no legitimate registry use under any
-// deployment this project supports.
-var registryDialer = &net.Dialer{
-	Timeout: 20 * time.Second,
-	Control: func(_, address string, _ syscall.RawConn) error {
-		host, _, err := net.SplitHostPort(address)
+// newSSRFGuardedDialer resolves a target once, validates every answer, then
+// dials the validated IP directly. This closes the DNS-rebinding/TOCTOU gap
+// between a separate safety lookup and net.Dialer's own resolution. Both
+// registry URLs and attacker-controlled bearer realms/redirects pass through
+// this function.
+func newSSRFGuardedDialer(allowedPrivateEndpoints map[string]struct{}) func(context.Context, string, string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: 20 * time.Second, KeepAlive: 30 * time.Second}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
 		if err != nil {
-			return err
+			return nil, fmt.Errorf("registry: parse destination %q: %w", addr, err)
 		}
-		ip := net.ParseIP(host)
-		if ip == nil {
-			return fmt.Errorf("registry: could not parse resolved address %q", host)
+		_, allowPrivate := allowedPrivateEndpoints[endpointKey(host, port)]
+
+		var resolved []net.IPAddr
+		if ip := net.ParseIP(host); ip != nil {
+			resolved = []net.IPAddr{{IP: ip}}
+		} else {
+			resolved, err = net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("registry: resolve %q: %w", host, err)
+			}
 		}
-		if isBlockedDestination(ip) {
-			return fmt.Errorf("registry: refusing to connect to %s (loopback/link-local/unspecified)", host)
+		if len(resolved) == 0 {
+			return nil, fmt.Errorf("registry: %q resolved to no addresses", host)
 		}
-		return nil
-	},
+		for _, candidate := range resolved {
+			if err := validateDestination(candidate.IP, allowPrivate); err != nil {
+				return nil, fmt.Errorf("registry: refusing destination %q (%s): %w", host, candidate.IP, err)
+			}
+		}
+
+		var dialErrors []error
+		for _, candidate := range resolved {
+			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(candidate.IP.String(), port))
+			if dialErr == nil {
+				return conn, nil
+			}
+			dialErrors = append(dialErrors, dialErr)
+		}
+		return nil, fmt.Errorf("registry: connect to %q: %w", host, errors.Join(dialErrors...))
+	}
 }
 
-func dialSSRFGuard(ctx context.Context, network, addr string) (net.Conn, error) {
-	return registryDialer.DialContext(ctx, network, addr)
+func validateDestination(ip net.IP, allowPrivate bool) error {
+	if ip == nil {
+		return errors.New("invalid IP address")
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() || ip.IsMulticast() {
+		return errors.New("loopback, link-local, unspecified, and multicast addresses are forbidden")
+	}
+	if ip.IsPrivate() && !allowPrivate {
+		return errors.New("private addresses require an explicitly configured registry host")
+	}
+	return nil
 }
 
-// isBlockedDestination reports whether ip is a class of address no
-// legitimate container registry (self-hosted or public) is ever reached at.
-func isBlockedDestination(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified() || ip.IsMulticast()
+func endpointKey(host, port string) string {
+	host = strings.TrimSuffix(strings.ToLower(strings.Trim(host, "[]")), ".")
+	return net.JoinHostPort(host, port)
+}
+
+// canonicalEndpoint converts a configured registry host[:port] into the same
+// exact key used by the dialer. Registries without a port use HTTPS/443.
+func canonicalEndpoint(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsAny(raw, "/?#@") {
+		return "", false
+	}
+	host, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		if ip := net.ParseIP(strings.Trim(raw, "[]")); ip != nil {
+			host, port = ip.String(), "443"
+		} else if strings.Contains(raw, ":") {
+			return "", false
+		} else {
+			host, port = raw, "443"
+		}
+	}
+	if host == "" || port == "" {
+		return "", false
+	}
+	return endpointKey(host, port), true
+}
+
+func checkRegistryRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("registry: stopped after 10 redirects")
+	}
+	if !strings.EqualFold(req.URL.Scheme, "https") {
+		return fmt.Errorf("registry: refusing redirect to non-HTTPS URL %q", req.URL.String())
+	}
+	if len(via) > 0 {
+		previous, previousOK := canonicalEndpoint(via[len(via)-1].URL.Host)
+		next, nextOK := canonicalEndpoint(req.URL.Host)
+		if !previousOK || !nextOK || previous != next {
+			req.Header.Del("Authorization")
+		}
+	}
+	return nil
 }
 
 // manifestAccept lists every manifest/index media type we can handle, so the
@@ -193,7 +284,11 @@ func (c *Client) authorize(ctx context.Context, reg, repo, challenge string) (st
 		if realm == "" {
 			return "", fmt.Errorf("registry %s: bearer challenge missing realm", reg)
 		}
-		q := url.Values{}
+		realmURL, err := parseAuthRealm(realm)
+		if err != nil {
+			return "", fmt.Errorf("registry %s: invalid bearer realm: %w", reg, err)
+		}
+		q := realmURL.Query()
 		if s := params["service"]; s != "" {
 			q.Set("service", s)
 		}
@@ -202,12 +297,13 @@ func (c *Client) authorize(ctx context.Context, reg, repo, challenge string) (st
 			scope = "repository:" + repo + ":pull"
 		}
 		q.Set("scope", scope)
+		realmURL.RawQuery = q.Encode()
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, realm+"?"+q.Encode(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, realmURL.String(), nil)
 		if err != nil {
 			return "", err
 		}
-		if hasCred {
+		if hasCred && credentialAllowedForRealm(reg, realmURL.Host, cred) {
 			req.Header.Set("Authorization", basicAuth(cred))
 		}
 		resp, err := c.http.Do(req)
@@ -237,6 +333,49 @@ func (c *Client) authorize(ctx context.Context, reg, repo, challenge string) (st
 	default:
 		return "", fmt.Errorf("registry %s: unsupported auth scheme %q", reg, scheme)
 	}
+}
+
+func parseAuthRealm(raw string) (*url.URL, error) {
+	realmURL, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(realmURL.Scheme, "https") || realmURL.Host == "" {
+		return nil, errors.New("realm must be an absolute HTTPS URL")
+	}
+	if realmURL.User != nil {
+		return nil, errors.New("realm URL must not contain user information")
+	}
+	if realmURL.Fragment != "" {
+		return nil, errors.New("realm URL must not contain a fragment")
+	}
+	return realmURL, nil
+}
+
+// credentialAllowedForRealm ensures registry credentials are never forwarded
+// to an attacker-selected public token service. Same-endpoint realms are safe;
+// Docker Hub's documented auth host is built in, and operators can explicitly
+// trust additional realm endpoints per credential entry.
+func credentialAllowedForRealm(registryHost, realmHost string, cred Cred) bool {
+	registryEndpoint, registryOK := canonicalEndpoint(registryHost)
+	realmEndpoint, realmOK := canonicalEndpoint(realmHost)
+	if !registryOK || !realmOK {
+		return false
+	}
+	if registryEndpoint == realmEndpoint {
+		return true
+	}
+	dockerRegistry, _ := canonicalEndpoint("registry-1.docker.io")
+	dockerAuth, _ := canonicalEndpoint("auth.docker.io")
+	if registryEndpoint == dockerRegistry && realmEndpoint == dockerAuth {
+		return true
+	}
+	for _, allowed := range cred.AuthRealmHosts {
+		if endpoint, ok := canonicalEndpoint(allowed); ok && endpoint == realmEndpoint {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseImage splits a Docker image reference into registry host, repository,

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -115,16 +115,116 @@ func newSSRFGuardedDialer(allowedPrivateEndpoints map[string]struct{}) func(cont
 			}
 		}
 
-		var dialErrors []error
-		for _, candidate := range resolved {
-			conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(candidate.IP.String(), port))
-			if dialErr == nil {
-				return conn, nil
-			}
-			dialErrors = append(dialErrors, dialErr)
+		conn, err := dialValidatedAddresses(ctx, network, port, resolved, 300*time.Millisecond, dialer.DialContext)
+		if err != nil {
+			return nil, fmt.Errorf("registry: connect to %q: %w", host, err)
 		}
-		return nil, fmt.Errorf("registry: connect to %q: %w", host, errors.Join(dialErrors...))
+		return conn, nil
 	}
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+type dialResult struct {
+	conn net.Conn
+	err  error
+}
+
+// dialValidatedAddresses implements a small Happy-Eyeballs race without
+// handing the hostname back to net.Dialer. Candidates have already passed the
+// SSRF policy, so each attempt dials its validated IP directly. Opposite IP
+// families are interleaved and attempts are staggered to avoid penalising a
+// healthy first route while still escaping a blackholed IPv6 or IPv4 path.
+func dialValidatedAddresses(
+	ctx context.Context,
+	network, port string,
+	resolved []net.IPAddr,
+	fallbackDelay time.Duration,
+	dial dialContextFunc,
+) (net.Conn, error) {
+	candidates := interleaveIPFamilies(resolved)
+	if len(candidates) == 0 {
+		return nil, errors.New("no validated addresses")
+	}
+	attemptCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	results := make(chan dialResult, len(candidates))
+
+	for i, candidate := range candidates {
+		candidate := candidate
+		delay := time.Duration(i) * fallbackDelay
+		go func() {
+			if delay > 0 {
+				timer := time.NewTimer(delay)
+				defer timer.Stop()
+				select {
+				case <-attemptCtx.Done():
+					results <- dialResult{err: attemptCtx.Err()}
+					return
+				case <-timer.C:
+				}
+			}
+			conn, err := dial(attemptCtx, network, net.JoinHostPort(candidate.IP.String(), port))
+			results <- dialResult{conn: conn, err: err}
+		}()
+	}
+
+	dialErrors := make([]error, 0, len(candidates))
+	for received := 0; received < len(candidates); received++ {
+		result := <-results
+		if result.err == nil && result.conn != nil {
+			cancel()
+			// Other attempts may win their race with cancellation. Drain their
+			// buffered results and close any late connection so it cannot leak.
+			go func(remaining int) {
+				for range remaining {
+					late := <-results
+					if late.conn != nil {
+						_ = late.conn.Close()
+					}
+				}
+			}(len(candidates) - received - 1)
+			return result.conn, nil
+		}
+		if result.conn != nil {
+			_ = result.conn.Close()
+		}
+		if result.err != nil {
+			dialErrors = append(dialErrors, result.err)
+		} else {
+			dialErrors = append(dialErrors, errors.New("dial returned no connection"))
+		}
+	}
+	return nil, errors.Join(dialErrors...)
+}
+
+func interleaveIPFamilies(resolved []net.IPAddr) []net.IPAddr {
+	if len(resolved) < 2 {
+		return append([]net.IPAddr(nil), resolved...)
+	}
+	firstIsIPv4 := resolved[0].IP.To4() != nil
+	preferred := make([]net.IPAddr, 0, len(resolved))
+	fallback := make([]net.IPAddr, 0, len(resolved))
+	for _, candidate := range resolved {
+		if (candidate.IP.To4() != nil) == firstIsIPv4 {
+			preferred = append(preferred, candidate)
+		} else {
+			fallback = append(fallback, candidate)
+		}
+	}
+
+	interleaved := make([]net.IPAddr, 0, len(resolved))
+	for len(preferred) > 0 || len(fallback) > 0 {
+		if len(preferred) > 0 {
+			interleaved = append(interleaved, preferred[0])
+			preferred = preferred[1:]
+		}
+		if len(fallback) > 0 {
+			interleaved = append(interleaved, fallback[0])
+			fallback = fallback[1:]
+		}
+	}
+	return interleaved
 }
 
 func validateDestination(ip net.IP, allowPrivate bool) error {

--- a/internal/registry/ssrf_test.go
+++ b/internal/registry/ssrf_test.go
@@ -1,31 +1,116 @@
 package registry
 
-import "testing"
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
 
-func TestRegistryDialerControlBlocksDangerousDestinations(t *testing.T) {
+func TestValidateDestination(t *testing.T) {
 	cases := []struct {
-		name    string
-		address string
-		blocked bool
+		name         string
+		address      string
+		allowPrivate bool
+		blocked      bool
 	}{
-		{"loopback v4", "127.0.0.1:443", true},
-		{"loopback v6", "[::1]:443", true},
-		{"link-local / cloud metadata", "169.254.169.254:80", true},
-		{"link-local multicast", "224.0.0.1:443", true},
-		{"unspecified", "0.0.0.0:443", true},
-		{"public IP (docker hub-ish)", "104.18.121.25:443", false},
-		{"RFC1918 private — must stay allowed for self-hosted registries", "192.168.1.50:5000", false},
-		{"RFC1918 10/8 — must stay allowed", "10.0.0.5:443", false},
+		{"loopback v4", "127.0.0.1", false, true},
+		{"loopback v4 even when allowlisted", "127.0.0.1", true, true},
+		{"loopback v6", "::1", false, true},
+		{"link-local cloud metadata", "169.254.169.254", false, true},
+		{"link-local multicast", "224.0.0.1", false, true},
+		{"unspecified", "0.0.0.0", false, true},
+		{"public IP", "104.18.121.25", false, false},
+		{"RFC1918 private denied by default", "192.168.1.50", false, true},
+		{"RFC1918 private explicitly allowed", "192.168.1.50", true, false},
+		{"IPv6 ULA denied by default", "fd00::1", false, true},
+		{"IPv6 ULA explicitly allowed", "fd00::1", true, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := registryDialer.Control("tcp", tc.address, nil)
+			err := validateDestination(net.ParseIP(tc.address), tc.allowPrivate)
 			if tc.blocked && err == nil {
-				t.Fatalf("expected %s to be blocked, but Control allowed it", tc.address)
+				t.Fatalf("expected %s to be blocked", tc.address)
 			}
 			if !tc.blocked && err != nil {
-				t.Fatalf("expected %s to be allowed, but Control blocked it: %v", tc.address, err)
+				t.Fatalf("expected %s to be allowed: %v", tc.address, err)
 			}
 		})
+	}
+}
+
+func TestCanonicalEndpoint(t *testing.T) {
+	tests := map[string]string{
+		"registry.example.com":      "registry.example.com:443",
+		"REGISTRY.EXAMPLE.COM:5000": "registry.example.com:5000",
+		"[fd00::1]:5000":            "[fd00::1]:5000",
+		"fd00::1":                   "[fd00::1]:443",
+	}
+	for input, want := range tests {
+		got, ok := canonicalEndpoint(input)
+		if !ok || got != want {
+			t.Errorf("canonicalEndpoint(%q) = %q, %v; want %q, true", input, got, ok, want)
+		}
+	}
+	for _, input := range []string{"", "https://registry.example.com", "host/path", "host:bad:port"} {
+		if got, ok := canonicalEndpoint(input); ok {
+			t.Errorf("canonicalEndpoint(%q) = %q, true; want rejection", input, got)
+		}
+	}
+}
+
+func TestParseAuthRealmRequiresSafeHTTPSURL(t *testing.T) {
+	for _, raw := range []string{
+		"http://auth.example/token",
+		"/relative/token",
+		"https://user:password@auth.example/token",
+		"https://auth.example/token#fragment",
+	} {
+		if _, err := parseAuthRealm(raw); err == nil {
+			t.Errorf("parseAuthRealm(%q) unexpectedly succeeded", raw)
+		}
+	}
+	got, err := parseAuthRealm("https://auth.example/token?audience=trove")
+	if err != nil || got.Host != "auth.example" || got.Query().Get("audience") != "trove" {
+		t.Fatalf("valid auth realm = %v, %v", got, err)
+	}
+}
+
+func TestCredentialAllowedForRealm(t *testing.T) {
+	cred := Cred{AuthRealmHosts: []string{"sso.example.com"}}
+	tests := []struct {
+		registry string
+		realm    string
+		want     bool
+	}{
+		{"ghcr.io", "ghcr.io", true},
+		{"registry-1.docker.io", "auth.docker.io", true},
+		{"registry.example.com", "sso.example.com", true},
+		{"registry.example.com", "attacker.example", false},
+	}
+	for _, tt := range tests {
+		if got := credentialAllowedForRealm(tt.registry, tt.realm, cred); got != tt.want {
+			t.Errorf("credentialAllowedForRealm(%q, %q) = %v, want %v", tt.registry, tt.realm, got, tt.want)
+		}
+	}
+}
+
+func TestRegistryRedirectRequiresHTTPSAndStripsCrossOriginAuth(t *testing.T) {
+	previous := &http.Request{URL: &url.URL{Scheme: "https", Host: "registry.example.com"}}
+	crossOrigin := &http.Request{
+		URL:    &url.URL{Scheme: "https", Host: "cdn.example.com", Path: "/manifest"},
+		Header: http.Header{"Authorization": []string{"Bearer secret"}},
+	}
+	if err := checkRegistryRedirect(crossOrigin, []*http.Request{previous}); err != nil {
+		t.Fatalf("HTTPS redirect rejected: %v", err)
+	}
+	if got := crossOrigin.Header.Get("Authorization"); got != "" {
+		t.Fatalf("cross-origin Authorization header retained: %q", got)
+	}
+
+	insecure := &http.Request{URL: &url.URL{Scheme: "http", Host: "registry.example.com"}}
+	if err := checkRegistryRedirect(insecure, []*http.Request{previous}); err == nil || !strings.Contains(err.Error(), "non-HTTPS") {
+		t.Fatalf("HTTP redirect error = %v, want non-HTTPS rejection", err)
 	}
 }

--- a/internal/registry/ssrf_test.go
+++ b/internal/registry/ssrf_test.go
@@ -1,11 +1,13 @@
 package registry
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateDestination(t *testing.T) {
@@ -37,6 +39,49 @@ func TestValidateDestination(t *testing.T) {
 				t.Fatalf("expected %s to be allowed: %v", tc.address, err)
 			}
 		})
+	}
+}
+
+func TestDialValidatedAddressesFallsBackAcrossIPFamilies(t *testing.T) {
+	candidates := []net.IPAddr{
+		{IP: net.ParseIP("2001:db8::1")},
+		{IP: net.ParseIP("2001:db8::2")},
+		{IP: net.ParseIP("192.0.2.10")},
+	}
+	attempts := make(chan string, len(candidates))
+	dial := func(ctx context.Context, _, address string) (net.Conn, error) {
+		attempts <- address
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if net.ParseIP(host).To4() == nil {
+			<-ctx.Done() // simulate a blackholed IPv6 path
+			return nil, ctx.Err()
+		}
+		conn, peer := net.Pipe()
+		_ = peer.Close()
+		return conn, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	started := time.Now()
+	conn, err := dialValidatedAddresses(ctx, "tcp", "443", candidates, 10*time.Millisecond, dial)
+	if err != nil {
+		t.Fatalf("dialValidatedAddresses: %v", err)
+	}
+	defer conn.Close()
+	if elapsed := time.Since(started); elapsed >= 200*time.Millisecond {
+		t.Fatalf("fallback took %s; blackholed first address delayed the successful candidate", elapsed)
+	}
+
+	first := <-attempts
+	second := <-attempts
+	firstHost, _, _ := net.SplitHostPort(first)
+	secondHost, _, _ := net.SplitHostPort(second)
+	if net.ParseIP(firstHost).To4() != nil || net.ParseIP(secondHost).To4() == nil {
+		t.Fatalf("attempt order = %q, %q; want preferred IPv6 then fallback IPv4", first, second)
 	}
 }
 

--- a/internal/server/freshness.go
+++ b/internal/server/freshness.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,10 +15,11 @@ import (
 
 // FreshnessConfig controls the image-freshness checker.
 type FreshnessConfig struct {
-	Enabled  bool
-	Interval time.Duration // how often to scan for images due a check
-	TTL      time.Duration // how long a successful result is considered current
-	Creds    map[string]registry.Cred
+	Enabled                  bool
+	Interval                 time.Duration // how often to scan for images due a check
+	TTL                      time.Duration // how long a successful result is considered current
+	Creds                    map[string]registry.Cred
+	AllowedPrivateRegistries []string
 }
 
 // freshness tuning constants.
@@ -36,6 +38,7 @@ const (
 //	TROVE_FRESHNESS_INTERVAL   scan cadence (Go duration, default 5m)
 //	TROVE_FRESHNESS_TTL        per-image recheck interval (default 6h)
 //	TROVE_REGISTRY_AUTHS       JSON {"host":{"username":..,"password":..}}
+//	TROVE_REGISTRY_PRIVATE_HOSTS comma-separated private registry host[:port] allowlist
 func LoadFreshnessConfigFromEnv() FreshnessConfig {
 	cfg := FreshnessConfig{
 		Enabled:  true,
@@ -63,13 +66,20 @@ func LoadFreshnessConfigFromEnv() FreshnessConfig {
 			cfg.Creds = creds
 		}
 	}
+	if v := os.Getenv("TROVE_REGISTRY_PRIVATE_HOSTS"); v != "" {
+		for _, host := range strings.Split(v, ",") {
+			if host = strings.TrimSpace(host); host != "" {
+				cfg.AllowedPrivateRegistries = append(cfg.AllowedPrivateRegistries, host)
+			}
+		}
+	}
 	return cfg
 }
 
 // ConfigureFreshness enables the freshness checker with the given config.
 func (s *Server) ConfigureFreshness(cfg FreshnessConfig) {
 	s.freshness = cfg
-	s.registry = registry.New(cfg.Creds)
+	s.registry = registry.New(cfg.Creds, registry.Options{AllowedPrivateRegistries: cfg.AllowedPrivateRegistries})
 }
 
 // RunFreshnessLoop periodically resolves the latest registry digest for images

--- a/internal/server/freshness_config_test.go
+++ b/internal/server/freshness_config_test.go
@@ -1,0 +1,19 @@
+package server
+
+import "testing"
+
+func TestLoadFreshnessConfigPrivateRegistryAllowlist(t *testing.T) {
+	t.Setenv("TROVE_REGISTRY_AUTHS", `{"registry.lan:5000":{"username":"trove","password":"secret","auth_realm_hosts":["sso.lan"]}}`)
+	t.Setenv("TROVE_REGISTRY_PRIVATE_HOSTS", "anonymous.lan:5000,  mirror.lan  ,")
+
+	cfg := LoadFreshnessConfigFromEnv()
+	cred, ok := cfg.Creds["registry.lan:5000"]
+	if !ok || cred.Username != "trove" || len(cred.AuthRealmHosts) != 1 || cred.AuthRealmHosts[0] != "sso.lan" {
+		t.Fatalf("registry credentials = %#v", cfg.Creds)
+	}
+	if len(cfg.AllowedPrivateRegistries) != 2 ||
+		cfg.AllowedPrivateRegistries[0] != "anonymous.lan:5000" ||
+		cfg.AllowedPrivateRegistries[1] != "mirror.lan" {
+		t.Fatalf("private registry allowlist = %#v", cfg.AllowedPrivateRegistries)
+	}
+}

--- a/internal/server/health_details.go
+++ b/internal/server/health_details.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+const maxStoredHealthDetailRunes = 512
+
+var (
+	healthBearerSecret = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+`)
+	healthNamedSecret  = regexp.MustCompile(`(?i)\b(authorization|api[_-]?key|password|passwd|secret|token)\s*[:=]\s*[^\s,;]+`)
+)
+
+// LoadHealthDetailsEnabledFromEnv returns the explicit opt-in for collecting,
+// storing, and exposing platform health messages. The secure default is off.
+func LoadHealthDetailsEnabledFromEnv() bool {
+	enabled, err := strconv.ParseBool(os.Getenv("TROVE_HEALTH_DETAILS_ENABLED"))
+	return err == nil && enabled
+}
+
+// ConfigureHealthDetails controls whether optional platform health messages
+// are retained and returned by the services API. It is disabled by default.
+func (s *Server) ConfigureHealthDetails(enabled bool) {
+	s.healthDetailsEnabled = enabled
+}
+
+func (s *Server) filterHealthDetails(report *model.Report) {
+	for i := range report.Services {
+		if !s.healthDetailsEnabled {
+			report.Services[i].HealthDetail = ""
+			continue
+		}
+		report.Services[i].HealthDetail = sanitizeHealthDetail(report.Services[i].HealthDetail)
+	}
+}
+
+func (s *Server) exposedHealthDetail(value string) string {
+	if !s.healthDetailsEnabled {
+		return ""
+	}
+	return sanitizeHealthDetail(value)
+}
+
+func sanitizeHealthDetail(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	value = healthBearerSecret.ReplaceAllString(value, "Bearer [REDACTED]")
+	value = healthNamedSecret.ReplaceAllStringFunc(value, func(match string) string {
+		if i := strings.IndexAny(match, ":="); i >= 0 {
+			return strings.TrimSpace(match[:i]) + "=[REDACTED]"
+		}
+		return "[REDACTED]"
+	})
+	runes := []rune(value)
+	if len(runes) > maxStoredHealthDetailRunes {
+		value = string(runes[:maxStoredHealthDetailRunes-1]) + "…"
+	}
+	return value
+}

--- a/internal/server/health_details_test.go
+++ b/internal/server/health_details_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/techdox/trove/pkg/model"
+)
+
+func TestHealthDetailsDisabledByDefault(t *testing.T) {
+	t.Setenv("TROVE_HEALTH_DETAILS_ENABLED", "")
+	if LoadHealthDetailsEnabledFromEnv() {
+		t.Fatal("health details must be disabled by default")
+	}
+	srv := New(nil, nil)
+	report := &model.Report{Services: []model.ReportService{{HealthDetail: "token=secret"}}}
+	srv.filterHealthDetails(report)
+	if report.Services[0].HealthDetail != "" {
+		t.Fatalf("disabled health detail retained: %q", report.Services[0].HealthDetail)
+	}
+	if got := srv.exposedHealthDetail("old database detail"); got != "" {
+		t.Fatalf("disabled health detail exposed from old data: %q", got)
+	}
+}
+
+func TestEnabledHealthDetailsAreRedactedAndBounded(t *testing.T) {
+	srv := New(nil, nil)
+	srv.ConfigureHealthDetails(true)
+	report := &model.Report{Services: []model.ReportService{{
+		HealthDetail: "request failed\nAuthorization: Bearer abc.def token=topsecret password=hunter2 " + strings.Repeat("x", 700),
+	}}}
+	srv.filterHealthDetails(report)
+	got := report.Services[0].HealthDetail
+	for _, secret := range []string{"abc.def", "topsecret", "hunter2"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("health detail leaked %q: %q", secret, got)
+		}
+	}
+	if strings.Contains(got, "\n") || len([]rune(got)) > maxStoredHealthDetailRunes {
+		t.Fatalf("health detail not normalized/bounded: %q", got)
+	}
+}

--- a/internal/server/ingest.go
+++ b/internal/server/ingest.go
@@ -26,6 +26,7 @@ func (s *Server) handleReport(w http.ResponseWriter, r *http.Request, agent stor
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	s.filterHealthDetails(&report)
 
 	if err := s.store.ApplyReport(r.Context(), agent.ID, &report); err != nil {
 		s.log.Error("apply report", "agent", agent.Name, "err", err)

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -44,6 +44,17 @@ type OIDCConfig struct {
 
 const oidcDiscoveryTimeout = 10 * time.Second
 
+const minAPITokenLength = 32
+
+var rejectedAPITokens = map[string]struct{}{
+	"trove_api_token_value": {},
+	"change-me":             {},
+	"changeme":              {},
+	"example":               {},
+	"secret":                {},
+	"token":                 {},
+}
+
 // Enabled reports whether OIDC authentication is active.
 func (c OIDCConfig) Enabled() bool {
 	return c.Issuer != "" && c.ClientID != "" && c.ClientSecret != "" && c.RedirectURL != ""
@@ -75,6 +86,17 @@ func (c OIDCConfig) validate() error {
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("incomplete OIDC configuration: missing %s", strings.Join(missing, ", "))
+	}
+	if c.APIToken != "" {
+		if c.APIToken != strings.TrimSpace(c.APIToken) {
+			return errors.New("TROVE_API_TOKEN must not have leading or trailing whitespace")
+		}
+		if _, rejected := rejectedAPITokens[strings.ToLower(c.APIToken)]; rejected {
+			return errors.New("TROVE_API_TOKEN uses a public example value; generate one with: openssl rand -hex 32")
+		}
+		if len(c.APIToken) < minAPITokenLength {
+			return fmt.Errorf("TROVE_API_TOKEN must be at least %d characters; generate one with: openssl rand -hex 32", minAPITokenLength)
+		}
 	}
 	return nil
 }

--- a/internal/server/oidc_test.go
+++ b/internal/server/oidc_test.go
@@ -455,6 +455,48 @@ func TestConfigureOIDCRejectsAPITokenWithoutOIDC(t *testing.T) {
 	}
 }
 
+func TestOIDCConfigRejectsWeakAPITokens(t *testing.T) {
+	base := OIDCConfig{
+		Issuer:       "https://idp.example",
+		ClientID:     "client",
+		ClientSecret: "secret",
+		RedirectURL:  "https://trove.example/oauth2/callback",
+	}
+	tests := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{"short", "api-token", "at least 32 characters"},
+		{"documented placeholder", "TROVE_API_TOKEN_VALUE", "public example value"},
+		{"leading whitespace", " " + strings.Repeat("a", minAPITokenLength), "leading or trailing whitespace"},
+		{"trailing whitespace", strings.Repeat("a", minAPITokenLength) + " ", "leading or trailing whitespace"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			cfg.APIToken = tt.token
+			err := cfg.validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validate() error = %v, want text %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestOIDCConfigAcceptsGeneratedLengthAPIToken(t *testing.T) {
+	cfg := OIDCConfig{
+		Issuer:       "https://idp.example",
+		ClientID:     "client",
+		ClientSecret: "secret",
+		RedirectURL:  "https://trove.example/oauth2/callback",
+		APIToken:     strings.Repeat("a", minAPITokenLength),
+	}
+	if err := cfg.validate(); err != nil {
+		t.Fatalf("validate() rejected API token at minimum length: %v", err)
+	}
+}
+
 func TestConfigureOIDCAcceptsCompleteConfiguration(t *testing.T) {
 	var issuer string
 	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/read.go
+++ b/internal/server/read.go
@@ -183,7 +183,7 @@ func (s *Server) handleServices(w http.ResponseWriter, r *http.Request) {
 			ImageDigest:      row.ImageDigest,
 			State:            row.State,
 			Health:           row.Health,
-			HealthDetail:     row.HealthDetail,
+			HealthDetail:     s.exposedHealthDetail(row.HealthDetail),
 			Freshness:        freshness,
 			LatestDigest:     latestDigest,
 			Ports:            rawJSON(row.PortsJSON, "[]"),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,10 @@ type Server struct {
 	// authentication. Agent ingest and /healthz are never gated.
 	oidc *oidcProvider
 
+	// healthDetailsEnabled is an explicit opt-in for storing and returning
+	// platform-provided free-form health messages. The default is false.
+	healthDetailsEnabled bool
+
 	startTime       time.Time
 	reportsAccepted atomic.Uint64
 }

--- a/internal/store/backup.go
+++ b/internal/store/backup.go
@@ -3,7 +3,12 @@ package store
 import (
 	"context"
 	"fmt"
+	"os"
+	"sync"
+	"syscall"
 )
+
+var backupPermissionMu sync.Mutex
 
 // Backup writes a consistent SQLite backup to dst using SQLite's online
 // VACUUM INTO mechanism. SQLite refuses to overwrite an existing output file;
@@ -12,8 +17,20 @@ func (s *Store) Backup(ctx context.Context, dst string) error {
 	if dst == "" {
 		return fmt.Errorf("backup path is required")
 	}
+	// VACUUM INTO insists on creating a new destination itself, so pre-creating
+	// a 0600 file is not possible. The backup command is a single-purpose
+	// process; hold a package lock while applying a restrictive process umask,
+	// then enforce the final mode as defense in depth.
+	backupPermissionMu.Lock()
+	defer backupPermissionMu.Unlock()
+	oldUmask := syscall.Umask(0o077)
+	defer syscall.Umask(oldUmask)
+
 	if _, err := s.db.ExecContext(ctx, `VACUUM INTO ?`, dst); err != nil {
 		return fmt.Errorf("backup database to %q: %w", dst, err)
+	}
+	if err := os.Chmod(dst, 0o600); err != nil {
+		return fmt.Errorf("secure backup permissions for %q: %w", dst, err)
 	}
 	return nil
 }

--- a/internal/store/backup_test.go
+++ b/internal/store/backup_test.go
@@ -20,6 +20,9 @@ func TestBackupWritesDatabaseAndRefusesOverwrite(t *testing.T) {
 	if info.Size() == 0 {
 		t.Fatal("backup is empty")
 	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("backup mode = %04o, want 0600", got)
+	}
 	if err := st.Backup(context.Background(), dst); err == nil {
 		t.Fatal("second backup unexpectedly overwrote existing file")
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Health is the normalized health enum. Agents map platform-specific status
@@ -89,6 +91,14 @@ func (p Platform) Valid() bool {
 // previously reported but is absent from the latest full-state report. Agents
 // never send this value.
 const StateRemoved = "removed"
+
+const (
+	maxIdentityLength     = 255
+	maxExternalIDLength   = 512
+	maxStateLength        = 128
+	maxImageLength        = 2048
+	maxHealthDetailLength = 4096
+)
 
 // Report is the full-state payload an agent POSTs to /api/v1/report. Reports
 // are full snapshots, not deltas: the server replaces its view of the host's
@@ -205,8 +215,8 @@ type Port struct {
 // ingest handler can reject malformed pushes with a 400 before touching the
 // store. It does not enforce business rules beyond the wire contract.
 func (r *Report) Validate() error {
-	if strings.TrimSpace(r.Agent.Name) == "" {
-		return errors.New("agent.name is required")
+	if err := validateTextField("agent.name", r.Agent.Name, maxIdentityLength, true); err != nil {
+		return err
 	}
 	if strings.TrimSpace(string(r.Agent.Platform)) == "" {
 		return errors.New("agent.platform is required")
@@ -214,8 +224,11 @@ func (r *Report) Validate() error {
 	if !r.Agent.Platform.Valid() {
 		return fmt.Errorf("agent.platform %q is not a recognized platform", r.Agent.Platform)
 	}
-	if strings.TrimSpace(r.Host.Hostname) == "" {
-		return errors.New("host.hostname is required")
+	if err := validateTextField("agent.version", r.Agent.Version, maxIdentityLength, false); err != nil {
+		return err
+	}
+	if err := validateTextField("host.hostname", r.Host.Hostname, maxIdentityLength, true); err != nil {
+		return err
 	}
 	if r.Host.Condition != "" && !r.Host.Condition.Valid() {
 		return fmt.Errorf("host.condition %q is not a recognized condition", r.Host.Condition)
@@ -224,9 +237,16 @@ func (r *Report) Validate() error {
 		return err
 	}
 	seen := make(map[string]struct{}, len(r.Services))
-	for i, s := range r.Services {
-		if strings.TrimSpace(s.ExternalID) == "" {
-			return fmt.Errorf("services[%d].external_id is required", i)
+	for i := range r.Services {
+		s := &r.Services[i]
+		if err := validateTextField(fmt.Sprintf("services[%d].external_id", i), s.ExternalID, maxExternalIDLength, true); err != nil {
+			return err
+		}
+		if err := validateTextField(fmt.Sprintf("services[%d].parent_external_id", i), s.ParentExternalID, maxExternalIDLength, false); err != nil {
+			return err
+		}
+		if err := validateTextField(fmt.Sprintf("services[%d].name", i), s.Name, maxIdentityLength, false); err != nil {
+			return err
 		}
 		if _, dup := seen[s.ExternalID]; dup {
 			return fmt.Errorf("services[%d].external_id %q is duplicated within the report", i, s.ExternalID)
@@ -235,14 +255,39 @@ func (r *Report) Validate() error {
 		if !s.Kind.Valid() {
 			return fmt.Errorf("services[%d].kind %q is not a recognized kind", i, s.Kind)
 		}
-		if strings.TrimSpace(s.State) == "" {
-			return fmt.Errorf("services[%d].state is required", i)
+		if err := validateTextField(fmt.Sprintf("services[%d].state", i), s.State, maxStateLength, true); err != nil {
+			return err
 		}
 		if s.State == StateRemoved {
 			return fmt.Errorf("services[%d].state %q is server-derived", i, s.State)
 		}
 		if !s.Health.Valid() {
 			return fmt.Errorf("services[%d].health %q is not an agent-reportable health value", i, s.Health)
+		}
+		if err := validateTextField(fmt.Sprintf("services[%d].image", i), s.Image, maxImageLength, false); err != nil {
+			return err
+		}
+		if utf8.RuneCountInString(s.HealthDetail) > maxHealthDetailLength {
+			return fmt.Errorf("services[%d].health_detail exceeds %d characters", i, maxHealthDetailLength)
+		}
+	}
+	return nil
+}
+
+// validateTextField constrains attacker-influenced identifiers before they
+// enter storage, alert titles, HTTP headers, or channel payloads. Human-facing
+// identity fields never need control characters; rejecting them here avoids
+// channel-specific header injection and poison-message failures.
+func validateTextField(field, value string, maxLength int, required bool) error {
+	if required && strings.TrimSpace(value) == "" {
+		return fmt.Errorf("%s is required", field)
+	}
+	if utf8.RuneCountInString(value) > maxLength {
+		return fmt.Errorf("%s exceeds %d characters", field, maxLength)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%s contains a control character", field)
 		}
 	}
 	return nil

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -52,6 +52,12 @@ func TestReportValidate(t *testing.T) {
 			r.Host.Metrics = &HostMetrics{Memory: &HostResourceUsage{UsedBytes: 11, TotalBytes: 10}}
 		}},
 		{"missing external id", func(r *Report) { r.Services[0].ExternalID = "" }},
+		{"service name control character", func(r *Report) { r.Services[0].Name = "api\nX-Header: injected" }},
+		{"service name too long", func(r *Report) { r.Services[0].Name = strings.Repeat("a", maxIdentityLength+1) }},
+		{"hostname control character", func(r *Report) { r.Host.Hostname = "host\r\nmalicious" }},
+		{"external id too long", func(r *Report) { r.Services[0].ExternalID = strings.Repeat("a", maxExternalIDLength+1) }},
+		{"image control character", func(r *Report) { r.Services[0].Image = "registry.example/image\nnext" }},
+		{"health detail too long", func(r *Report) { r.Services[0].HealthDetail = strings.Repeat("a", maxHealthDetailLength+1) }},
 		{"bad kind", func(r *Report) { r.Services[0].Kind = "widget" }},
 		{"missing service state", func(r *Report) { r.Services[0].State = " 	" }},
 		{"agent may not report removed", func(r *Report) { r.Services[0].State = StateRemoved }},

--- a/scripts/check-dockerfile-drift.sh
+++ b/scripts/check-dockerfile-drift.sh
@@ -11,7 +11,7 @@
 #   Dockerfile.agents -> build/docker/Dockerfile.agent-proxmox
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 fail=0
 
@@ -22,7 +22,19 @@ final_stage_runtime() {
   local file=$1
   awk '/^FROM /{stage=""} {stage=stage $0 "\n"} END{printf "%s", stage}' "$file" \
     | sed -e 's/#.*$//' \
-    | tr -d '\\' \
+    | awk '
+        {
+          line = pending $0
+          if (line ~ /\\[[:space:]]*$/) {
+            sub(/\\[[:space:]]*$/, " ", line)
+            pending = line
+            next
+          }
+          print line
+          pending = ""
+        }
+        END { if (pending != "") print pending }
+      ' \
     | tr -s ' \t' ' ' \
     | grep -E '^ ?(FROM|ENV|EXPOSE|VOLUME) ' \
     | sed -e 's/^ //' -e 's/ $//' \
@@ -43,9 +55,15 @@ check_pair() {
   fi
 }
 
-check_pair Dockerfile.server build/docker/Dockerfile.server
-check_pair Dockerfile.agent  build/docker/Dockerfile.agent-docker
-check_pair Dockerfile.agents build/docker/Dockerfile.agent-k8s
-check_pair Dockerfile.agents build/docker/Dockerfile.agent-proxmox
+main() {
+  cd "$repo_root"
+  check_pair Dockerfile.server build/docker/Dockerfile.server
+  check_pair Dockerfile.agent  build/docker/Dockerfile.agent-docker
+  check_pair Dockerfile.agents build/docker/Dockerfile.agent-k8s
+  check_pair Dockerfile.agents build/docker/Dockerfile.agent-proxmox
+  exit "$fail"
+}
 
-exit "$fail"
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/check-dockerfile-drift_test.sh
+++ b/scripts/check-dockerfile-drift_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+source "$repo_root/scripts/check-dockerfile-drift.sh"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+cat >"$tmp/dev" <<'EOF'
+FROM scratch
+ENV TROVE_ONE=one \
+    TROVE_TWO=two
+EOF
+
+cat >"$tmp/same" <<'EOF'
+FROM scratch
+ENV TROVE_ONE=one \
+    TROVE_TWO=two
+EOF
+
+cat >"$tmp/drift" <<'EOF'
+FROM scratch
+ENV TROVE_ONE=one \
+    TROVE_TWO=changed
+EOF
+
+if [[ $(final_stage_runtime "$tmp/dev") != $(final_stage_runtime "$tmp/same") ]]; then
+  echo "equal continued ENV directives were reported as drift" >&2
+  exit 1
+fi
+if [[ $(final_stage_runtime "$tmp/dev") == $(final_stage_runtime "$tmp/drift") ]]; then
+  echo "changed value in continued ENV directive was not detected" >&2
+  exit 1
+fi
+
+echo "ok: continued Dockerfile directives are compared atomically"


### PR DESCRIPTION
## Summary

Remediates all 15 findings from the July 2026 Codex security report:

- 4 high
- 9 medium
- 1 low
- 1 informational

## Changes

- Enforce strong, non-placeholder API tokens.
- Pin privileged GitHub Actions to immutable commit SHAs.
- Isolate release manifest parsing from release credentials.
- Prevent tag-name command injection and preview-tag collisions.
- Close registry SSRF, redirect, DNS-rebinding, and credential-forwarding paths.
- Add explicit private-registry and authentication-realm allowlists.
- Constrain attacker-controlled report and alert fields.
- Prevent permanently rejected alert payloads from blocking later notifications.
- Disable raw health details by default and redact bounded values when enabled.
- Create database backups and documented `.env` files with restrictive permissions.
- Restore Proxmox TLS verification by default with custom-CA support.
- Fix Dockerfile drift detection for continued directives.

## Operator impact

- `TROVE_API_TOKEN` must be randomly generated and at least 32 characters.
- Private registries resolving to private addresses must be explicitly configured.
- Raw health details require `TROVE_HEALTH_DETAILS_ENABLED=true`.
- Proxmox private CAs should be mounted and configured with `TROVE_PROXMOX_CA_FILE`.
- `TROVE_PROXMOX_INSECURE=true` remains only as a legacy diagnostic escape hatch.

## Validation

Passed locally:

- `gofmt`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `golangci-lint`
- `actionlint`
- GoReleaser configuration validation
- Release-surface validation
- Dockerfile drift regression tests
- Linux amd64 and arm64 cross-builds