### PR TITLE
fix: publish container digests with releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
             "trove-server_${version}_linux_arm64.tar.gz"
             "trove-server_${version}_linux_arm64.tar.gz.sbom.spdx.json"
           )
+          printf '%s\n' "${expected_assets[@]}" > "$RUNNER_TEMP/trove-expected-release-assets.txt"
 
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' > /tmp/trove-release-assets.txt 2>/tmp/trove-release-check.err; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -125,6 +126,28 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify published release assets
+        if: steps.existing_release.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' > "$RUNNER_TEMP/trove-release-assets.txt"
+
+          missing=0
+          while IFS= read -r asset; do
+            if ! grep -Fxq "$asset" "$RUNNER_TEMP/trove-release-assets.txt"; then
+              echo "::error::Published release $TAG is missing expected asset: $asset"
+              missing=1
+            fi
+          done < "$RUNNER_TEMP/trove-expected-release-assets.txt"
+
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Release $TAG was published without its complete artifact set."
+            exit 1
+          fi
       - name: Attest release archives and SBOMs
         if: steps.existing_release.outputs.skip != 'true'
         # actions/attest@v4

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,6 +146,10 @@ changelog:
     exclude: ["^docs:", "^chore:", "^ci:"]
 
 release:
+  # docker_digest is generated during the publish phase but is not an
+  # uploadable artifact unless it is explicitly added to the release.
+  extra_files:
+    - glob: ./dist/digests.txt
   # Preserve the exact tagged commit in GitHub release metadata. Release Please
   # uses that reference to identify the latest release boundary.
   target_commitish: "{{ .Commit }}"


### PR DESCRIPTION
## Summary

- Publish GoReleaser's generated `dist/digests.txt` as a GitHub release asset.
- Verify the complete promised asset set immediately after each new release is published.

## Root cause

The `docker_digest` pipe generated `dist/digests.txt` for image attestations, but GoReleaser does not classify that file as a release-uploadable artifact. The existing completeness check only examined releases that already existed before the job, so the first v0.16.0 run remained green despite omitting the file from the release page.

## Impact

The v0.16.0 release has already been repaired by attaching the exact digest file reconstructed from the immutable release logs and verified against the live OCI indexes and signed provenance attestations. Future releases will upload the file automatically and fail visibly if any expected asset is missing after publication.

## Verification

- `go run github.com/goreleaser/goreleaser/v2@v2.17.0 check`
- Workflow YAML parse
- `git diff --check`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- Downloaded the repaired v0.16.0 `digests.txt` and byte-compared it with the verified source file (`sha256:2ac3eac05095ccee577dc576c8ae6c8a4a1d60bfc15eace7102abdb1cd8e2cef`)

## Notes

This changes release metadata and validation only. It does not rebuild, retag, or modify the v0.16.0 binaries or container images.