### PR TITLE
feat: rotate agent credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create <name>
 # e.g. <name> = docker-nas, k8s-homelab, proxmox
 ```
 
+If an agent token is exposed or the host changes hands, rotate it with
+`trove-server agent rotate <name>`. Rotation immediately invalidates the old
+token, without deleting the agent or its history. Follow the platform-specific
+[maintenance-window rotation guide](docs/agents/rotation.md) before running the
+command.
+
 Then follow the guide for the platform:
 
 | Platform                | Agent                 | Guide                                             |

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -6,6 +6,7 @@
 //	trove-server [serve]                 run the server (default)
 //	trove-server agent create <name>     mint a bearer token for a new agent
 //	trove-server agent list              list agents and last-seen
+//	trove-server agent rotate <name>     replace an agent bearer token
 //	trove-server agent delete <name>     remove an agent and its data
 //
 // Config (serve): TROVE_ADDR (default :8080), TROVE_DB (default trove.db).
@@ -87,6 +88,7 @@ Commands:
   serve                     run the server (default)
   agent create <name>       mint a bearer token for a new agent
   agent list                list agents with last-seen status
+  agent rotate <name>       replace an agent bearer token
   agent delete <name>       remove an agent and all its data
   alert test                send a test notification through configured channels
   backup [path]             write a consistent SQLite backup (default timestamped file)
@@ -464,7 +466,7 @@ func runHealthcheck() error {
 
 func runAgent(args []string) error {
 	if len(args) == 0 {
-		return errors.New("usage: trove-server agent <create|list|delete> ...")
+		return errors.New("usage: trove-server agent <create|list|rotate|delete> ...")
 	}
 	st, err := openStore()
 	if err != nil {
@@ -481,6 +483,11 @@ func runAgent(args []string) error {
 		return agentCreate(ctx, st, args[1])
 	case "list":
 		return agentList(ctx, st)
+	case "rotate":
+		if len(args) != 2 {
+			return errors.New("usage: trove-server agent rotate <name>")
+		}
+		return agentRotate(ctx, st, args[1])
 	case "delete", "rm":
 		if len(args) < 2 {
 			return errors.New("usage: trove-server agent delete <name>")
@@ -542,6 +549,24 @@ func agentList(ctx context.Context, st *store.Store) error {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", a.Name, platform, ver, status, lastSeenStr)
 	}
 	return tw.Flush()
+}
+
+func agentRotate(ctx context.Context, st *store.Store, name string) error {
+	token, err := st.RotateAgentToken(ctx, name)
+	if err != nil {
+		return err
+	}
+	fmt.Printf(`Rotated token for agent %q.
+
+  Replacement token (shown once — store it now, it is not recoverable):
+
+      %s
+
+  The previous token stopped working immediately. Update the agent's
+  TROVE_TOKEN and restart or redeploy it now.
+
+`, strings.TrimSpace(name), token)
+	return nil
 }
 
 func agentDelete(ctx context.Context, st *store.Store, name string) error {

--- a/cmd/trove-server/main_test.go
+++ b/cmd/trove-server/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -98,6 +99,84 @@ func TestRunSupervisedMarksWorkerUnavailableDuringBackoff(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("supervisor did not leave backoff after context cancellation")
 	}
+}
+
+func TestRunAgentRotateReplacesToken(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "trove.db")
+	t.Setenv("TROVE_DB", dbPath)
+	st, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	oldToken, agent, err := st.CreateAgent(ctx, "docker-a")
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+
+	output, err := captureStdout(t, func() error {
+		return runAgent([]string{"rotate", agent.Name})
+	})
+	if err != nil {
+		t.Fatalf("run rotate: %v", err)
+	}
+	if !strings.Contains(output, `Rotated token for agent "docker-a"`) || !strings.Contains(output, "previous token stopped working immediately") {
+		t.Fatalf("rotate output = %q", output)
+	}
+	newToken := firstToken(output)
+	if newToken == "" || newToken == oldToken {
+		t.Fatalf("replacement token = %q, want new token", newToken)
+	}
+	if _, err := st.AuthenticateByToken(ctx, oldToken); !errors.Is(err, store.ErrAgentNotFound) {
+		t.Fatalf("old token auth error = %v, want ErrAgentNotFound", err)
+	}
+	got, err := st.AuthenticateByToken(ctx, newToken)
+	if err != nil {
+		t.Fatalf("new token auth: %v", err)
+	}
+	if got.ID != agent.ID {
+		t.Fatalf("rotated agent id = %d, want %d", got.ID, agent.ID)
+	}
+	if err := runAgent([]string{"rotate"}); err == nil || !strings.Contains(err.Error(), "usage") {
+		t.Fatalf("rotate without name error = %v, want usage", err)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = previous
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	callErr := fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	os.Stdout = previous
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	return string(output), callErr
+}
+
+func firstToken(output string) string {
+	for _, field := range strings.Fields(output) {
+		if strings.HasPrefix(field, "trove_") {
+			return field
+		}
+	}
+	return ""
 }
 
 type compatibilitySnapshot struct {

--- a/docs/agents/docker.md
+++ b/docs/agents/docker.md
@@ -18,6 +18,9 @@ docker compose exec server trove-server agent create docker-nuc01
 
 Copy the `trove_...` token — it is shown once.
 
+To replace an exposed or retired token without deleting this agent's history,
+follow the [agent-token rotation guide](rotation.md).
+
 ## 2. Run the agent
 
 ```sh

--- a/docs/agents/kubernetes.md
+++ b/docs/agents/kubernetes.md
@@ -24,6 +24,9 @@ docker compose exec server trove-server agent create k8s-homelab
 # bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create k8s-homelab
 ```
 
+To replace an exposed or retired token without deleting this agent's history,
+follow the [agent-token rotation guide](rotation.md).
+
 ## 2. Create the namespace + token secret
 
 ```sh

--- a/docs/agents/local.md
+++ b/docs/agents/local.md
@@ -21,6 +21,9 @@ docker compose exec server trove-server agent create nas01
 # bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create nas01
 ```
 
+To replace an exposed or retired token without deleting this agent's history,
+follow the [agent-token rotation guide](rotation.md).
+
 ## 2. Install the binary + unit
 
 ```sh

--- a/docs/agents/proxmox.md
+++ b/docs/agents/proxmox.md
@@ -76,6 +76,9 @@ docker compose exec server trove-server agent create proxmox
 # bare-metal server: sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent create proxmox
 ```
 
+To replace an exposed or retired token without deleting this agent's history,
+follow the [agent-token rotation guide](rotation.md).
+
 ## 3. Run the agent
 
 ### With Docker Compose (server + agent together)

--- a/docs/agents/rotation.md
+++ b/docs/agents/rotation.md
@@ -1,0 +1,93 @@
+# Rotating an agent token
+
+Rotate an agent token when a host changes hands, a token may have been exposed,
+or as part of routine credential maintenance. Rotation preserves the agent, its
+hosts, services, events, and alert state.
+
+The replacement is intentionally immediate: when `agent rotate` succeeds, the
+old token is invalid. Schedule a short maintenance window and have the agent's
+configuration ready to update before running it. A temporary `401` and a stale
+agent while the old process is still running are expected; they stop once the
+agent is recreated or restarted with the replacement token.
+
+## 1. Mint the replacement token
+
+Run this on the machine that owns the Trove database:
+
+```sh
+# Docker Compose server:
+docker compose exec server trove-server agent rotate <name>
+
+# Bare-metal server:
+sudo TROVE_DB=/var/lib/trove/trove.db trove-server agent rotate <name>
+```
+
+The replacement `trove_...` token is shown once. Store it in the platform's
+secret or environment file immediately. Do not put it in source control, shell
+history, or a ticket.
+
+## 2. Replace the token and restart the agent
+
+### Docker Compose
+
+Update `TROVE_TOKEN` in the Compose `.env` file, then recreate **only** the
+agent service. The server does not need a restart:
+
+```sh
+docker compose up -d --force-recreate agent
+```
+
+If you use the Proxmox Compose example, include its file name:
+
+```sh
+docker compose -f docker-compose.proxmox.yml up -d --force-recreate agent
+```
+
+### Docker run
+
+Container environment variables cannot be changed in place. Remove and recreate
+the agent container with the same command used at installation, substituting the
+replacement `TROVE_TOKEN`:
+
+```sh
+docker rm -f trove-agent
+# Re-run the documented docker run command with the replacement TROVE_TOKEN.
+```
+
+### Kubernetes
+
+Replace the Secret value, then restart the Deployment so it reads the new
+environment variable:
+
+```sh
+read -r -s TROVE_REPLACEMENT
+printf '\n'
+kubectl -n trove create secret generic trove-agent \
+  --from-literal=token="$TROVE_REPLACEMENT" \
+  --dry-run=client -o yaml | kubectl apply -f -
+unset TROVE_REPLACEMENT
+kubectl -n trove rollout restart deployment/trove-agent
+kubectl -n trove rollout status deployment/trove-agent
+```
+
+### Bare-metal Linux (systemd)
+
+Edit the private environment file, replace only `TROVE_TOKEN`, then restart the
+unit:
+
+```sh
+sudoedit /etc/trove-agent-local.env
+sudo systemctl restart trove-agent-local
+sudo systemctl status trove-agent-local --no-pager
+```
+
+## 3. Verify
+
+Check the platform's logs for a successful report and confirm the agent returns
+to `reporting ok` in Trove. If it keeps returning `401`, the replacement was
+saved to the wrong config file, the old process was not recreated, or the token
+was minted against a different Trove database.
+
+Never use `agent create` as a rotation workaround: it creates a second agent
+and splits the inventory/history. `agent rotate <name>` keeps the existing
+agent identity intact.

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -79,6 +79,44 @@ func (s *Store) CreateAgent(ctx context.Context, name string) (token string, age
 	return token, Agent{ID: id, Name: name, CreatedAt: now}, nil
 }
 
+// RotateAgentToken replaces an agent's bearer token and returns the one-time
+// plaintext replacement. The old token stops authenticating as soon as this
+// method succeeds. The plaintext is never stored.
+func (s *Store) RotateAgentToken(ctx context.Context, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", ErrAgentNotFound
+	}
+
+	// A collision between independently generated 256-bit tokens is
+	// extraordinarily unlikely, but token_hash is unique, so retry rather than
+	// ever returning a token that was not stored.
+	for attempt := 0; attempt < 3; attempt++ {
+		token, err := generateToken()
+		if err != nil {
+			return "", err
+		}
+		res, err := s.db.ExecContext(ctx,
+			`UPDATE agents SET token_hash = ? WHERE name = ?`, HashToken(token), name,
+		)
+		if err != nil {
+			if isUniqueViolation(err) {
+				continue
+			}
+			return "", fmt.Errorf("rotate agent token: %w", err)
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return "", fmt.Errorf("rotate agent token: %w", err)
+		}
+		if n == 0 {
+			return "", ErrAgentNotFound
+		}
+		return token, nil
+	}
+	return "", errors.New("rotate agent token: generated token collision")
+}
+
 // EnsureAgentWithToken creates an agent with a caller-supplied token when no
 // agent of that name exists yet, and reports whether it created one. This
 // backs the docker-compose dev bootstrap (TROVE_BOOTSTRAP_*); production mints

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -102,6 +102,76 @@ func TestAgentCreateAndAuthenticate(t *testing.T) {
 	}
 }
 
+func TestRotateAgentTokenPreservesAgentData(t *testing.T) {
+	st, _ := newTestStore(t)
+	ctx := context.Background()
+
+	oldToken, agent, err := st.CreateAgent(ctx, "docker-a")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := st.ApplyReport(ctx, agent.ID, report(svc("c1", "running", model.HealthHealthy))); err != nil {
+		t.Fatalf("apply report: %v", err)
+	}
+	beforeHosts, err := st.ListHosts(ctx)
+	if err != nil {
+		t.Fatalf("list hosts before rotation: %v", err)
+	}
+	beforeServices, err := st.ListServices(ctx)
+	if err != nil {
+		t.Fatalf("list services before rotation: %v", err)
+	}
+	beforeEvents, err := st.RecentEvents(ctx, 100)
+	if err != nil {
+		t.Fatalf("list events before rotation: %v", err)
+	}
+
+	newToken, err := st.RotateAgentToken(ctx, " docker-a ")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if newToken == "" || newToken == oldToken {
+		t.Fatalf("replacement token = %q, want new non-empty token", newToken)
+	}
+	if _, err := st.AuthenticateByToken(ctx, oldToken); !errors.Is(err, ErrAgentNotFound) {
+		t.Fatalf("old token auth error = %v, want ErrAgentNotFound", err)
+	}
+	got, err := st.AuthenticateByToken(ctx, newToken)
+	if err != nil {
+		t.Fatalf("new token auth: %v", err)
+	}
+	if got.ID != agent.ID || got.Name != agent.Name {
+		t.Fatalf("rotated agent = %+v, want id=%d name=%q", got, agent.ID, agent.Name)
+	}
+
+	var storedHash string
+	if err := st.db.QueryRowContext(ctx, `SELECT token_hash FROM agents WHERE id = ?`, agent.ID).Scan(&storedHash); err != nil {
+		t.Fatalf("read stored token hash: %v", err)
+	}
+	if storedHash != HashToken(newToken) || storedHash == newToken {
+		t.Fatalf("stored token hash = %q, want hash only", storedHash)
+	}
+
+	afterHosts, err := st.ListHosts(ctx)
+	if err != nil {
+		t.Fatalf("list hosts after rotation: %v", err)
+	}
+	afterServices, err := st.ListServices(ctx)
+	if err != nil {
+		t.Fatalf("list services after rotation: %v", err)
+	}
+	afterEvents, err := st.RecentEvents(ctx, 100)
+	if err != nil {
+		t.Fatalf("list events after rotation: %v", err)
+	}
+	if len(afterHosts) != len(beforeHosts) || len(afterServices) != len(beforeServices) || len(afterEvents) != len(beforeEvents) {
+		t.Fatalf("rotation changed stored data: hosts %d->%d services %d->%d events %d->%d", len(beforeHosts), len(afterHosts), len(beforeServices), len(afterServices), len(beforeEvents), len(afterEvents))
+	}
+	if _, err := st.RotateAgentToken(ctx, "missing"); !errors.Is(err, ErrAgentNotFound) {
+		t.Fatalf("missing agent error = %v, want ErrAgentNotFound", err)
+	}
+}
+
 func TestApplyReportUpsertAndEvents(t *testing.T) {
 	st, clock := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- add `trove-server agent rotate <name>` to replace an existing agent token
- invalidate the old token immediately while preserving the agent identity, inventory, history, and alert state
- store only the replacement hash in SQLite; display the plaintext token exactly once
- document maintenance-window rotation for Compose, Docker, Kubernetes, Proxmox, and systemd

## Why

Operators need to retire a potentially exposed agent credential without creating a second agent or discarding its historical context.

## Validation

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `make native`
- [x] `python3 scripts/check_markdown_links.py`
- [x] `python3 scripts/check_release_surface.py`
- [x] `git diff --check`