### PR TITLE
feat: add diagnostic doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,20 @@ interface; see [CONTRIBUTING.md](CONTRIBUTING.md).
 Upgrades are a `pull` (or binary swap) and restart away: schema migrations apply
 automatically on startup and are additive. Upgrade the server first; agents from
 the immediately previous release may lag while the rollout completes.
+
+Before an upgrade or when collecting a safe support report, run
+`trove-server doctor` on the server. It checks the configured database and
+local configuration without contacting external services, creating a database,
+applying migrations, or printing credentials:
+
+```sh
+# Docker Compose
+docker compose exec server trove-server doctor
+
+# Bare metal
+sudo TROVE_DB=/var/lib/trove/trove.db trove-server doctor
+```
+
 Everything is one SQLite file (`trove.db` / the `trove-data` volume) — treat it
 as durable and back it up with `trove-server backup` or `sqlite3 ... ".backup"`.
 It contains agent token hashes,

--- a/cmd/trove-server/doctor.go
+++ b/cmd/trove-server/doctor.go
@@ -83,6 +83,11 @@ func validateDoctorConfig() []string {
 	if addr := envOr("TROVE_ADDR", ":8080"); !validListenAddress(addr) {
 		problems = append(problems, "TROVE_ADDR must be a valid host:port address")
 	}
+	bootstrapAgent := os.Getenv("TROVE_BOOTSTRAP_AGENT")
+	bootstrapToken := os.Getenv("TROVE_BOOTSTRAP_TOKEN")
+	if (bootstrapAgent == "") != (bootstrapToken == "") {
+		problems = append(problems, "TROVE_BOOTSTRAP_AGENT and TROVE_BOOTSTRAP_TOKEN must both be set")
+	}
 	if err := server.LoadOIDCConfigFromEnv().Validate(); err != nil {
 		problems = append(problems, err.Error())
 	}
@@ -182,10 +187,21 @@ func doctorAlertsStatus() string {
 }
 
 func doctorDigestStatus() string {
-	if strings.TrimSpace(os.Getenv("TROVE_SMTP_HOST")) != "" &&
-		strings.TrimSpace(os.Getenv("TROVE_SMTP_FROM")) != "" &&
-		strings.TrimSpace(os.Getenv("TROVE_SMTP_TO")) != "" {
-		return "configured"
+	if strings.TrimSpace(os.Getenv("TROVE_SMTP_HOST")) == "" ||
+		strings.TrimSpace(os.Getenv("TROVE_SMTP_FROM")) == "" ||
+		strings.TrimSpace(os.Getenv("TROVE_SMTP_TO")) == "" {
+		return "disabled"
 	}
-	return "disabled"
+	schedule := os.Getenv("TROVE_DIGEST")
+	if schedule == "" {
+		schedule = "daily@08:00"
+	}
+	parsed, err := alert.ParseSchedule(schedule)
+	if err != nil {
+		return "invalid"
+	}
+	if parsed.Off {
+		return "disabled"
+	}
+	return "configured"
 }

--- a/cmd/trove-server/doctor.go
+++ b/cmd/trove-server/doctor.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/techdox/trove/internal/alert"
+	"github.com/techdox/trove/internal/registry"
+	"github.com/techdox/trove/internal/server"
+	"github.com/techdox/trove/internal/store"
+)
+
+// runDoctor inspects local configuration and the configured SQLite database.
+// It deliberately opens the database read-only: it never creates a database,
+// applies migrations, contacts external services, or prints secret values.
+func runDoctor() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fmt.Println("Trove doctor")
+	fmt.Printf("binary: %s (%s %s)\n", version, runtime.GOOS, runtime.GOARCH)
+
+	st, err := store.OpenReadOnly(envOr("TROVE_DB", "trove.db"))
+	if err != nil {
+		return fmt.Errorf("open configured database read-only: %w", err)
+	}
+	defer st.Close()
+
+	problems := make([]string, 0)
+	if integrity, err := st.CheckIntegrity(ctx); err != nil {
+		problems = append(problems, err.Error())
+		fmt.Println("database: unavailable")
+	} else if integrity != "ok" {
+		problems = append(problems, "SQLite integrity check did not return ok")
+		fmt.Printf("database: integrity check failed (%s)\n", integrity)
+	} else {
+		fmt.Println("database: ok (read-only integrity check)")
+	}
+
+	if migrations, err := st.MigrationStatus(ctx); err != nil {
+		problems = append(problems, err.Error())
+		fmt.Println("migrations: unavailable")
+	} else if len(migrations.Pending) != 0 || len(migrations.Unknown) != 0 {
+		if len(migrations.Pending) != 0 {
+			problems = append(problems, "database has pending migrations")
+		}
+		if len(migrations.Unknown) != 0 {
+			problems = append(problems, "database has migrations unknown to this binary")
+		}
+		fmt.Printf("migrations: not current (%d/%d applied)\n", len(migrations.Applied), len(migrations.Applied)+len(migrations.Pending))
+	} else {
+		fmt.Printf("migrations: current (%d applied)\n", len(migrations.Applied))
+	}
+
+	configProblems := validateDoctorConfig()
+	if len(configProblems) == 0 {
+		fmt.Println("configuration: valid (secrets redacted)")
+	} else {
+		problems = append(problems, configProblems...)
+		fmt.Println("configuration: invalid")
+		for _, problem := range configProblems {
+			fmt.Printf("  - %s\n", problem)
+		}
+	}
+	fmt.Printf("workers: freshness=%s, alerts=%s, digest=%s\n", doctorFreshnessStatus(), doctorAlertsStatus(), doctorDigestStatus())
+
+	if len(problems) != 0 {
+		return fmt.Errorf("doctor found %d problem(s)", len(problems))
+	}
+	fmt.Println("result: ok")
+	return nil
+}
+
+func validateDoctorConfig() []string {
+	problems := make([]string, 0)
+	if addr := envOr("TROVE_ADDR", ":8080"); !validListenAddress(addr) {
+		problems = append(problems, "TROVE_ADDR must be a valid host:port address")
+	}
+	if err := server.LoadOIDCConfigFromEnv().Validate(); err != nil {
+		problems = append(problems, err.Error())
+	}
+	if raw := os.Getenv("TROVE_OIDC_SESSION_MAX_AGE"); raw != "" && !validPositiveDuration(raw) {
+		problems = append(problems, "TROVE_OIDC_SESSION_MAX_AGE must be a positive duration")
+	}
+	if raw := os.Getenv("TROVE_HEALTH_DETAILS_ENABLED"); raw != "" && !validBool(raw) {
+		problems = append(problems, "TROVE_HEALTH_DETAILS_ENABLED must be true or false")
+	}
+	if raw := os.Getenv("TROVE_FRESHNESS_ENABLED"); raw != "" && !validBool(raw) {
+		problems = append(problems, "TROVE_FRESHNESS_ENABLED must be true or false")
+	}
+	for _, key := range []string{"TROVE_FRESHNESS_INTERVAL", "TROVE_FRESHNESS_TTL", "TROVE_EVENT_RETENTION", "TROVE_REMOVED_RETENTION", "TROVE_HOST_RETENTION"} {
+		if raw := os.Getenv(key); raw != "" && !validPositiveDuration(raw) {
+			problems = append(problems, key+" must be a positive duration")
+		}
+	}
+	if raw := os.Getenv("TROVE_ALERT_COOLDOWN"); raw != "" && !validNonNegativeDuration(raw) {
+		problems = append(problems, "TROVE_ALERT_COOLDOWN must be a non-negative duration")
+	}
+	if raw := os.Getenv("TROVE_REGISTRY_AUTHS"); raw != "" {
+		var creds map[string]registry.Cred
+		if !json.Valid([]byte(raw)) || json.Unmarshal([]byte(raw), &creds) != nil {
+			problems = append(problems, "TROVE_REGISTRY_AUTHS must contain a valid registry credential map")
+		}
+	}
+	if raw := os.Getenv("TROVE_SMTP_PORT"); raw != "" && !validPort(raw) {
+		problems = append(problems, "TROVE_SMTP_PORT must be a port number between 1 and 65535")
+	}
+	if raw := os.Getenv("TROVE_DIGEST"); raw != "" {
+		if _, err := alert.ParseSchedule(raw); err != nil {
+			problems = append(problems, "TROVE_DIGEST must be off, daily@HH:MM, or weekly@day:HH:MM")
+		}
+	}
+	if raw := os.Getenv("TROVE_ALERT_EVENTS"); raw != "" {
+		for _, kind := range strings.Split(raw, ",") {
+			kind = strings.TrimSpace(strings.ToLower(kind))
+			if kind != "" && !validAlertKind(kind) {
+				problems = append(problems, "TROVE_ALERT_EVENTS contains an unknown event kind")
+				break
+			}
+		}
+	}
+	return problems
+}
+
+func validAlertKind(kind string) bool {
+	switch kind {
+	case "agent", "freshness", "health", "host", "state":
+		return true
+	default:
+		return false
+	}
+}
+
+func validListenAddress(addr string) bool {
+	_, port, err := net.SplitHostPort(addr)
+	return err == nil && validPort(port)
+}
+
+func validPort(raw string) bool {
+	port, err := strconv.ParseUint(raw, 10, 16)
+	return err == nil && port > 0
+}
+
+func validBool(raw string) bool {
+	_, err := strconv.ParseBool(raw)
+	return err == nil
+}
+
+func validPositiveDuration(raw string) bool {
+	d, err := time.ParseDuration(raw)
+	return err == nil && d > 0
+}
+
+func validNonNegativeDuration(raw string) bool {
+	d, err := time.ParseDuration(raw)
+	return err == nil && d >= 0
+}
+
+func doctorFreshnessStatus() string {
+	if raw := os.Getenv("TROVE_FRESHNESS_ENABLED"); raw != "" {
+		if enabled, err := strconv.ParseBool(raw); err == nil && !enabled {
+			return "disabled"
+		}
+	}
+	return "enabled"
+}
+
+func doctorAlertsStatus() string {
+	for _, key := range []string{"TROVE_ALERT_WEBHOOK_URL", "TROVE_ALERT_DISCORD_URL", "TROVE_ALERT_NTFY_URL"} {
+		if strings.TrimSpace(os.Getenv(key)) != "" {
+			return "configured"
+		}
+	}
+	return "disabled"
+}
+
+func doctorDigestStatus() string {
+	if strings.TrimSpace(os.Getenv("TROVE_SMTP_HOST")) != "" &&
+		strings.TrimSpace(os.Getenv("TROVE_SMTP_FROM")) != "" &&
+		strings.TrimSpace(os.Getenv("TROVE_SMTP_TO")) != "" {
+		return "configured"
+	}
+	return "disabled"
+}

--- a/cmd/trove-server/doctor_test.go
+++ b/cmd/trove-server/doctor_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/techdox/trove/internal/store"
+)
+
+func TestRunDoctorReportsReadOnlyHealthyStateWithoutSecrets(t *testing.T) {
+	path := newDoctorDatabase(t)
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+	t.Setenv("TROVE_ADDR", "127.0.0.1:8080")
+	t.Setenv("TROVE_OIDC_ISSUER", "https://idp.example")
+	t.Setenv("TROVE_OIDC_CLIENT_ID", "doctor-client")
+	t.Setenv("TROVE_OIDC_CLIENT_SECRET", "doctor-client-secret-must-not-appear")
+	t.Setenv("TROVE_OIDC_REDIRECT_URL", "https://trove.example/oauth2/callback")
+	t.Setenv("TROVE_API_TOKEN", "doctor-api-token-must-not-appear-123456")
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err != nil {
+		t.Fatalf("run doctor: %v", err)
+	}
+	for _, want := range []string{"Trove doctor", "database: ok (read-only integrity check)", "migrations: current", "configuration: valid", "result: ok"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("doctor output missing %q:\n%s", want, output)
+		}
+	}
+	for _, secret := range []string{"doctor-client-secret-must-not-appear", "doctor-api-token-must-not-appear-123456"} {
+		if strings.Contains(output, secret) {
+			t.Errorf("doctor output exposed a secret: %q", secret)
+		}
+	}
+}
+
+func TestRunDoctorReportsInvalidConfiguration(t *testing.T) {
+	path := newDoctorDatabase(t)
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+	t.Setenv("TROVE_ADDR", "not-an-address")
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err == nil {
+		t.Fatal("doctor accepted an invalid listen address")
+	}
+	if !strings.Contains(output, "TROVE_ADDR must be a valid host:port address") {
+		t.Errorf("doctor output did not explain invalid address:\n%s", output)
+	}
+}
+
+func newDoctorDatabase(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "trove.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open doctor database: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close doctor database: %v", err)
+	}
+	return path
+}
+
+func clearDoctorEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"TROVE_ADDR", "TROVE_DB", "TROVE_OIDC_ISSUER", "TROVE_OIDC_CLIENT_ID", "TROVE_OIDC_CLIENT_SECRET", "TROVE_OIDC_REDIRECT_URL", "TROVE_API_TOKEN", "TROVE_OIDC_SESSION_MAX_AGE", "TROVE_HEALTH_DETAILS_ENABLED", "TROVE_FRESHNESS_ENABLED", "TROVE_FRESHNESS_INTERVAL", "TROVE_FRESHNESS_TTL", "TROVE_EVENT_RETENTION", "TROVE_REMOVED_RETENTION", "TROVE_HOST_RETENTION", "TROVE_ALERT_COOLDOWN", "TROVE_REGISTRY_AUTHS", "TROVE_SMTP_PORT", "TROVE_DIGEST", "TROVE_ALERT_EVENTS", "TROVE_ALERT_WEBHOOK_URL", "TROVE_ALERT_DISCORD_URL", "TROVE_ALERT_NTFY_URL", "TROVE_SMTP_HOST", "TROVE_SMTP_FROM", "TROVE_SMTP_TO",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func captureDoctorOutput(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() {
+		os.Stdout = previous
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	callErr := fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout pipe: %v", err)
+	}
+	os.Stdout = previous
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout pipe: %v", err)
+	}
+	return string(output), callErr
+}

--- a/cmd/trove-server/doctor_test.go
+++ b/cmd/trove-server/doctor_test.go
@@ -52,6 +52,39 @@ func TestRunDoctorReportsInvalidConfiguration(t *testing.T) {
 	}
 }
 
+func TestRunDoctorReportsPartialBootstrapConfiguration(t *testing.T) {
+	path := newDoctorDatabase(t)
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+	t.Setenv("TROVE_BOOTSTRAP_AGENT", "quickstart-agent")
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err == nil {
+		t.Fatal("doctor accepted a partial bootstrap configuration")
+	}
+	if !strings.Contains(output, "TROVE_BOOTSTRAP_AGENT and TROVE_BOOTSTRAP_TOKEN must both be set") {
+		t.Errorf("doctor output did not explain partial bootstrap configuration:\n%s", output)
+	}
+}
+
+func TestRunDoctorReportsDisabledDigest(t *testing.T) {
+	path := newDoctorDatabase(t)
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+	t.Setenv("TROVE_SMTP_HOST", "smtp.example")
+	t.Setenv("TROVE_SMTP_FROM", "trove@example")
+	t.Setenv("TROVE_SMTP_TO", "operator@example")
+	t.Setenv("TROVE_DIGEST", "off")
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err != nil {
+		t.Fatalf("run doctor: %v", err)
+	}
+	if !strings.Contains(output, "digest=disabled") {
+		t.Errorf("doctor output did not report disabled digest:\n%s", output)
+	}
+}
+
 func newDoctorDatabase(t *testing.T) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "trove.db")
@@ -68,7 +101,7 @@ func newDoctorDatabase(t *testing.T) string {
 func clearDoctorEnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"TROVE_ADDR", "TROVE_DB", "TROVE_OIDC_ISSUER", "TROVE_OIDC_CLIENT_ID", "TROVE_OIDC_CLIENT_SECRET", "TROVE_OIDC_REDIRECT_URL", "TROVE_API_TOKEN", "TROVE_OIDC_SESSION_MAX_AGE", "TROVE_HEALTH_DETAILS_ENABLED", "TROVE_FRESHNESS_ENABLED", "TROVE_FRESHNESS_INTERVAL", "TROVE_FRESHNESS_TTL", "TROVE_EVENT_RETENTION", "TROVE_REMOVED_RETENTION", "TROVE_HOST_RETENTION", "TROVE_ALERT_COOLDOWN", "TROVE_REGISTRY_AUTHS", "TROVE_SMTP_PORT", "TROVE_DIGEST", "TROVE_ALERT_EVENTS", "TROVE_ALERT_WEBHOOK_URL", "TROVE_ALERT_DISCORD_URL", "TROVE_ALERT_NTFY_URL", "TROVE_SMTP_HOST", "TROVE_SMTP_FROM", "TROVE_SMTP_TO",
+		"TROVE_ADDR", "TROVE_DB", "TROVE_BOOTSTRAP_AGENT", "TROVE_BOOTSTRAP_TOKEN", "TROVE_OIDC_ISSUER", "TROVE_OIDC_CLIENT_ID", "TROVE_OIDC_CLIENT_SECRET", "TROVE_OIDC_REDIRECT_URL", "TROVE_API_TOKEN", "TROVE_OIDC_SESSION_MAX_AGE", "TROVE_HEALTH_DETAILS_ENABLED", "TROVE_FRESHNESS_ENABLED", "TROVE_FRESHNESS_INTERVAL", "TROVE_FRESHNESS_TTL", "TROVE_EVENT_RETENTION", "TROVE_REMOVED_RETENTION", "TROVE_HOST_RETENTION", "TROVE_ALERT_COOLDOWN", "TROVE_REGISTRY_AUTHS", "TROVE_SMTP_PORT", "TROVE_DIGEST", "TROVE_ALERT_EVENTS", "TROVE_ALERT_WEBHOOK_URL", "TROVE_ALERT_DISCORD_URL", "TROVE_ALERT_NTFY_URL", "TROVE_SMTP_HOST", "TROVE_SMTP_FROM", "TROVE_SMTP_TO",
 	} {
 		t.Setenv(key, "")
 	}

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -7,6 +7,7 @@
 //	trove-server agent create <name>     mint a bearer token for a new agent
 //	trove-server agent list              list agents and last-seen
 //	trove-server agent delete <name>     remove an agent and its data
+//	trove-server doctor                  inspect local configuration and SQLite health
 //
 // Config (serve): TROVE_ADDR (default :8080), TROVE_DB (default trove.db).
 package main
@@ -66,6 +67,8 @@ func main() {
 		err = runBackup(args[1:])
 	case "healthcheck":
 		err = runHealthcheck()
+	case "doctor":
+		err = runDoctor()
 	case "version", "-v", "--version":
 		fmt.Println("trove-server", version)
 	case "help", "-h", "--help":
@@ -91,6 +94,7 @@ Commands:
   alert test                send a test notification through configured channels
   backup [path]             write a consistent SQLite backup (default timestamped file)
   healthcheck               probe /healthz on the local server (exit 0/1)
+  doctor                    inspect local configuration and SQLite health (read-only)
 
 Environment:
   TROVE_ADDR              listen address (default ":8080")

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -101,6 +101,13 @@ func (c OIDCConfig) validate() error {
 	return nil
 }
 
+// Validate checks local OIDC settings without contacting the issuer. It is
+// used by diagnostics before a server starts, so it never exposes credentials
+// or performs network I/O.
+func (c OIDCConfig) Validate() error {
+	return c.validate()
+}
+
 // LoadOIDCConfigFromEnv reads OIDC configuration from the environment.
 func LoadOIDCConfigFromEnv() OIDCConfig {
 	cfg := OIDCConfig{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,7 +74,7 @@ func New(st *store.Store, log *slog.Logger) *Server {
 // configuration is partial or OIDC discovery fails (e.g. the issuer is
 // unreachable).
 func (s *Server) ConfigureOIDC(cfg OIDCConfig) error {
-	if err := cfg.validate(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		return err
 	}
 	if !cfg.Enabled() {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,6 +49,22 @@ func Open(path string) (*Store, error) {
 	return s, nil
 }
 
+// OpenReadOnly opens an existing database without creating it or applying
+// migrations. It is for diagnostics and backup verification commands that
+// must not change the database they inspect.
+func OpenReadOnly(path string) (*Store, error) {
+	db, err := sql.Open("sqlite", buildReadOnlyDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite read-only: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if err := db.PingContext(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("open sqlite read-only: %w", err)
+	}
+	return &Store{db: db, now: func() time.Time { return time.Now().UTC() }}, nil
+}
+
 func buildDSN(path string) string {
 	// modernc accepts PRAGMAs via the DSN query string.
 	q := url.Values{}
@@ -60,12 +76,85 @@ func buildDSN(path string) string {
 	return "file:" + path + "?" + q.Encode()
 }
 
+func buildReadOnlyDSN(path string) string {
+	q := url.Values{}
+	q.Set("mode", "ro")
+	q.Add("_pragma", "busy_timeout(5000)")
+	// query_only is connection-local. It is redundant with mode=ro, but keeps
+	// the diagnostic connection unable to write if the driver ever changes how
+	// it handles read-only URI mode.
+	q.Add("_pragma", "query_only(1)")
+	return "file:" + path + "?" + q.Encode()
+}
+
 // Close closes the underlying database.
 func (s *Store) Close() error { return s.db.Close() }
 
 // DB exposes the raw handle for health checks (Ping). Callers must not run
 // schema-mutating statements through it.
 func (s *Store) DB() *sql.DB { return s.db }
+
+// CheckIntegrity runs SQLite's integrity check without changing the database.
+// A healthy database returns "ok".
+func (s *Store) CheckIntegrity(ctx context.Context) (string, error) {
+	var result string
+	if err := s.db.QueryRowContext(ctx, `PRAGMA integrity_check`).Scan(&result); err != nil {
+		return "", fmt.Errorf("integrity check: %w", err)
+	}
+	return result, nil
+}
+
+// MigrationStatus describes the migrations recorded by a database relative to
+// the migrations embedded in this binary.
+type MigrationStatus struct {
+	Applied []string
+	Pending []string
+	Unknown []string
+}
+
+// MigrationStatus reads migration state without applying any migrations.
+func (s *Store) MigrationStatus(ctx context.Context) (MigrationStatus, error) {
+	expected, err := migrationNames()
+	if err != nil {
+		return MigrationStatus{}, err
+	}
+
+	rows, err := s.db.QueryContext(ctx, `SELECT version FROM schema_migrations ORDER BY version`)
+	if err != nil {
+		return MigrationStatus{}, fmt.Errorf("read schema migrations: %w", err)
+	}
+	defer rows.Close()
+
+	recorded := make(map[string]bool, len(expected))
+	for rows.Next() {
+		var version string
+		if err := rows.Scan(&version); err != nil {
+			return MigrationStatus{}, fmt.Errorf("read schema migration: %w", err)
+		}
+		recorded[version] = true
+	}
+	if err := rows.Err(); err != nil {
+		return MigrationStatus{}, fmt.Errorf("read schema migrations: %w", err)
+	}
+
+	status := MigrationStatus{}
+	expectedSet := make(map[string]bool, len(expected))
+	for _, name := range expected {
+		expectedSet[name] = true
+		if recorded[name] {
+			status.Applied = append(status.Applied, name)
+		} else {
+			status.Pending = append(status.Pending, name)
+		}
+	}
+	for name := range recorded {
+		if !expectedSet[name] {
+			status.Unknown = append(status.Unknown, name)
+		}
+	}
+	sort.Strings(status.Unknown)
+	return status, nil
+}
 
 func (s *Store) migrate(ctx context.Context) error {
 	if _, err := s.db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -75,17 +164,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		return fmt.Errorf("create schema_migrations: %w", err)
 	}
 
-	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	names, err := migrationNames()
 	if err != nil {
-		return fmt.Errorf("read migrations: %w", err)
+		return err
 	}
-	names := make([]string, 0, len(entries))
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
-			names = append(names, e.Name())
-		}
-	}
-	sort.Strings(names) // lexical order == apply order (0001_, 0002_, ...)
 
 	for _, name := range names {
 		var exists int
@@ -121,4 +203,19 @@ func (s *Store) migrate(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func migrationNames() ([]string, error) {
+	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names) // lexical order == apply order (0001_, 0002_, ...)
+	return names, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,9 +1,11 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -40,6 +42,60 @@ func svc(id, state string, health model.Health) model.ReportService {
 }
 
 func pointer[T any](v T) *T { return &v }
+
+func TestOpenReadOnlyInspectsWithoutWriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trove.db")
+	rw, err := Open(path)
+	if err != nil {
+		t.Fatalf("open writable store: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("close writable store: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read database before inspection: %v", err)
+	}
+
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("open read-only store: %v", err)
+	}
+	if integrity, err := ro.CheckIntegrity(context.Background()); err != nil || integrity != "ok" {
+		t.Fatalf("integrity = %q, %v; want ok", integrity, err)
+	}
+	status, err := ro.MigrationStatus(context.Background())
+	if err != nil {
+		t.Fatalf("migration status: %v", err)
+	}
+	if len(status.Pending) != 0 || len(status.Unknown) != 0 || len(status.Applied) == 0 {
+		t.Fatalf("migration status = %+v, want all current", status)
+	}
+	if _, err := ro.DB().Exec(`CREATE TABLE doctor_must_not_write (id INTEGER)`); err == nil {
+		t.Fatal("read-only store unexpectedly accepted a write")
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("close read-only store: %v", err)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read database after inspection: %v", err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("read-only inspection changed the database file")
+	}
+}
+
+func TestOpenReadOnlyDoesNotCreateMissingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.db")
+	if _, err := OpenReadOnly(path); err == nil {
+		t.Fatal("read-only open unexpectedly created a missing database")
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("missing database state = %v, want not exist", err)
+	}
+}
 
 func TestImagesDueForCheckRequiresRunningDigest(t *testing.T) {
 	st, _ := newTestStore(t)


### PR DESCRIPTION
## Summary

- add `trove-server doctor` for safe local diagnostics
- open SQLite strictly read-only: no database creation, migrations, or writes
- report integrity, migration state, sanitized configuration validation, and worker-relevant configuration
- document Docker Compose and bare-metal usage

## Why

Operators need a safe support and pre-upgrade command that can validate Trove without changing a production deployment or exposing credentials.

## Validation

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `make native`
- [x] `python3 scripts/check_markdown_links.py`
- [x] `python3 scripts/check_release_surface.py`
- [x] `git diff --check`