### PR TITLE
feat: verify SQLite backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ before current inventory can repopulate; event history and prior alert state
 cannot be rebuilt.
 
 See **[docs/upgrades.md](docs/upgrades.md)** for per-method upgrade steps (Docker
-Compose, bare metal, `go install`, agents), version pinning, backup commands,
+Compose, bare metal, `go install`, agents), version pinning, backup creation and
+read-only verification, cron/systemd retention examples, restore rehearsals,
 and how to roll back.
 
 ## Building from source

--- a/cmd/trove-server/backup_verify.go
+++ b/cmd/trove-server/backup_verify.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/techdox/trove/internal/store"
+)
+
+// runBackupVerify checks an existing Trove backup without creating, migrating,
+// or modifying it. The digest comparison detects changes while the command is
+// running, including accidental writes by this process.
+func runBackupVerify(args []string) error {
+	if len(args) != 1 || args[0] == "" {
+		return errors.New("usage: trove-server backup verify <path>")
+	}
+	path := args[0]
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat backup path: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("backup path %q must be a regular file", path)
+	}
+
+	before, err := fileSHA256(path)
+	if err != nil {
+		return fmt.Errorf("hash backup before verification: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	migrations, err := inspectBackupReadOnly(ctx, path)
+	if err != nil {
+		return err
+	}
+
+	after, err := fileSHA256(path)
+	if err != nil {
+		return fmt.Errorf("hash backup after verification: %w", err)
+	}
+	if before != after {
+		return errors.New("backup changed during read-only verification")
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	fmt.Println("Trove backup verify")
+	fmt.Printf("backup: %s (%d bytes)\n", absPath, info.Size())
+	fmt.Printf("sha256: %x\n", before)
+	fmt.Println("database: ok (read-only integrity check)")
+	fmt.Printf("migrations: %d applied, %d pending, %d unknown\n", len(migrations.Applied), len(migrations.Pending), len(migrations.Unknown))
+	fmt.Println("result: ok (backup opened and unchanged)")
+	return nil
+}
+
+func inspectBackupReadOnly(ctx context.Context, path string) (store.MigrationStatus, error) {
+	st, err := store.OpenReadOnly(path)
+	if err != nil {
+		return store.MigrationStatus{}, fmt.Errorf("open backup read-only: %w", err)
+	}
+	defer st.Close()
+
+	integrity, err := st.CheckIntegrity(ctx)
+	if err != nil {
+		return store.MigrationStatus{}, err
+	}
+	if integrity != "ok" {
+		return store.MigrationStatus{}, fmt.Errorf("SQLite integrity check failed: %s", integrity)
+	}
+	return st.MigrationStatus(ctx)
+}
+
+func fileSHA256(path string) ([sha256.Size]byte, error) {
+	var sum [sha256.Size]byte
+	f, err := os.Open(path)
+	if err != nil {
+		return sum, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return sum, err
+	}
+	copy(sum[:], h.Sum(nil))
+	return sum, nil
+}

--- a/cmd/trove-server/backup_verify.go
+++ b/cmd/trove-server/backup_verify.go
@@ -63,7 +63,7 @@ func runBackupVerify(args []string) error {
 }
 
 func inspectBackupReadOnly(ctx context.Context, path string) (store.MigrationStatus, error) {
-	st, err := store.OpenReadOnly(path)
+	st, err := store.OpenImmutableReadOnly(path)
 	if err != nil {
 		return store.MigrationStatus{}, fmt.Errorf("open backup read-only: %w", err)
 	}

--- a/cmd/trove-server/backup_verify_test.go
+++ b/cmd/trove-server/backup_verify_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/techdox/trove/internal/store"
+)
+
+func TestRunBackupVerifyReadsBackupWithoutChangingIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trove-backup.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("create backup database: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close backup database: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read backup before verification: %v", err)
+	}
+
+	output, err := captureDoctorOutput(t, func() error {
+		return runBackup([]string{"verify", path})
+	})
+	if err != nil {
+		t.Fatalf("verify backup: %v", err)
+	}
+	for _, want := range []string{
+		"Trove backup verify",
+		"database: ok (read-only integrity check)",
+		"migrations:",
+		"result: ok (backup opened and unchanged)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("verification output missing %q:\n%s", want, output)
+		}
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read backup after verification: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("backup changed during verification")
+	}
+}
+
+func TestRunBackupVerifyRejectsNonRegularPath(t *testing.T) {
+	err := runBackupVerify([]string{t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "must be a regular file") {
+		t.Fatalf("verify directory error = %v, want regular-file error", err)
+	}
+}
+
+func TestRunBackupVerifyRequiresPath(t *testing.T) {
+	err := runBackupVerify(nil)
+	if err == nil || !strings.Contains(err.Error(), "usage: trove-server backup verify <path>") {
+		t.Fatalf("verify without path error = %v, want usage error", err)
+	}
+}

--- a/cmd/trove-server/backup_verify_test.go
+++ b/cmd/trove-server/backup_verify_test.go
@@ -62,3 +62,33 @@ func TestRunBackupVerifyRequiresPath(t *testing.T) {
 		t.Fatalf("verify without path error = %v, want usage error", err)
 	}
 }
+
+func TestRunBackupVerifyDoesNotCreateWALSidecars(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trove-backup.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("create backup database: %v", err)
+	}
+	if _, err := st.DB().Exec(`PRAGMA journal_mode=WAL`); err != nil {
+		t.Fatalf("enable WAL: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close backup database: %v", err)
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if err := os.Remove(sidecar); err != nil && !os.IsNotExist(err) {
+			t.Fatalf("remove %s: %v", sidecar, err)
+		}
+	}
+
+	if _, err := captureDoctorOutput(t, func() error {
+		return runBackupVerify([]string{path})
+	}); err != nil {
+		t.Fatalf("verify WAL-mode backup: %v", err)
+	}
+	for _, sidecar := range []string{path + "-wal", path + "-shm"} {
+		if _, err := os.Lstat(sidecar); !os.IsNotExist(err) {
+			t.Errorf("verification created sidecar %s", sidecar)
+		}
+	}
+}

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -8,6 +8,7 @@
 //	trove-server agent list              list agents and last-seen
 //	trove-server agent rotate <name>     replace an agent bearer token
 //	trove-server agent delete <name>     remove an agent and its data
+//	trove-server backup verify <path>    inspect an existing SQLite backup read-only
 //	trove-server doctor                  inspect local configuration and SQLite health
 //
 // Config (serve): TROVE_ADDR (default :8080), TROVE_DB (default trove.db).
@@ -95,6 +96,7 @@ Commands:
   agent delete <name>       remove an agent and all its data
   alert test                send a test notification through configured channels
   backup [path]             write a consistent SQLite backup (default timestamped file)
+  backup verify <path>      verify an existing SQLite backup without modifying it
   healthcheck               probe /healthz on the local server (exit 0/1)
   doctor                    inspect local configuration and SQLite health (read-only)
 
@@ -361,8 +363,11 @@ func bootstrapAgent(ctx context.Context, st *store.Store, logger *slog.Logger) e
 // overwrite an existing file; backups are rollback points, not disposable temp
 // files.
 func runBackup(args []string) error {
+	if len(args) > 0 && args[0] == "verify" {
+		return runBackupVerify(args[1:])
+	}
 	if len(args) > 1 {
-		return errors.New("usage: trove-server backup [path]")
+		return errors.New("usage: trove-server backup [path]\n       trove-server backup verify <path>")
 	}
 	dst := ""
 	if len(args) == 1 {

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -102,6 +102,106 @@ equivalent:
 sqlite3 /var/lib/trove/trove.db ".backup '/var/backups/trove.db'"
 ```
 
+### Verify a backup
+
+Verify every new backup before relying on it. This command opens the backup
+with SQLite read-only mode, runs `PRAGMA integrity_check`, reports its migration
+record, and hashes the file before and after inspection. It never creates a
+database, applies migrations, or changes the backup.
+
+```sh
+# Bare metal / a copied Compose backup on the host
+trove-server backup verify /var/backups/trove/trove-20260725T021700Z.db
+
+# Before copying a Compose backup out of the container
+docker compose exec server trove-server backup verify /data/backups/trove-20260725T021700Z.db
+```
+
+`result: ok (backup opened and unchanged)` means that the file was readable and
+internally consistent at verification time. It does not make an older server
+binary compatible with a newer schema; follow the rollback procedure below.
+
+### Scheduled backups and retention
+
+Keep backups outside the live database volume and retain more than one recovery
+point. The example below keeps 14 daily copies. Run the `find` command without
+`-delete` once first to confirm exactly which files would age out; keep an
+additional encrypted off-host copy for failures affecting the server itself.
+
+Create a root-owned helper, changing the database and backup paths to match
+your installation:
+
+```sh
+sudo install -d -o trove -g trove -m 0700 /var/backups/trove
+sudo tee /usr/local/sbin/trove-backup >/dev/null <<'EOF'
+#!/bin/sh
+set -eu
+
+backup_dir=/var/backups/trove
+retention_days=14
+backup="$backup_dir/trove-$(date -u +%Y%m%dT%H%M%SZ).db"
+
+TROVE_DB=/var/lib/trove/trove.db /usr/local/bin/trove-server backup "$backup"
+/usr/local/bin/trove-server backup verify "$backup"
+find "$backup_dir" -maxdepth 1 -type f -name 'trove-*.db' -mtime +"$retention_days" -print -delete
+EOF
+sudo chown root:trove /usr/local/sbin/trove-backup
+sudo chmod 0750 /usr/local/sbin/trove-backup
+```
+
+For cron, add this line to `/etc/cron.d/trove-backup` to run it daily at
+02:17 UTC. The script verifies a new backup before pruning old ones.
+
+```cron
+17 2 * * * trove /usr/local/sbin/trove-backup
+```
+
+For systemd, use the same helper and install these units instead of cron:
+
+```ini
+# /etc/systemd/system/trove-backup.service
+[Unit]
+Description=Create and verify a Trove SQLite backup
+
+[Service]
+Type=oneshot
+User=trove
+Group=trove
+ExecStart=/usr/local/sbin/trove-backup
+```
+
+```ini
+# /etc/systemd/system/trove-backup.timer
+[Unit]
+Description=Run the Trove backup daily
+
+[Timer]
+OnCalendar=*-*-* 02:17:00 UTC
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and inspect it with:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now trove-backup.timer
+systemctl list-timers trove-backup.timer
+```
+
+### Restore rehearsal
+
+Rehearse recovery before an upgrade and at least quarterly:
+
+1. Create and verify a fresh backup; retain its SHA-256 output with the backup record.
+2. Copy the backup to an isolated test path or host. Never start a server against the only backup copy.
+3. Run `TROVE_DB=/srv/trove-rehearsal/trove.db trove-server doctor` against the copy.
+4. Start the candidate server against that copy on loopback only, for example `TROVE_ADDR=127.0.0.1:18081 TROVE_DB=/srv/trove-rehearsal/trove.db trove-server`, then confirm `curl -fsS http://127.0.0.1:18081/healthz` returns `200`.
+5. Check representative agents, hosts, services, and recent events in the test dashboard/API; stop the test server and keep the original backup unchanged.
+
 Do not treat the database as disposable. In addition to current inventory and
 event history, it contains agent token hashes, image-freshness cache state, and
 alert cursor, cooldown, and per-channel delivery state. If the database is lost,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,7 +53,19 @@ func Open(path string) (*Store, error) {
 // migrations. It is for diagnostics and backup verification commands that
 // must not change the database they inspect.
 func OpenReadOnly(path string) (*Store, error) {
-	db, err := sql.Open("sqlite", buildReadOnlyDSN(path))
+	return openReadOnly(path, false)
+}
+
+// OpenImmutableReadOnly opens a complete SQLite backup without creating or
+// consulting WAL sidecar files. It is for standalone backup verification only;
+// use OpenReadOnly for diagnostics against a live database, which may have an
+// active WAL.
+func OpenImmutableReadOnly(path string) (*Store, error) {
+	return openReadOnly(path, true)
+}
+
+func openReadOnly(path string, immutable bool) (*Store, error) {
+	db, err := sql.Open("sqlite", buildReadOnlyDSN(path, immutable))
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite read-only: %w", err)
 	}
@@ -73,18 +85,28 @@ func buildDSN(path string) string {
 	if path != ":memory:" {
 		q.Add("_pragma", "journal_mode(WAL)")
 	}
-	return "file:" + path + "?" + q.Encode()
+	return buildFileDSN(path, q)
 }
 
-func buildReadOnlyDSN(path string) string {
+func buildReadOnlyDSN(path string, immutable bool) string {
 	q := url.Values{}
 	q.Set("mode", "ro")
+	if immutable {
+		q.Set("immutable", "1")
+	}
 	q.Add("_pragma", "busy_timeout(5000)")
 	// query_only is connection-local. It is redundant with mode=ro, but keeps
 	// the diagnostic connection unable to write if the driver ever changes how
 	// it handles read-only URI mode.
 	q.Add("_pragma", "query_only(1)")
-	return "file:" + path + "?" + q.Encode()
+	return buildFileDSN(path, q)
+}
+
+func buildFileDSN(path string, q url.Values) string {
+	// Constructing a SQLite URI by string concatenation would let a legal
+	// filename containing ? or # change the URI query or fragment. URL escapes
+	// the filesystem path independently from SQLite's connection parameters.
+	return (&url.URL{Scheme: "file", Path: path, RawQuery: q.Encode()}).String()
 }
 
 // Close closes the underlying database.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -97,6 +97,37 @@ func TestOpenReadOnlyDoesNotCreateMissingDatabase(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlyEscapesURIPath(t *testing.T) {
+	dir := t.TempDir()
+	wantPath := filepath.Join(dir, "backup?verified#copy.db")
+	otherPath := filepath.Join(dir, "backup")
+	for path, value := range map[string]string{wantPath: "wanted", otherPath: "other"} {
+		st, err := Open(path)
+		if err != nil {
+			t.Fatalf("open %q: %v", path, err)
+		}
+		if _, err := st.DB().Exec(`CREATE TABLE marker (value TEXT); INSERT INTO marker(value) VALUES (?)`, value); err != nil {
+			t.Fatalf("write marker to %q: %v", path, err)
+		}
+		if err := st.Close(); err != nil {
+			t.Fatalf("close %q: %v", path, err)
+		}
+	}
+
+	ro, err := OpenReadOnly(wantPath)
+	if err != nil {
+		t.Fatalf("open escaped path read-only: %v", err)
+	}
+	defer ro.Close()
+	var got string
+	if err := ro.DB().QueryRow(`SELECT value FROM marker`).Scan(&got); err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if got != "wanted" {
+		t.Fatalf("read marker = %q, want %q", got, "wanted")
+	}
+}
+
 func TestImagesDueForCheckRequiresRunningDigest(t *testing.T) {
 	st, _ := newTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- add `trove-server backup verify <path>` for existing Trove SQLite backups
- open the backup strictly read-only, check SQLite integrity and migration records, and compare SHA-256 before and after inspection
- document verification, daily cron/systemd schedules, retention, off-host copies, and a restore-rehearsal checklist

## Why

A successful backup command alone does not establish that a recovery file is readable or intact. Operators need a supported, non-mutating verification path before upgrades and for routine recovery confidence.

## Safety

The verifier creates no files or directories, applies no migrations, and does not modify the backup. It rejects non-regular paths and fails if the backup's digest changes while it runs.

## Validation

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `make native`
- [x] `python3 scripts/check_markdown_links.py`
- [x] `python3 scripts/check_release_surface.py`
- [x] `git diff --check`