### PR TITLE
test: add dashboard browser regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      # actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22
+          cache: npm
       - name: gofmt
         run: |
           out=$(gofmt -l .)
@@ -48,6 +53,12 @@ jobs:
           echo "Total: $total" >> "$GITHUB_STEP_SUMMARY"
       - name: go test race detector
         run: go test -race ./...
+      - name: Install dashboard browser test dependencies
+        run: npm ci
+      - name: Install Chromium for dashboard browser tests
+        run: npx playwright install --with-deps chromium
+      - name: Dashboard browser regressions
+        run: npm run test:browser
       - name: cross-compile all binaries (linux amd64 + arm64)
         run: make build
       - name: GoReleaser config check

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /dist/
 coverage.out
 coverage.txt
+node_modules/
+test-results/
+playwright-report/
 # stray binaries from `go build ./cmd/<x>` in the repo root
 /trove-server
 /trove-agent-docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "trove-browser-regressions",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "trove-browser-regressions",
+      "devDependencies": {
+        "@playwright/test": "1.62.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "trove-browser-regressions",
+  "private": true,
+  "scripts": {
+    "test:browser": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.0"
+  }
+}

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/browser",
+  timeout: 30_000,
+  workers: 1,
+  use: {
+    baseURL: "http://127.0.0.1:18081",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "node test/browser/server.mjs",
+    url: "http://127.0.0.1:18081/healthz",
+    timeout: 120_000,
+    reuseExistingServer: false,
+  },
+});

--- a/test/browser/dashboard.spec.mjs
+++ b/test/browser/dashboard.spec.mjs
@@ -128,6 +128,16 @@ async function loadDashboard(page) {
   await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
 }
 
+async function expectNoHorizontalPageOverflow(page) {
+  const widths = await page.evaluate(() => ({
+    document: document.documentElement.scrollWidth,
+    body: document.body.scrollWidth,
+    viewport: window.innerWidth,
+  }));
+  expect(widths.document).toBeLessThanOrEqual(widths.viewport);
+  expect(widths.body).toBeLessThanOrEqual(widths.viewport);
+}
+
 test("long Kubernetes labels remain readable and the drawer keeps event timestamps clear", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 1000 });
   await loadDashboard(page);
@@ -177,7 +187,9 @@ test("tablet catalogue preserves each Kubernetes kind label", async ({ page }) =
   await page.setViewportSize({ width: 900, height: 1000 });
   await loadDashboard(page);
 
-  await expect(page.locator("#hosts .kind")).toHaveText(["deployment", "pod", "deployment"]);
+  const kinds = page.locator("#hosts .kind");
+  await expect(kinds).toHaveText(["deployment", "pod", "deployment"]);
+  for (const kind of await kinds.all()) await expect(kind).toBeVisible();
   const overflow = await page.locator("#hosts tr[data-ext]").evaluateAll((rows) => rows.map((row) => ({
     clientWidth: row.clientWidth,
     scrollWidth: row.scrollWidth,
@@ -190,13 +202,7 @@ test("mobile dashboard and drawer do not create horizontal page overflow", async
   await loadDashboard(page);
 
   await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
-  const pageWidth = await page.evaluate(() => ({
-    document: document.documentElement.scrollWidth,
-    body: document.body.scrollWidth,
-    viewport: window.innerWidth,
-  }));
-  expect(pageWidth.document).toBeLessThanOrEqual(pageWidth.viewport);
-  expect(pageWidth.body).toBeLessThanOrEqual(pageWidth.viewport);
+  await expectNoHorizontalPageOverflow(page);
 
   await page.locator('[data-ext="authentik-server-deployment"] [data-service-details]').click();
   const drawer = page.locator("#drawer");
@@ -204,4 +210,10 @@ test("mobile dashboard and drawer do not create horizontal page overflow", async
   const drawerBox = await drawer.boundingBox();
   expect(drawerBox).not.toBeNull();
   expect(drawerBox.x + drawerBox.width).toBeLessThanOrEqual(391);
+  const drawerWidth = await drawer.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  expect(drawerWidth.scrollWidth).toBeLessThanOrEqual(drawerWidth.clientWidth + 1);
+  await expectNoHorizontalPageOverflow(page);
 });

--- a/test/browser/dashboard.spec.mjs
+++ b/test/browser/dashboard.spec.mjs
@@ -1,0 +1,207 @@
+import { expect, test } from "@playwright/test";
+
+const now = "2026-07-25T00:00:00Z";
+const host = {
+  agent: "browser-kubernetes",
+  hostname: "kubernetes-production-cluster-with-an-intentionally-long-hostname",
+  platform: "kubernetes",
+  status: "ok",
+  last_seen_at: now,
+  agent_status: "ok",
+  condition: "normal",
+  metrics: {},
+  meta: { version: "v1.34.8" },
+};
+
+const service = (overrides) => ({
+  id: 0,
+  external_id: "",
+  parent_external_id: "",
+  name: "",
+  kind: "deployment",
+  image: "ghcr.io/goauthentik/server:2024.2.0",
+  image_digest: "",
+  state: "1/1",
+  health: "healthy",
+  health_detail: "",
+  freshness: "current",
+  latest_digest: "",
+  ports: [],
+  labels: {},
+  first_seen_at: now,
+  last_seen_at: now,
+  updated_at: now,
+  ...overrides,
+});
+
+const services = {
+  generated_at: now,
+  hosts: [{
+    ...host,
+    services: [
+      service({
+        id: 101,
+        external_id: "authentik-server-deployment",
+        name: "authentik-server-with-a-very-long-deployment-name",
+      }),
+      service({
+        id: 102,
+        external_id: "authentik-server-pod-6d48b848d-v4x5d",
+        parent_external_id: "authentik-server-deployment",
+        name: "authentik-server-pod-with-a-very-long-kubernetes-name-6d48b848d-v4x5d",
+        kind: "pod",
+        state: "running",
+      }),
+      service({
+        id: 103,
+        external_id: "authentik-worker-deployment",
+        name: "authentik-worker-with-a-long-deployment-name",
+        health: "unhealthy",
+        health_detail: "test health detail",
+        freshness: "outdated",
+      }),
+    ],
+  }],
+};
+
+const agents = {
+  generated_at: now,
+  agents: [{
+    name: host.agent,
+    platform: host.platform,
+    version: "0.17.0",
+    interval_seconds: 30,
+    status: "ok",
+    created_at: now,
+    last_seen_at: now,
+  }],
+};
+
+const events = {
+  generated_at: now,
+  events: [
+    {
+      id: 1,
+      service_id: 101,
+      kind: "health",
+      service: services.hosts[0].services[0].name,
+      hostname: host.hostname,
+      agent: host.agent,
+      from_state: "unknown",
+      to_state: "healthy",
+      at: now,
+    },
+    {
+      id: 2,
+      service_id: 101,
+      kind: "state",
+      service: services.hosts[0].services[0].name,
+      hostname: host.hostname,
+      agent: host.agent,
+      from_state: "pending",
+      to_state: "running",
+      at: now,
+    },
+  ],
+};
+
+async function fixtureAPI(page) {
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const body = {
+      "/api/v1/services": services,
+      "/api/v1/agents": agents,
+      "/api/v1/events": events,
+      "/api/v1/me": { authenticated: false },
+    }[path];
+    if (body) {
+      await route.fulfill({ contentType: "application/json", body: JSON.stringify(body) });
+      return;
+    }
+    await route.fulfill({ status: 404, contentType: "application/json", body: "{}" });
+  });
+}
+
+async function loadDashboard(page) {
+  await fixtureAPI(page);
+  await page.goto("/");
+  await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
+}
+
+test("long Kubernetes labels remain readable and the drawer keeps event timestamps clear", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await loadDashboard(page);
+
+  const details = page.locator('[data-ext="authentik-server-deployment"] [data-service-details]');
+  const kind = details.locator(".kind");
+  await expect(kind).toHaveText("deployment");
+  const [detailsBox, kindBox] = await Promise.all([details.boundingBox(), kind.boundingBox()]);
+  expect(detailsBox).not.toBeNull();
+  expect(kindBox).not.toBeNull();
+  expect(kindBox.x).toBeGreaterThanOrEqual(detailsBox.x);
+  expect(kindBox.x + kindBox.width).toBeLessThanOrEqual(detailsBox.x + detailsBox.width + 1);
+  expect(kindBox.height).toBeLessThanOrEqual(detailsBox.height + 1);
+
+  await details.click();
+  const drawer = page.locator("#drawer");
+  await expect(drawer).toBeVisible();
+  const event = drawer.locator(".d-events .event-row").first();
+  const when = event.locator(".when");
+  const what = event.locator(".what");
+  const [eventBox, whenBox, whatBox] = await Promise.all([event.boundingBox(), when.boundingBox(), what.boundingBox()]);
+  expect(eventBox).not.toBeNull();
+  expect(whenBox).not.toBeNull();
+  expect(whatBox).not.toBeNull();
+  expect(whenBox.x).toBeGreaterThanOrEqual(eventBox.x + 11);
+  expect(whenBox.x + whenBox.width).toBeLessThanOrEqual(whatBox.x + 1);
+
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden();
+  await expect(details).toBeFocused();
+});
+
+test("service filtering updates the real catalogue rows", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await loadDashboard(page);
+
+  const query = page.locator("#q");
+  await query.fill("worker");
+  await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(1);
+  await expect(page.locator('[data-ext="authentik-worker-deployment"]')).toBeVisible();
+
+  await query.fill("");
+  await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
+});
+
+test("tablet catalogue preserves each Kubernetes kind label", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 1000 });
+  await loadDashboard(page);
+
+  await expect(page.locator("#hosts .kind")).toHaveText(["deployment", "pod", "deployment"]);
+  const overflow = await page.locator("#hosts tr[data-ext]").evaluateAll((rows) => rows.map((row) => ({
+    clientWidth: row.clientWidth,
+    scrollWidth: row.scrollWidth,
+  })));
+  for (const row of overflow) expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
+});
+
+test("mobile dashboard and drawer do not create horizontal page overflow", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await loadDashboard(page);
+
+  await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
+  const pageWidth = await page.evaluate(() => ({
+    document: document.documentElement.scrollWidth,
+    body: document.body.scrollWidth,
+    viewport: window.innerWidth,
+  }));
+  expect(pageWidth.document).toBeLessThanOrEqual(pageWidth.viewport);
+  expect(pageWidth.body).toBeLessThanOrEqual(pageWidth.viewport);
+
+  await page.locator('[data-ext="authentik-server-deployment"] [data-service-details]').click();
+  const drawer = page.locator("#drawer");
+  await expect(drawer).toBeVisible();
+  const drawerBox = await drawer.boundingBox();
+  expect(drawerBox).not.toBeNull();
+  expect(drawerBox.x + drawerBox.width).toBeLessThanOrEqual(391);
+});

--- a/test/browser/server.mjs
+++ b/test/browser/server.mjs
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const database = path.join(tmpdir(), `trove-browser-regressions-${process.pid}.db`);
+
+for (const suffix of ["", "-wal", "-shm"]) {
+  await rm(`${database}${suffix}`, { force: true });
+}
+
+const server = spawn("go", ["run", "./cmd/trove-server"], {
+  cwd: root,
+  env: {
+    ...process.env,
+    TROVE_ADDR: "127.0.0.1:18081",
+    TROVE_DB: database,
+    TROVE_FRESHNESS_ENABLED: "false",
+  },
+  stdio: "inherit",
+});
+
+let shuttingDown = false;
+function stop(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  server.kill(signal);
+}
+
+process.on("SIGINT", () => stop("SIGINT"));
+process.on("SIGTERM", () => stop("SIGTERM"));
+server.on("exit", (code, signal) => {
+  if (signal) process.exit(0);
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## What changed

- Adds a test-only Playwright suite for the embedded dashboard.
- Exercises long Kubernetes workload labels, drawer event timestamp clearance, filtering, tablet layout, and mobile horizontal overflow.
- Runs Chromium regression checks in CI without adding a dashboard build step.

## Why

The existing dashboard coverage checked source markers only. These tests catch the visual regressions fixed during the 0.16 release work in a real browser before they ship again.

## Validation

- `npm run test:browser` (4 passed)
- `go vet ./...`
- `go test ./...`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10`
- `git diff --check`