### PR TITLE
docs: define documentation ownership boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         run: python3 ./scripts/check_release_surface.py
       - name: Markdown link check
         run: python3 ./scripts/check_markdown_links.py
+      - name: Documentation ownership check
+        run: |
+          python3 -m unittest scripts/check_docs_ownership_test.py
+          python3 ./scripts/check_docs_ownership.py
       - name: golangci-lint
         run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run
       - name: go test with coverage

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage.txt
 node_modules/
 test-results/
 playwright-report/
+__pycache__/
 # stray binaries from `go build ./cmd/<x>` in the repo root
 /trove-server
 /trove-agent-docker

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ not a feature toggle, and it's the project's one hard rule.
   storage, automatic schema migrations, push-model agents that work from
   behind NAT.
 
+## Documentation
+
+Use this README for installation, quickstarts, and the configuration reference.
+Versioned operational guidance lives in the repository:
+
+- [Documentation index](docs/README.md) — ownership and the complete guide map.
+- [Authentication](docs/authentication.md) and [API](docs/api.md).
+- [Upgrades, backup, and recovery](docs/upgrades.md).
+- [Security model](SECURITY.md) and
+  [release verification](docs/release-security.md).
+
+The [wiki](https://github.com/Techdox/trove/wiki) is for discoverable
+walkthroughs, screenshots, and community-oriented guides. It links back to the
+repository for version-specific commands, configuration, authentication,
+upgrades, and security details.
+
 ## Quickstart (5 minutes)
 
 Trove is a **server** (the dashboard + API) plus one **agent per platform** you
@@ -284,38 +300,11 @@ server fails startup and names the missing variables instead of leaving the
 dashboard open. `TROVE_API_TOKEN` is valid only alongside a complete OIDC
 configuration.
 
-When OIDC is enabled, browser requests without a session are redirected to
-your IdP's login page. After login, Trove sets a signed session cookie. API
-requests with a bearer token matching `TROVE_API_TOKEN` bypass OIDC for script
-access. See the safe, copyable example in
-[docs/authentication.md](docs/authentication.md#programmatic-api-access).
-Generate this optional token with `openssl rand -hex 32`; Trove rejects short
-tokens and known documentation placeholders at startup.
-
-Logout clears Trove's local session cookie and, when the provider exposes an
-OIDC `end_session_endpoint`, redirects through provider logout so users are not
-silently signed straight back in by an upstream SSO session.
-
-Agent ingest (`POST /api/v1/report`) and `/healthz` are never gated by OIDC.
-
-**Authentik setup:** create an OAuth2/OpenID provider with these settings:
-
-- Redirect URI: `https://trove.example.com/oauth2/callback`
-- Post-logout redirect/return URI: `https://trove.example.com/`
-- Client type: Confidential
-- Scopes: `openid`, `profile`, `email`
-
-Then set the env vars:
-
-```sh
-TROVE_OIDC_ISSUER=https://auth.example.com/application/o/trove/
-TROVE_OIDC_CLIENT_ID=trove
-TROVE_OIDC_CLIENT_SECRET=OIDC_CLIENT_SECRET_VALUE
-TROVE_OIDC_REDIRECT_URL=https://trove.example.com/oauth2/callback
-```
-
-Full setup, logout behaviour, verification commands, and troubleshooting live
-in [docs/authentication.md](docs/authentication.md).
+Generate the optional API token with `openssl rand -hex 32`; Trove rejects
+short tokens and known documentation placeholders at startup. Provider setup,
+login/logout behaviour, API-token examples, verification, and troubleshooting
+are owned by [docs/authentication.md](docs/authentication.md). Agent ingest
+(`POST /api/v1/report`) and `/healthz` remain outside OIDC.
 
 Private registry / Docker Hub credentials for freshness checks:
 
@@ -404,35 +393,14 @@ interface; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Upgrades & backup
 
-Upgrades are a `pull` (or binary swap) and restart away: schema migrations apply
-automatically on startup and are additive. Upgrade the server first; agents from
-the immediately previous release may lag while the rollout completes.
+Schema migrations are automatic and additive, but the SQLite database is
+durable state and a verified backup is the rollback path. Upgrade the server
+before its agents.
 
-Before an upgrade or when collecting a safe support report, run
-`trove-server doctor` on the server. It checks the configured database and
-local configuration without contacting external services, creating a database,
-applying migrations, or printing credentials:
-
-```sh
-# Docker Compose
-docker compose exec server trove-server doctor
-
-# Bare metal
-sudo TROVE_DB=/var/lib/trove/trove.db trove-server doctor
-```
-
-Everything is one SQLite file (`trove.db` / the `trove-data` volume) — treat it
-as durable and back it up with `trove-server backup` or `sqlite3 ... ".backup"`.
-It contains agent token hashes,
-inventory and event history, and alert cursor/delivery state. If it is lost,
-production agents must be recreated and configured with newly issued tokens
-before current inventory can repopulate; event history and prior alert state
-cannot be rebuilt.
-
-See **[docs/upgrades.md](docs/upgrades.md)** for per-method upgrade steps (Docker
-Compose, bare metal, `go install`, agents), version pinning, backup creation and
-read-only verification, cron/systemd retention examples, restore rehearsals,
-and how to roll back.
+The canonical procedure is [docs/upgrades.md](docs/upgrades.md): it owns the
+Compose, systemd, and `go install` commands; `trove-server doctor`; backup
+creation and read-only verification; retention examples; restore rehearsal;
+and rollback.
 
 ## Building from source
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,36 +43,39 @@ This milestone does not add another monitored platform or any control path.
 
 ### Agent credential rotation
 
-- [ ] Add `trove-server agent rotate <name>` to issue a one-time replacement
+- [x] Add `trove-server agent rotate <name>` to issue a one-time replacement
   token without deleting the agent, its hosts, services, or history.
-- [ ] Invalidate the previous token when rotation succeeds, never persist the
+- [x] Invalidate the previous token when rotation succeeds, never persist the
   replacement in plaintext, and cover the CLI/store behavior with tests.
-- [ ] Document a maintenance-window rotation flow for Compose, Kubernetes,
+- [x] Document a maintenance-window rotation flow for Compose, Kubernetes,
   Proxmox, and systemd agents, including the expected temporary `401` state.
 
 ### Diagnostics and recovery
 
-- [ ] Add a sanitized `trove-server doctor` command covering database access
+- [x] Add a sanitized `trove-server doctor` command covering database access
   and integrity, migration state, configuration validation, and non-secret
   operational facts suitable for a bug report.
-- [ ] Add a supported backup-verification command or workflow that checks
+- [x] Add a supported backup-verification command or workflow that checks
   SQLite integrity and proves the backup can be opened without modifying it.
-- [ ] Publish cron and systemd-timer backup examples with retention guidance,
+- [x] Publish cron and systemd-timer backup examples with retention guidance,
   plus a short restore-rehearsal checklist.
 
 ### UI and documentation regression protection
 
-- [ ] Add automated desktop/tablet/mobile browser coverage for the dashboard's
+- [x] Add automated desktop/tablet/mobile browser coverage for the dashboard's
   highest-risk layouts: long Kubernetes names and kind labels, event dates and
   status colors, drawers, filters, and the no-horizontal-scroll mobile view.
-- [ ] Keep the browser suite test-only; the shipped dashboard remains vanilla
+- [x] Keep the browser suite test-only; the shipped dashboard remains vanilla
   JavaScript/CSS with no frontend build or runtime dependency.
-- [ ] Make repository docs the source of truth, define what belongs in the
+- [x] Make repository docs the source of truth, define what belongs in the
   wiki, and prevent duplicated upgrade/authentication guidance from drifting.
 
-**Exit:** complete the gates above, exercise the resulting commands against a
-copy of real deployment data, and run the candidate on the main deployment
-without changing Trove's observation-only boundary.
+### Exit evidence
+
+- [ ] Exercise the resulting commands against a copy of real deployment data.
+- [ ] Run the candidate on the main deployment and confirm agent ingest,
+  dashboard/read APIs, OIDC, `/healthz`, and background workers remain healthy
+  without changing Trove's observation-only boundary.
 
 ## Following milestone — `v0.18.0` stability contract
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Trove documentation
+
+Repository documentation is versioned with the code and is the source of truth
+for behaviour that can change between releases.
+
+## Ownership
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| [Root README](../README.md) | Product overview, supported installation paths, quickstarts, and the complete environment-variable configuration reference. | Detailed operational, upgrade, authentication, API, or security procedures. |
+| Repository docs | Agent operation, authentication behaviour, API contracts, alerts, upgrades, backup/recovery, and release security for this code version. | General discovery content or screenshot-heavy walkthroughs. |
+| [Wiki](https://github.com/Techdox/trove/wiki) | Non-versioned walkthroughs, screenshots, examples, and community-oriented discovery guides. | Canonical configuration, authentication, upgrade, recovery, API, or security instructions. |
+
+Wiki pages should link to the relevant repository document instead of copying
+version-specific commands or configuration. A repository change that alters
+operator behaviour must update the owning repository document in the same pull
+request.
+
+## Guides
+
+- Agents: [Docker](agents/docker.md), [Kubernetes](agents/kubernetes.md),
+  [Proxmox](agents/proxmox.md), [Linux/systemd](agents/local.md), and
+  [credential rotation](agents/rotation.md).
+- [Dashboard authentication](authentication.md).
+- [API and metrics](api.md).
+- [Alerts and digest](alerts.md).
+- [Upgrades, backup, restore rehearsal, and rollback](upgrades.md).
+- [Release integrity and provenance](release-security.md).
+- Project-wide vulnerability and trust boundaries: [SECURITY.md](../SECURITY.md).
+
+## Keeping the boundary intact
+
+CI runs `scripts/check_docs_ownership.py`. It confirms canonical cross-links,
+keeps operational command blocks out of the README's upgrade and authentication
+sections, and rejects duplicated multi-line command examples shared between the
+README and their versioned operational guides.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -28,47 +28,18 @@ OIDC does **not** protect these routes:
 | `GET` | `/oauth2/callback` | Receives the provider callback. |
 | `POST` | `/oauth2/logout` | Clears the local Trove session and redirects to provider logout when available. |
 
-## Required environment variables
+## Configuration source
 
-Set these on the `trove-server` process:
+The canonical list of OIDC variables, defaults, and startup-validation rules is
+the [README configuration reference](../README.md#configuration-reference).
+This guide owns provider setup and operational verification, so it deliberately
+does not duplicate that configuration table.
 
-| Variable | Purpose |
-| --- | --- |
-| `TROVE_OIDC_ISSUER` | OIDC issuer/discovery URL. Example: `https://auth.example.com/application/o/trove/` |
-| `TROVE_OIDC_CLIENT_ID` | OAuth2/OIDC client ID from the provider. |
-| `TROVE_OIDC_CLIENT_SECRET` | OAuth2/OIDC client secret from the provider. |
-| `TROVE_OIDC_REDIRECT_URL` | Trove callback URL. Example: `https://trove.example.com/oauth2/callback` |
-
-All four settings are required together. Trove performs OIDC discovery during startup with a ten-second timeout; invalid, unreachable, or incomplete configuration prevents the server from listening.
-
-Optional:
-
-| Variable | Default | Purpose |
-| --- | --- | --- |
-| `TROVE_API_TOKEN` | unset | Static bearer token for scripts/API clients that cannot use browser OIDC. Must be at least 32 characters and randomly generated. |
-| `TROVE_OIDC_SESSION_MAX_AGE` | `8h` | Signed dashboard session lifetime. Uses Go duration syntax such as `4h`, `12h`, or `30m`. |
-
-Example:
-
-```env
-TROVE_OIDC_ISSUER=https://auth.example.com/application/o/trove/
-TROVE_OIDC_CLIENT_ID=trove
-TROVE_OIDC_CLIENT_SECRET=OIDC_CLIENT_SECRET_VALUE
-TROVE_OIDC_REDIRECT_URL=https://trove.example.com/oauth2/callback
-TROVE_OIDC_SESSION_MAX_AGE=8h
-```
-
-Only configure programmatic API access when it is needed. Generate its token
-instead of inventing or copying one:
-
-```sh
-openssl rand -hex 32
-```
-
-Store that command's output in `TROVE_API_TOKEN`. Trove rejects short tokens,
-leading/trailing whitespace, and known documentation placeholders at startup.
-
-The session cookie is signed using the OIDC client secret. It is `HttpOnly`, `SameSite=Lax`, and marked `Secure` when the configured redirect URL is HTTPS.
+Configure all required OIDC settings together. Trove performs discovery during
+startup with a ten-second timeout; invalid, unreachable, or incomplete
+configuration prevents the server from listening. The session cookie is signed
+using the OIDC client secret. It is `HttpOnly`, `SameSite=Lax`, and marked
+`Secure` when the configured redirect URL is HTTPS.
 
 ## Authentik setup
 

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -17,6 +17,24 @@ run the server.
 - In anything you care about, pin a specific version (e.g. `0.16.1`) <!-- x-release-please-version --> rather than
   `latest`, so upgrades are a deliberate change you control.
 
+### Doctor preflight
+
+Before upgrading—or when collecting a safe support report—run
+`trove-server doctor` against the live server database. It checks database
+access and integrity, migration state, local configuration, binary details, and
+worker-relevant facts. The command is strictly read-only: it does not contact
+external services, create a database, apply migrations, or print credentials.
+
+```sh
+# Docker Compose
+docker compose exec server trove-server doctor
+
+# Bare metal / systemd
+sudo TROVE_DB=/var/lib/trove/trove.db trove-server doctor
+```
+
+Resolve any reported problem before proceeding with the upgrade.
+
 ## Docker Compose
 
 From the directory holding your compose file and `.env`:

--- a/scripts/check_docs_ownership.py
+++ b/scripts/check_docs_ownership.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Keep install/configuration and operational documentation ownership distinct."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FENCE = re.compile(r"```[^\n]*\n(?P<body>.*?)```", re.DOTALL)
+
+
+def read(root: Path, relative: str) -> str:
+    path = root / relative
+    if not path.is_file():
+        raise ValueError(f"{relative}: canonical documentation file is missing")
+    return path.read_text(encoding="utf-8")
+
+
+def section(text: str, heading: str) -> str:
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError as exc:
+        raise ValueError(f"missing canonical heading {heading!r}") from exc
+
+    level = len(heading) - len(heading.lstrip("#"))
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        match = re.match(r"^(#{1,6})\s", lines[index])
+        if match and len(match.group(1)) <= level:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
+def substantial_blocks(text: str) -> set[str]:
+    blocks: set[str] = set()
+    for match in FENCE.finditer(text):
+        body = "\n".join(line.rstrip() for line in match.group("body").strip().splitlines())
+        meaningful = [line for line in body.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+        if len(meaningful) >= 2:
+            blocks.add(body)
+    return blocks
+
+
+def check(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    try:
+        readme = read(root, "README.md")
+        docs_index = read(root, "docs/README.md")
+        authentication = read(root, "docs/authentication.md")
+        upgrades = read(root, "docs/upgrades.md")
+        release_security = read(root, "docs/release-security.md")
+    except ValueError as exc:
+        return [str(exc)]
+
+    required_readme_links = {
+        "documentation ownership": "(docs/README.md)",
+        "authentication": "(docs/authentication.md)",
+        "upgrades": "(docs/upgrades.md)",
+        "release security": "(docs/release-security.md)",
+    }
+    for label, link in required_readme_links.items():
+        if link not in readme:
+            errors.append(f"README.md: missing canonical {label} link {link}")
+
+    if "(../README.md#configuration-reference)" not in authentication:
+        errors.append(
+            "docs/authentication.md: must link to the README configuration reference"
+        )
+    if re.search(r"^\|\s*`TROVE_[A-Z0-9_]+`", authentication, re.MULTILINE):
+        errors.append(
+            "docs/authentication.md: environment-variable tables belong in README.md"
+        )
+
+    try:
+        oidc = section(readme, "#### Dashboard authentication (OIDC)")
+        upgrade_summary = section(readme, "## Upgrades & backup")
+    except ValueError as exc:
+        errors.append(f"README.md: {exc}")
+    else:
+        oidc_summary = oidc.split("Private registry / Docker Hub credentials", 1)[0]
+        if "```" in oidc_summary:
+            errors.append(
+                "README.md: OIDC configuration summary must link to operational examples, not copy them"
+            )
+        if "```" in upgrade_summary:
+            errors.append(
+                "README.md: upgrade summary must link to docs/upgrades.md, not contain command blocks"
+            )
+
+    duplicate_blocks = substantial_blocks(readme) & (
+        substantial_blocks(authentication) | substantial_blocks(upgrades)
+    )
+    for block in sorted(duplicate_blocks):
+        first_line = block.splitlines()[0][:80]
+        errors.append(
+            f"README.md: duplicates an operational command block beginning {first_line!r}"
+        )
+
+    ownership_phrases = (
+        "Repository documentation is versioned with the code",
+        "Root README",
+        "Repository docs",
+        "Wiki",
+        "Non-versioned walkthroughs",
+    )
+    for phrase in ownership_phrases:
+        if phrase not in docs_index:
+            errors.append(f"docs/README.md: ownership boundary is missing {phrase!r}")
+
+    if "## Rolling back" not in upgrades:
+        errors.append("docs/upgrades.md: canonical rollback procedure is missing")
+    if "Verify a container image" not in release_security:
+        errors.append("docs/release-security.md: canonical image verification is missing")
+
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        print("documentation ownership check failed:", file=sys.stderr)
+        print("\n".join(f"- {error}" for error in errors), file=sys.stderr)
+        return 1
+
+    print("documentation ownership boundary is intact")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docs_ownership_test.py
+++ b/scripts/check_docs_ownership_test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_docs_ownership import check
+
+
+class DocumentationOwnershipCheckTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "docs").mkdir()
+        (self.root / "README.md").write_text(
+            """# Trove
+
+[Documentation](docs/README.md)
+[Authentication](docs/authentication.md)
+[Upgrades](docs/upgrades.md)
+[Release security](docs/release-security.md)
+
+## Configuration reference
+
+#### Dashboard authentication (OIDC)
+
+Configuration belongs here.
+
+## Upgrades & backup
+
+See the canonical guide.
+""",
+            encoding="utf-8",
+        )
+        (self.root / "docs/README.md").write_text(
+            """Repository documentation is versioned with the code.
+
+Root README
+Repository docs
+Wiki
+Non-versioned walkthroughs
+""",
+            encoding="utf-8",
+        )
+        (self.root / "docs/authentication.md").write_text(
+            "[Configuration](../README.md#configuration-reference)\n",
+            encoding="utf-8",
+        )
+        (self.root / "docs/upgrades.md").write_text(
+            "## Rolling back\n\nRestore the verified backup.\n",
+            encoding="utf-8",
+        )
+        (self.root / "docs/release-security.md").write_text(
+            "## Verify a container image\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_valid_boundary_passes(self) -> None:
+        self.assertEqual(check(self.root), [])
+
+    def test_authentication_variable_table_fails(self) -> None:
+        path = self.root / "docs/authentication.md"
+        path.write_text(
+            path.read_text(encoding="utf-8")
+            + "\n| `TROVE_OIDC_ISSUER` | duplicated configuration |\n",
+            encoding="utf-8",
+        )
+        self.assertTrue(any("environment-variable tables" in error for error in check(self.root)))
+
+    def test_readme_upgrade_commands_fail(self) -> None:
+        path = self.root / "README.md"
+        path.write_text(
+            path.read_text(encoding="utf-8")
+            + "\n```sh\ndocker compose pull\ndocker compose up -d\n```\n",
+            encoding="utf-8",
+        )
+        self.assertTrue(any("command blocks" in error for error in check(self.root)))
+
+    def test_duplicated_operational_example_fails(self) -> None:
+        block = "```sh\nfirst command\nsecond command\n```\n"
+        readme = self.root / "README.md"
+        readme.write_text(
+            readme.read_text(encoding="utf-8").replace(
+                "## Configuration reference", f"{block}\n## Configuration reference"
+            ),
+            encoding="utf-8",
+        )
+        authentication = self.root / "docs/authentication.md"
+        authentication.write_text(
+            authentication.read_text(encoding="utf-8") + f"\n{block}",
+            encoding="utf-8",
+        )
+        self.assertTrue(
+            any("duplicates an operational command block" in error for error in check(self.root))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/browser/dashboard.spec.mjs
+++ b/test/browser/dashboard.spec.mjs
@@ -183,6 +183,28 @@ test("service filtering updates the real catalogue rows", async ({ page }) => {
   await expect(page.locator("#hosts tr[data-ext]")).toHaveCount(3);
 });
 
+test("health and freshness status colors remain semantically distinct", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await loadDashboard(page);
+
+  const badges = {
+    healthy: page.locator('[data-ext="authentik-server-deployment"] .health-cell .badge'),
+    unhealthy: page.locator('[data-ext="authentik-worker-deployment"] .health-cell .badge'),
+    current: page.locator('[data-ext="authentik-server-deployment"] .fresh-cell .badge'),
+    outdated: page.locator('[data-ext="authentik-worker-deployment"] .fresh-cell .badge'),
+  };
+  await expect(badges.healthy).toHaveClass(/b-green/);
+  await expect(badges.unhealthy).toHaveClass(/b-red/);
+  await expect(badges.current).toHaveClass(/b-blue/);
+  await expect(badges.outdated).toHaveClass(/b-peach/);
+
+  const signatures = await Promise.all(Object.values(badges).map((badge) => badge.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return [style.color, style.backgroundColor, style.borderColor].join("|");
+  })));
+  expect(new Set(signatures).size).toBe(4);
+});
+
 test("tablet catalogue preserves each Kubernetes kind label", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 1000 });
   await loadDashboard(page);


### PR DESCRIPTION
## What changed

- Defines README, repository-docs, and wiki ownership boundaries.
- Removes duplicated Authentik setup and upgrade/backup command blocks from the README while preserving canonical links.
- Adds a documentation index plus a tested CI drift check.
- Marks the completed v0.17 implementation gates and exposes the two remaining deployment-evidence checks.

## Why

Authentication and upgrade instructions were duplicated across surfaces and could disagree after a versioned change. This keeps install/configuration in the README, operational procedures with the code version, and the wiki focused on non-versioned walkthroughs and screenshots.

## Validation

- `python3 -m unittest scripts/check_docs_ownership_test.py` (4 passed)
- `python3 scripts/check_docs_ownership.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_release_surface.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10`
- `go vet ./...`
- `go test ./...`
- `git diff --check`