### PR TITLE
fix: harden backup diagnostics and help handling

### DIFF
--- a/cmd/trove-server/backup_verify.go
+++ b/cmd/trove-server/backup_verify.go
@@ -57,7 +57,17 @@ func runBackupVerify(args []string) error {
 	fmt.Printf("backup: %s (%d bytes)\n", absPath, info.Size())
 	fmt.Printf("sha256: %x\n", before)
 	fmt.Println("database: ok (read-only integrity check)")
-	fmt.Printf("migrations: %d applied, %d pending, %d unknown\n", len(migrations.Applied), len(migrations.Pending), len(migrations.Unknown))
+	fmt.Printf("migrations: %d applied, %d pending, %d retired, %d unknown\n",
+		len(migrations.Applied),
+		len(migrations.Pending),
+		len(migrations.Retired),
+		len(migrations.Unknown),
+	)
+	if len(migrations.Pending) == 0 && len(migrations.Unknown) == 0 {
+		fmt.Println("compatibility: migration history recognized by this binary")
+	} else {
+		fmt.Println("compatibility: migration history requires review with trove-server doctor")
+	}
 	fmt.Println("result: ok (backup opened and unchanged)")
 	return nil
 }

--- a/cmd/trove-server/backup_verify_test.go
+++ b/cmd/trove-server/backup_verify_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/techdox/trove/internal/store"
 )
@@ -46,6 +47,80 @@ func TestRunBackupVerifyReadsBackupWithoutChangingIt(t *testing.T) {
 	}
 	if !bytes.Equal(before, after) {
 		t.Fatal("backup changed during verification")
+	}
+}
+
+func TestRunBackupVerifyRecognizesRetiredMigrationWithoutChangingBackup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trove-backup.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("create backup database: %v", err)
+	}
+	if _, err := st.DB().Exec(
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)`,
+		"0008_runtime_settings.sql",
+		time.Now().Unix(),
+	); err != nil {
+		_ = st.Close()
+		t.Fatalf("insert retired migration: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close backup database: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read backup before verification: %v", err)
+	}
+
+	output, err := captureDoctorOutput(t, func() error {
+		return runBackupVerify([]string{path})
+	})
+	if err != nil {
+		t.Fatalf("verify backup: %v", err)
+	}
+	for _, want := range []string{
+		"0 pending, 1 retired, 0 unknown",
+		"compatibility: migration history recognized by this binary",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("verification output missing %q:\n%s", want, output)
+		}
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read backup after verification: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("backup changed during verification")
+	}
+}
+
+func TestRunBackupVerifyWarnsAboutUnknownMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "trove-backup.db")
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("create backup database: %v", err)
+	}
+	if _, err := st.DB().Exec(
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)`,
+		"9999_unknown.sql",
+		time.Now().Unix(),
+	); err != nil {
+		_ = st.Close()
+		t.Fatalf("insert unknown migration: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close backup database: %v", err)
+	}
+
+	output, err := captureDoctorOutput(t, func() error {
+		return runBackupVerify([]string{path})
+	})
+	if err != nil {
+		t.Fatalf("verify backup: %v", err)
+	}
+	if !strings.Contains(output, "compatibility: migration history requires review with trove-server doctor") {
+		t.Errorf("verification output did not flag migration review:\n%s", output)
 	}
 }
 

--- a/cmd/trove-server/doctor.go
+++ b/cmd/trove-server/doctor.go
@@ -54,9 +54,14 @@ func runDoctor() error {
 		if len(migrations.Unknown) != 0 {
 			problems = append(problems, "database has migrations unknown to this binary")
 		}
-		fmt.Printf("migrations: not current (%d/%d applied)\n", len(migrations.Applied), len(migrations.Applied)+len(migrations.Pending))
+		fmt.Printf("migrations: not current (%d/%d applied, %d retired, %d unknown)\n",
+			len(migrations.Applied),
+			len(migrations.Applied)+len(migrations.Pending),
+			len(migrations.Retired),
+			len(migrations.Unknown),
+		)
 	} else {
-		fmt.Printf("migrations: current (%d applied)\n", len(migrations.Applied))
+		fmt.Printf("migrations: current (%d applied, %d retired)\n", len(migrations.Applied), len(migrations.Retired))
 	}
 
 	configProblems := validateDoctorConfig()

--- a/cmd/trove-server/doctor_test.go
+++ b/cmd/trove-server/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/techdox/trove/internal/store"
 )
@@ -34,6 +35,39 @@ func TestRunDoctorReportsReadOnlyHealthyStateWithoutSecrets(t *testing.T) {
 		if strings.Contains(output, secret) {
 			t.Errorf("doctor output exposed a secret: %q", secret)
 		}
+	}
+}
+
+func TestRunDoctorAcceptsRetiredMigrationHistory(t *testing.T) {
+	path := newDoctorDatabase(t)
+	addDoctorMigration(t, path, "0008_runtime_settings.sql")
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err != nil {
+		t.Fatalf("run doctor: %v", err)
+	}
+	if !strings.Contains(output, "1 retired") {
+		t.Errorf("doctor output did not report retired migration:\n%s", output)
+	}
+	if !strings.Contains(output, "result: ok") {
+		t.Errorf("doctor output did not report success:\n%s", output)
+	}
+}
+
+func TestRunDoctorRejectsUnknownMigrationHistory(t *testing.T) {
+	path := newDoctorDatabase(t)
+	addDoctorMigration(t, path, "9999_unknown.sql")
+	clearDoctorEnv(t)
+	t.Setenv("TROVE_DB", path)
+
+	output, err := captureDoctorOutput(t, runDoctor)
+	if err == nil {
+		t.Fatal("doctor accepted an unknown migration")
+	}
+	if !strings.Contains(output, "migrations: not current") || !strings.Contains(output, "1 unknown") {
+		t.Errorf("doctor output did not report unknown migration:\n%s", output)
 	}
 }
 
@@ -96,6 +130,25 @@ func newDoctorDatabase(t *testing.T) string {
 		t.Fatalf("close doctor database: %v", err)
 	}
 	return path
+}
+
+func addDoctorMigration(t *testing.T, path, version string) {
+	t.Helper()
+	st, err := store.Open(path)
+	if err != nil {
+		t.Fatalf("open doctor database: %v", err)
+	}
+	if _, err := st.DB().Exec(
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)`,
+		version,
+		time.Now().Unix(),
+	); err != nil {
+		_ = st.Close()
+		t.Fatalf("insert doctor migration: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("close doctor database: %v", err)
+	}
 }
 
 func clearDoctorEnv(t *testing.T) {

--- a/cmd/trove-server/main.go
+++ b/cmd/trove-server/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -85,7 +86,7 @@ func main() {
 	}
 }
 
-func usage(w *os.File) {
+func usage(w io.Writer) {
 	fmt.Fprint(w, `trove-server — read-only service catalog + health monitor
 
 Commands:
@@ -364,7 +365,15 @@ func bootstrapAgent(ctx context.Context, st *store.Store, logger *slog.Logger) e
 // files.
 func runBackup(args []string) error {
 	if len(args) > 0 && args[0] == "verify" {
+		if len(args) == 2 && isHelpFlag(args[1]) {
+			backupUsage(os.Stdout)
+			return nil
+		}
 		return runBackupVerify(args[1:])
+	}
+	if len(args) == 1 && isHelpFlag(args[0]) {
+		backupUsage(os.Stdout)
+		return nil
 	}
 	if len(args) > 1 {
 		return errors.New("usage: trove-server backup [path]\n       trove-server backup verify <path>")
@@ -402,6 +411,19 @@ func runBackup(args []string) error {
 	}
 	fmt.Printf("backup written to %s\n", dst)
 	return nil
+}
+
+func isHelpFlag(arg string) bool {
+	return arg == "-h" || arg == "--help"
+}
+
+func backupUsage(w io.Writer) {
+	fmt.Fprint(w, `Usage:
+  trove-server backup [path]
+  trove-server backup verify <path>
+
+Create a consistent SQLite backup, or inspect an existing backup read-only.
+`)
 }
 
 // runAlertCmd handles `trove-server alert test`: it pushes a test

--- a/cmd/trove-server/main_test.go
+++ b/cmd/trove-server/main_test.go
@@ -179,6 +179,39 @@ func firstToken(output string) string {
 	return ""
 }
 
+func TestRunBackupHelpDoesNotCreateFiles(t *testing.T) {
+	for _, args := range [][]string{
+		{"-h"},
+		{"--help"},
+		{"verify", "-h"},
+		{"verify", "--help"},
+	} {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			t.Setenv("TROVE_DB", filepath.Join(dir, "must-not-be-created.db"))
+
+			output, err := captureStdout(t, func() error {
+				return runBackup(args)
+			})
+			if err != nil {
+				t.Fatalf("run backup help: %v", err)
+			}
+			if !strings.Contains(output, "trove-server backup [path]") ||
+				!strings.Contains(output, "trove-server backup verify <path>") {
+				t.Fatalf("backup help output = %q, want backup usage", output)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("read test directory: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("backup help created files: %v", entries)
+			}
+		})
+	}
+}
+
 type compatibilitySnapshot struct {
 	agents         int
 	hosts          int

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -34,6 +34,10 @@ sudo TROVE_DB=/var/lib/trove/trove.db trove-server doctor
 ```
 
 Resolve any reported problem before proceeding with the upgrade.
+Migration records from recognized pre-release builds are reported as `retired`
+and do not fail the check. A migration reported as `unknown` still blocks the
+upgrade because the database may have been used by a newer, incompatible
+binary.
 
 ## Docker Compose
 
@@ -136,8 +140,10 @@ docker compose exec server trove-server backup verify /data/backups/trove-202607
 ```
 
 `result: ok (backup opened and unchanged)` means that the file was readable and
-internally consistent at verification time. It does not make an older server
-binary compatible with a newer schema; follow the rollback procedure below.
+internally consistent at verification time. Check the separate `compatibility`
+line for whether this binary recognizes the migration history. Verification
+does not make an older server binary compatible with a newer schema; follow the
+rollback procedure below.
 
 ### Scheduled backups and retention
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -131,7 +131,16 @@ func (s *Store) CheckIntegrity(ctx context.Context) (string, error) {
 type MigrationStatus struct {
 	Applied []string
 	Pending []string
+	Retired []string
 	Unknown []string
+}
+
+// retiredMigrations are historical migration records that may remain in
+// databases created by pre-release builds. Keep these exact names recognized
+// without applying them to new databases or weakening detection of migrations
+// created by a genuinely newer binary.
+var retiredMigrations = map[string]struct{}{
+	"0008_runtime_settings.sql": {},
 }
 
 // MigrationStatus reads migration state without applying any migrations.
@@ -170,10 +179,13 @@ func (s *Store) MigrationStatus(ctx context.Context) (MigrationStatus, error) {
 		}
 	}
 	for name := range recorded {
-		if !expectedSet[name] {
+		if _, retired := retiredMigrations[name]; retired {
+			status.Retired = append(status.Retired, name)
+		} else if !expectedSet[name] {
 			status.Unknown = append(status.Unknown, name)
 		}
 	}
+	sort.Strings(status.Retired)
 	sort.Strings(status.Unknown)
 	return status, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -87,6 +87,47 @@ func TestOpenReadOnlyInspectsWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestMigrationStatusRecognizesRetiredMigration(t *testing.T) {
+	st, _ := newTestStore(t)
+	if _, err := st.DB().Exec(
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)`,
+		"0008_runtime_settings.sql",
+		time.Now().Unix(),
+	); err != nil {
+		t.Fatalf("insert retired migration: %v", err)
+	}
+
+	status, err := st.MigrationStatus(context.Background())
+	if err != nil {
+		t.Fatalf("migration status: %v", err)
+	}
+	if len(status.Pending) != 0 || len(status.Unknown) != 0 {
+		t.Fatalf("migration status = %+v, want no pending or unknown migrations", status)
+	}
+	if len(status.Retired) != 1 || status.Retired[0] != "0008_runtime_settings.sql" {
+		t.Fatalf("retired migrations = %v, want 0008_runtime_settings.sql", status.Retired)
+	}
+}
+
+func TestMigrationStatusStillReportsUnknownMigration(t *testing.T) {
+	st, _ := newTestStore(t)
+	if _, err := st.DB().Exec(
+		`INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)`,
+		"9999_unknown.sql",
+		time.Now().Unix(),
+	); err != nil {
+		t.Fatalf("insert unknown migration: %v", err)
+	}
+
+	status, err := st.MigrationStatus(context.Background())
+	if err != nil {
+		t.Fatalf("migration status: %v", err)
+	}
+	if len(status.Unknown) != 1 || status.Unknown[0] != "9999_unknown.sql" {
+		t.Fatalf("unknown migrations = %v, want 9999_unknown.sql", status.Unknown)
+	}
+}
+
 func TestOpenReadOnlyDoesNotCreateMissingDatabase(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing.db")
 	if _, err := OpenReadOnly(path); err == nil {


### PR DESCRIPTION
## What changed

- classify the historical `0008_runtime_settings.sql` record as a recognized retired migration
- continue treating every other recorded-but-unembedded migration as unknown and fail `trove-server doctor`
- report retired migration counts from `doctor` and `backup verify`
- add an explicit backup compatibility line without changing the command's read-only integrity contract
- make `backup -h`, `backup --help`, and both `backup verify` help forms print usage without creating a database or backup
- document retired versus unknown migration behavior
- add regression coverage for retired, genuinely unknown, and non-writing help paths

## Why

The v0.17 production-backup rehearsal found that a real Trove database contains `0008_runtime_settings.sql`, a migration recorded by a pre-release build but no longer embedded in current binaries. The candidate successfully opened and served a writable copy of that database, but `trove-server doctor` classified the retained record as unknown and exited non-zero.

Adding a no-op numbered migration would incorrectly apply historical state to new databases. This change instead recognizes only the exact retired name while preserving the safety guard for databases created by genuinely newer binaries.

The isolated Phase A retest then exposed that the old/current CLI interprets `backup --help` as a literal destination and writes a backup. The help paths now return usage successfully and regression tests verify that they create no files.

## Operator impact

Existing databases carrying the retired record pass the v0.17 doctor preflight and report `1 retired`. Truly unknown migration records still block the preflight. Backup verification remains read-only and states separately whether the current binary recognizes the migration history. Backup help flags no longer perform a write.

## Validation

- focused backup/help tests, repeated 20 times
- `gofmt`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `make native GOFLAGS='-trimpath -buildvcs=false'`
- `git diff --check`

The updated immutable preview image must pass Phase A before any production deployment or soak begins.