### PR TITLE
fix: bump Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/techdox/trove
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/coreos/go-oidc/v3 v3.19.0


### PR DESCRIPTION
## Summary
- bump the module Go baseline from 1.26.5 to 1.26.6
- clear the standard-library vulnerabilities reported by govulncheck

## Verification
- Go 1.26.6: fmt, vet, full tests, race tests, cross-build
- golangci-lint: 0 issues
- govulncheck: no vulnerabilities found
- GoReleaser config: validated
- browser regressions: 5 passed