### PR TITLE
feat: publish API compatibility schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10
       - name: Release surface check
         run: python3 ./scripts/check_release_surface.py
+      - name: API schema compatibility and DTO drift check
+        run: python3 ./scripts/check_api_schema.py
       - name: Markdown link check
         run: python3 ./scripts/check_markdown_links.py
       - name: Documentation ownership check

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,16 @@ curl --oauth2-bearer "$TROVE_API_TOKEN" \
   'https://trove.example/api/v1/events?kind=health&limit=50&offset=50'
 ```
 
+## Machine-readable schemas and compatibility
+
+The versioned JSON Schemas in [`schemas/v1/`](../schemas/v1/) are the source of truth for the agent report and JSON API response shapes. They cover `POST /api/v1/report`, its acknowledgement, and the `services`, `agents`, and `events` responses. The schemas are published with the repository so clients can validate payloads without running Trove.
+
+Trove follows additive evolution within `v1`: new optional response or report fields may be added, but existing field meanings, JSON types, and required fields are preserved. Clients must ignore unknown fields. Removing a field, changing its JSON type or meaning, or making an optional field required requires a new API version and a migration note. This is a compatibility guarantee for the documented JSON shapes, not a promise that undocumented fields, ordering, pagination totals, timestamps, or operational limits never change.
+
+`schemas/v1/baseline.json` records the supported v1 surface. CI fails if a baseline property is removed or changes type, if a current server DTO drifts from its schema, or if the frozen previous-release report fixtures stop being accepted. The Go compatibility tests exercise the v0.15.1 report fixtures against the current ingest path; keep a fixture for each supported previous release when changing the wire model.
+
+Upgrade agents only after the server is upgraded. The server accepts the immediately previous agent report shape, and rollback means restoring the previous server and agents together. A newer agent may send additive fields that an older server does not understand, so do not use that combination as a supported rollback path.
+
 ## Prometheus metrics
 
 `GET /metrics` exposes Prometheus text format and is protected like the other read APIs when OIDC/API-token auth is enabled.

--- a/schemas/v1/agents.json
+++ b/schemas/v1/agents.json
@@ -1,0 +1,7 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "title":"Trove agents response v1","type":"object","additionalProperties":true,
+  "required":["generated_at","agents"],
+  "properties":{"generated_at":{"type":"string"},"agents":{"type":"array","items":{"$ref":"#/$defs/agent"}}},
+  "$defs":{"agent":{"type":"object","required":["name","platform","version","interval_seconds","status","created_at","last_seen_at"],"properties":{"name":{"type":"string"},"platform":{"type":"string"},"version":{"type":"string"},"interval_seconds":{"type":"integer"},"status":{"type":"string"},"created_at":{"type":"string"},"last_seen_at":{}}}}
+}

--- a/schemas/v1/baseline.json
+++ b/schemas/v1/baseline.json
@@ -1,0 +1,387 @@
+{
+  "agents.json": {
+    "$defs": {
+      "agent": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "interval_seconds": {
+            "type": "integer"
+          },
+          "last_seen_at": {},
+          "name": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "platform",
+          "version",
+          "interval_seconds",
+          "status",
+          "created_at",
+          "last_seen_at"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "properties": {
+      "agents": {
+        "items": {
+          "$ref": "#/$defs/agent"
+        },
+        "type": "array"
+      },
+      "generated_at": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "generated_at",
+      "agents"
+    ],
+    "title": "Trove agents response v1",
+    "type": "object"
+  },
+  "events.json": {
+    "$defs": {
+      "event": {
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "at": {
+            "type": "string"
+          },
+          "from_state": {
+            "type": "string"
+          },
+          "host_id": {},
+          "hostname": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "service": {
+            "type": "string"
+          },
+          "service_id": {},
+          "to_state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "kind",
+          "from_state",
+          "to_state",
+          "at"
+        ],
+        "type": "object"
+      },
+      "pagination": {
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "next_offset": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "count"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "properties": {
+      "events": {
+        "items": {
+          "$ref": "#/$defs/event"
+        },
+        "type": "array"
+      },
+      "generated_at": {
+        "type": "string"
+      },
+      "pagination": {
+        "$ref": "#/$defs/pagination"
+      }
+    },
+    "required": [
+      "generated_at",
+      "events"
+    ],
+    "title": "Trove events response v1",
+    "type": "object"
+  },
+  "report-ack.json": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "properties": {
+      "ok": {
+        "type": "boolean"
+      },
+      "services": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "ok",
+      "services"
+    ],
+    "title": "Trove report acknowledgement v1",
+    "type": "object"
+  },
+  "report.json": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "properties": {
+      "agent": {
+        "properties": {
+          "interval_seconds": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platform": {
+            "enum": [
+              "docker",
+              "kubernetes",
+              "proxmox",
+              "local"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "platform",
+          "version"
+        ],
+        "type": "object"
+      },
+      "host": {
+        "properties": {
+          "condition": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "meta": {
+            "type": "object"
+          },
+          "metrics": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "hostname"
+        ],
+        "type": "object"
+      },
+      "services": {
+        "items": {
+          "type": "object"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "agent",
+      "host",
+      "services"
+    ],
+    "title": "Trove agent report v1",
+    "type": "object"
+  },
+  "services.json": {
+    "$defs": {
+      "host": {
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "agent_status": {
+            "type": "string"
+          },
+          "condition": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "last_seen_at": {},
+          "meta": {},
+          "metrics": {},
+          "platform": {
+            "type": "string"
+          },
+          "services": {
+            "items": {
+              "$ref": "#/$defs/service"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "agent",
+          "hostname",
+          "platform",
+          "status",
+          "last_seen_at",
+          "agent_status",
+          "condition",
+          "metrics",
+          "meta",
+          "services"
+        ],
+        "type": "object"
+      },
+      "pagination": {
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "next_offset": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "offset",
+          "count"
+        ],
+        "type": "object"
+      },
+      "service": {
+        "properties": {
+          "external_id": {
+            "type": "string"
+          },
+          "first_seen_at": {
+            "type": "string"
+          },
+          "freshness": {
+            "type": "string"
+          },
+          "health": {
+            "type": "string"
+          },
+          "health_detail": {
+            "type": "string"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "image": {
+            "type": "string"
+          },
+          "image_digest": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "labels": {},
+          "last_seen_at": {
+            "type": "string"
+          },
+          "latest_digest": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parent_external_id": {
+            "type": "string"
+          },
+          "ports": {},
+          "state": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "external_id",
+          "name",
+          "kind",
+          "image",
+          "state",
+          "health",
+          "freshness",
+          "ports",
+          "labels",
+          "first_seen_at",
+          "last_seen_at",
+          "updated_at"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": true,
+    "properties": {
+      "generated_at": {
+        "type": "string"
+      },
+      "hosts": {
+        "items": {
+          "$ref": "#/$defs/host"
+        },
+        "type": "array"
+      },
+      "pagination": {
+        "$ref": "#/$defs/pagination"
+      }
+    },
+    "required": [
+      "generated_at",
+      "hosts"
+    ],
+    "title": "Trove services response v1",
+    "type": "object"
+  }
+}

--- a/schemas/v1/baseline.json
+++ b/schemas/v1/baseline.json
@@ -159,16 +159,115 @@
     "type": "object"
   },
   "report.json": {
+    "$defs": {
+      "service": {
+        "additionalProperties": true,
+        "properties": {
+          "external_id": {
+            "maxLength": 512,
+            "minLength": 1,
+            "type": "string"
+          },
+          "health": {
+            "enum": [
+              "healthy",
+              "unhealthy",
+              "unknown"
+            ],
+            "type": "string"
+          },
+          "health_detail": {
+            "maxLength": 4096,
+            "type": "string"
+          },
+          "image": {
+            "maxLength": 2048,
+            "type": "string"
+          },
+          "image_digest": {
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "container",
+              "pod",
+              "vm",
+              "lxc",
+              "process",
+              "deployment",
+              "statefulset",
+              "daemonset"
+            ],
+            "type": "string"
+          },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "name": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "parent_external_id": {
+            "maxLength": 512,
+            "type": "string"
+          },
+          "ports": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "container": {
+                  "type": "integer"
+                },
+                "host": {
+                  "type": "integer"
+                },
+                "proto": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "host",
+                "container",
+                "proto"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "state": {
+            "maxLength": 128,
+            "minLength": 1,
+            "not": {
+              "const": "removed"
+            },
+            "type": "string"
+          }
+        },
+        "required": [
+          "external_id",
+          "kind",
+          "state",
+          "health"
+        ],
+        "type": "object"
+      }
+    },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": true,
     "properties": {
       "agent": {
+        "additionalProperties": true,
         "properties": {
           "interval_seconds": {
             "minimum": 0,
             "type": "integer"
           },
           "name": {
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
           },
           "platform": {
@@ -181,6 +280,7 @@
             "type": "string"
           },
           "version": {
+            "maxLength": 255,
             "type": "string"
           }
         },
@@ -192,14 +292,26 @@
         "type": "object"
       },
       "host": {
+        "additionalProperties": true,
         "properties": {
           "condition": {
+            "enum": [
+              "normal",
+              "warning",
+              "critical",
+              "unknown"
+            ],
             "type": "string"
           },
           "hostname": {
+            "maxLength": 255,
+            "minLength": 1,
             "type": "string"
           },
           "meta": {
+            "additionalProperties": {
+              "type": "string"
+            },
             "type": "object"
           },
           "metrics": {
@@ -213,7 +325,7 @@
       },
       "services": {
         "items": {
-          "type": "object"
+          "$ref": "#/$defs/service"
         },
         "type": "array"
       }

--- a/schemas/v1/events.json
+++ b/schemas/v1/events.json
@@ -1,0 +1,7 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "title":"Trove events response v1","type":"object","additionalProperties":true,
+  "required":["generated_at","events"],
+  "properties":{"generated_at":{"type":"string"},"events":{"type":"array","items":{"$ref":"#/$defs/event"}},"pagination":{"$ref":"#/$defs/pagination"}},
+  "$defs":{"event":{"type":"object","required":["id","kind","from_state","to_state","at"],"properties":{"id":{"type":"integer"},"service_id":{},"host_id":{},"kind":{"type":"string"},"service":{"type":"string"},"hostname":{"type":"string"},"agent":{"type":"string"},"from_state":{"type":"string"},"to_state":{"type":"string"},"at":{"type":"string"}}},"pagination":{"type":"object","required":["offset","count"],"properties":{"limit":{"type":"integer"},"offset":{"type":"integer"},"count":{"type":"integer"},"next_offset":{"type":"integer"}}}}
+}

--- a/schemas/v1/report-ack.json
+++ b/schemas/v1/report-ack.json
@@ -1,0 +1,5 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "title":"Trove report acknowledgement v1","type":"object","additionalProperties":true,
+  "required":["ok","services"],"properties":{"ok":{"type":"boolean"},"services":{"type":"integer"}}
+}

--- a/schemas/v1/report.json
+++ b/schemas/v1/report.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Trove agent report v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["agent", "host", "services"],
+  "properties": {
+    "agent": {"type":"object", "required":["name","platform","version"], "properties":{"name":{"type":"string"},"platform":{"type":"string","enum":["docker","kubernetes","proxmox","local"]},"version":{"type":"string"},"interval_seconds":{"type":"integer","minimum":0}}},
+    "host": {"type":"object", "required":["hostname"], "properties":{"hostname":{"type":"string"},"condition":{"type":"string"},"metrics":{"type":"object"},"meta":{"type":"object"}}},
+    "services": {"type":"array", "items":{"type":"object"}}
+  }
+}

--- a/schemas/v1/report.json
+++ b/schemas/v1/report.json
@@ -5,8 +5,66 @@
   "additionalProperties": true,
   "required": ["agent", "host", "services"],
   "properties": {
-    "agent": {"type":"object", "required":["name","platform","version"], "properties":{"name":{"type":"string"},"platform":{"type":"string","enum":["docker","kubernetes","proxmox","local"]},"version":{"type":"string"},"interval_seconds":{"type":"integer","minimum":0}}},
-    "host": {"type":"object", "required":["hostname"], "properties":{"hostname":{"type":"string"},"condition":{"type":"string"},"metrics":{"type":"object"},"meta":{"type":"object"}}},
-    "services": {"type":"array", "items":{"type":"object"}}
+    "agent": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "platform", "version"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1, "maxLength": 255},
+        "platform": {"type": "string", "enum": ["docker", "kubernetes", "proxmox", "local"]},
+        "version": {"type": "string", "maxLength": 255},
+        "interval_seconds": {"type": "integer", "minimum": 0}
+      }
+    },
+    "host": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["hostname"],
+      "properties": {
+        "hostname": {"type": "string", "minLength": 1, "maxLength": 255},
+        "condition": {"type": "string", "enum": ["normal", "warning", "critical", "unknown"]},
+        "metrics": {"type": "object"},
+        "meta": {"type": "object", "additionalProperties": {"type": "string"}}
+      }
+    },
+    "services": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/service"}
+    }
+  },
+  "$defs": {
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["external_id", "kind", "state", "health"],
+      "properties": {
+        "external_id": {"type": "string", "minLength": 1, "maxLength": 512},
+        "parent_external_id": {"type": "string", "maxLength": 512},
+        "name": {"type": "string", "maxLength": 255},
+        "kind": {
+          "type": "string",
+          "enum": ["container", "pod", "vm", "lxc", "process", "deployment", "statefulset", "daemonset"]
+        },
+        "image": {"type": "string", "maxLength": 2048},
+        "image_digest": {"type": "string"},
+        "state": {"type": "string", "minLength": 1, "maxLength": 128, "not": {"const": "removed"}},
+        "health": {"type": "string", "enum": ["healthy", "unhealthy", "unknown"]},
+        "health_detail": {"type": "string", "maxLength": 4096},
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["host", "container", "proto"],
+            "properties": {
+              "host": {"type": "integer"},
+              "container": {"type": "integer"},
+              "proto": {"type": "string"}
+            }
+          }
+        },
+        "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+      }
+    }
   }
 }

--- a/schemas/v1/services.json
+++ b/schemas/v1/services.json
@@ -1,0 +1,12 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "title":"Trove services response v1",
+  "type":"object","additionalProperties":true,
+  "required":["generated_at","hosts"],
+  "properties":{"generated_at":{"type":"string"},"hosts":{"type":"array","items":{"$ref":"#/$defs/host"}},"pagination":{"$ref":"#/$defs/pagination"}},
+  "$defs":{
+    "host":{"type":"object","required":["agent","hostname","platform","status","last_seen_at","agent_status","condition","metrics","meta","services"],"properties":{"agent":{"type":"string"},"hostname":{"type":"string"},"platform":{"type":"string"},"status":{"type":"string"},"last_seen_at":{},"agent_status":{"type":"string"},"condition":{"type":"string"},"metrics":{},"meta":{},"services":{"type":"array","items":{"$ref":"#/$defs/service"}}}},
+    "service":{"type":"object","required":["id","external_id","name","kind","image","state","health","freshness","ports","labels","first_seen_at","last_seen_at","updated_at"],"properties":{"id":{"type":"integer"},"external_id":{"type":"string"},"parent_external_id":{"type":"string"},"name":{"type":"string"},"kind":{"type":"string"},"image":{"type":"string"},"image_digest":{"type":"string"},"state":{"type":"string"},"health":{"type":"string"},"health_detail":{"type":"string"},"freshness":{"type":"string"},"latest_digest":{"type":"string"},"ports":{},"labels":{},"first_seen_at":{"type":"string"},"last_seen_at":{"type":"string"},"updated_at":{"type":"string"}}},
+    "pagination":{"type":"object","required":["offset","count"],"properties":{"limit":{"type":"integer"},"offset":{"type":"integer"},"count":{"type":"integer"},"next_offset":{"type":"integer"}}}
+  }
+}

--- a/scripts/check_api_schema.py
+++ b/scripts/check_api_schema.py
@@ -16,22 +16,55 @@ def props(schema):
     return set(schema.get("properties", {}))
 
 
+def compare_schema(old, current, path, failures):
+    """Compare every nested schema object represented in the frozen baseline."""
+    if not isinstance(old, dict):
+        return
+    if not isinstance(current, dict):
+        failures.append(f"{path}: schema node was removed or changed shape")
+        return
+
+    old_type = old.get("type")
+    new_type = current.get("type")
+    if old_type != new_type:
+        failures.append(f"{path}: changed type {old_type!r} -> {new_type!r}")
+
+    old_props = old.get("properties", {})
+    new_props = current.get("properties", {})
+    missing = set(old_props) - set(new_props)
+    if missing:
+        failures.append(f"{path}: removed properties: {sorted(missing)}")
+    newly_required = set(current.get("required", [])) - set(old.get("required", []))
+    if newly_required:
+        failures.append(f"{path}: newly required fields: {sorted(newly_required)}")
+    for field in set(old_props) & set(new_props):
+        compare_schema(old_props[field], new_props[field], f"{path}.properties.{field}", failures)
+
+    old_defs = old.get("$defs", {})
+    new_defs = current.get("$defs", {})
+    missing_defs = set(old_defs) - set(new_defs)
+    if missing_defs:
+        failures.append(f"{path}: removed definitions: {sorted(missing_defs)}")
+    for name in set(old_defs) & set(new_defs):
+        compare_schema(old_defs[name], new_defs[name], f"{path}.$defs.{name}", failures)
+
+    if "items" in old:
+        if "items" not in current:
+            failures.append(f"{path}: removed array item schema")
+        else:
+            compare_schema(old["items"], current["items"], f"{path}.items", failures)
+
+    old_enum = set(old.get("enum", []))
+    new_enum = set(current.get("enum", []))
+    if old_enum and not old_enum.issubset(new_enum):
+        failures.append(f"{path}: removed enum values: {sorted(old_enum - new_enum)}")
+
+
 def check_additive():
     baseline = json.loads(BASELINE.read_text())
     failures = []
     for name, old in baseline.items():
-        current = load(name)
-        missing = props(old) - props(current)
-        if missing:
-            failures.append(f"{name}: removed properties: {sorted(missing)}")
-        required_missing = set(old.get("required", [])) - set(current.get("required", []))
-        if required_missing:
-            failures.append(f"{name}: baseline required fields changed: {sorted(required_missing)}")
-        for field in props(old) & props(current):
-            old_type = old["properties"][field].get("type")
-            new_type = current["properties"][field].get("type")
-            if old_type != new_type:
-                failures.append(f"{name}.{field}: changed type {old_type!r} -> {new_type!r}")
+        compare_schema(old, load(name), name, failures)
     return failures
 
 

--- a/scripts/check_api_schema.py
+++ b/scripts/check_api_schema.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Check the published v1 wire schemas for additive evolution and DTO drift."""
+import json, re, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "v1"
+BASELINE = SCHEMA / "baseline.json"
+
+
+def load(name):
+    return json.loads((SCHEMA / name).read_text())
+
+
+def props(schema):
+    return set(schema.get("properties", {}))
+
+
+def check_additive():
+    baseline = json.loads(BASELINE.read_text())
+    failures = []
+    for name, old in baseline.items():
+        current = load(name)
+        missing = props(old) - props(current)
+        if missing:
+            failures.append(f"{name}: removed properties: {sorted(missing)}")
+        required_missing = set(old.get("required", [])) - set(current.get("required", []))
+        if required_missing:
+            failures.append(f"{name}: baseline required fields changed: {sorted(required_missing)}")
+        for field in props(old) & props(current):
+            old_type = old["properties"][field].get("type")
+            new_type = current["properties"][field].get("type")
+            if old_type != new_type:
+                failures.append(f"{name}.{field}: changed type {old_type!r} -> {new_type!r}")
+    return failures
+
+
+def check_dto(source, type_name, schema_name, definition=None):
+    text = (ROOT / source).read_text()
+    match = re.search(r"type\s+" + re.escape(type_name) + r"\s+struct\s*\{(.*?)\n\}", text, re.S)
+    if not match:
+        return [f"could not find Go DTO {type_name}"]
+    go_fields = set()
+    for line in match.group(1).splitlines():
+        m = re.search(r"^\s*\w+\s+[^`]+`json:\"([^,\"]+)", line)
+        if m and m.group(1) != "-":
+            go_fields.add(m.group(1))
+    schema = load(schema_name)
+    if definition:
+        schema = schema["$defs"][definition]
+    schema_fields = props(schema)
+    missing = go_fields - schema_fields
+    extra = schema_fields - go_fields
+    failures = []
+    if missing:
+        failures.append(f"{schema_name}: DTO fields missing from schema: {sorted(missing)}")
+    if extra:
+        failures.append(f"{schema_name}: schema fields missing from DTO: {sorted(extra)}")
+    return failures
+
+
+def check_fixture(path, schema):
+    value = json.loads(path.read_text())
+    failures = []
+    for field in schema.get("required", []):
+        if field not in value:
+            failures.append(f"{path.name}: missing required field {field}")
+    return failures
+
+
+def main():
+    failures = check_additive()
+    failures += check_dto("internal/server/read.go", "serviceDTO", "services.json", "service")
+    failures += check_dto("internal/server/read.go", "hostGroupDTO", "services.json", "host")
+    failures += check_dto("internal/server/read.go", "agentDTO", "agents.json", "agent")
+    failures += check_dto("internal/server/read.go", "eventDTO", "events.json", "event")
+    report = load("report.json")
+    for fixture in sorted((ROOT / "internal/server/testdata").glob("report-v*.json")):
+        failures += check_fixture(fixture, report)
+    if failures:
+        print("API schema check failed:", *failures, sep="\n- ")
+        return 1
+    print("API schemas: additive baseline, DTO fields, and report fixtures passed")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Publishes additive v1 JSON Schemas for agent reports and supported API responses, documents compatibility rules, and adds a CI drift/fixture gate. Frozen previous-release report fixtures and DTO field checks were validated before handoff.