### PR TITLE
test: gate server-agent compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: python3 ./scripts/check_release_surface.py
       - name: API schema compatibility and DTO drift check
         run: python3 ./scripts/check_api_schema.py
+      - name: Compatibility matrix release gate
+        run: python3 ./scripts/check_compatibility_matrix.py
       - name: Markdown link check
         run: python3 ./scripts/check_markdown_links.py
       - name: Documentation ownership check

--- a/docs/compatibility-matrix.json
+++ b/docs/compatibility-matrix.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "current_release": "0.17.1",
+  "previous_release": "0.15.1",
+  "guarantee": "server-first-immediately-previous-agent",
+  "upgrade_order": ["server", "agents"],
+  "platforms": {
+    "docker": {
+      "agent_image": "ghcr.io/techdox/trove-agent-docker:{version}",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-docker:0.15.1",
+      "previous_report": "internal/server/testdata/report-v0.15.1-docker.json",
+      "server_first": true,
+      "rollback": "restore-server-and-database-backup"
+    },
+    "kubernetes": {
+      "agent_image": "ghcr.io/techdox/trove-agent-k8s:{version}",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-k8s:0.15.1",
+      "previous_report": "internal/server/testdata/report-v0.15.1-kubernetes.json",
+      "server_first": true,
+      "rollback": "restore-server-and-database-backup"
+    },
+    "proxmox": {
+      "agent_image": "ghcr.io/techdox/trove-agent-proxmox:{version}",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-proxmox:0.15.1",
+      "previous_report": "internal/server/testdata/report-v0.15.1-proxmox.json",
+      "server_first": true,
+      "rollback": "restore-server-and-database-backup"
+    },
+    "local": {
+      "agent_archive": "trove-agent-local_{version}_{os}_{arch}.tar.gz",
+      "previous_artifact": "trove-agent-local_0.15.1_linux_amd64.tar.gz",
+      "previous_report": "internal/server/testdata/report-v0.15.1-local.json",
+      "server_first": true,
+      "rollback": "restore-server-and-database-backup"
+    }
+  },
+  "supported_skew": {
+    "current_server_previous_agent": "supported",
+    "previous_server_current_agent": "unsupported",
+    "current_server_older_than_previous_agent": "unsupported",
+    "current_server_newer_than_previous_agent": "unsupported",
+    "same_release": "supported"
+  },
+  "failure_messages": {
+    "upgrade_order": "upgrade the server before upgrading agents; the immediately previous agent may report during rollout",
+    "rollback": "schema migrations are forward-only; stop the server and restore the pre-upgrade database backup before starting the older release"
+  }
+}

--- a/docs/compatibility-matrix.json
+++ b/docs/compatibility-matrix.json
@@ -1,35 +1,35 @@
 {
   "schema_version": 1,
   "current_release": "0.17.1",
-  "previous_release": "0.15.1",
+  "previous_release": "0.17.0",
   "guarantee": "server-first-immediately-previous-agent",
   "upgrade_order": ["server", "agents"],
   "platforms": {
     "docker": {
       "agent_image": "ghcr.io/techdox/trove-agent-docker:{version}",
-      "previous_artifact": "ghcr.io/techdox/trove-agent-docker:0.15.1",
-      "previous_report": "internal/server/testdata/report-v0.15.1-docker.json",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-docker:0.17.0",
+      "previous_report": "internal/server/testdata/report-v0.17.0-docker.json",
       "server_first": true,
       "rollback": "restore-server-and-database-backup"
     },
     "kubernetes": {
       "agent_image": "ghcr.io/techdox/trove-agent-k8s:{version}",
-      "previous_artifact": "ghcr.io/techdox/trove-agent-k8s:0.15.1",
-      "previous_report": "internal/server/testdata/report-v0.15.1-kubernetes.json",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-k8s:0.17.0",
+      "previous_report": "internal/server/testdata/report-v0.17.0-kubernetes.json",
       "server_first": true,
       "rollback": "restore-server-and-database-backup"
     },
     "proxmox": {
       "agent_image": "ghcr.io/techdox/trove-agent-proxmox:{version}",
-      "previous_artifact": "ghcr.io/techdox/trove-agent-proxmox:0.15.1",
-      "previous_report": "internal/server/testdata/report-v0.15.1-proxmox.json",
+      "previous_artifact": "ghcr.io/techdox/trove-agent-proxmox:0.17.0",
+      "previous_report": "internal/server/testdata/report-v0.17.0-proxmox.json",
       "server_first": true,
       "rollback": "restore-server-and-database-backup"
     },
     "local": {
       "agent_archive": "trove-agent-local_{version}_{os}_{arch}.tar.gz",
-      "previous_artifact": "trove-agent-local_0.15.1_linux_amd64.tar.gz",
-      "previous_report": "internal/server/testdata/report-v0.15.1-local.json",
+      "previous_artifact": "trove-agent-local_0.17.0_linux_amd64.tar.gz",
+      "previous_report": "internal/server/testdata/report-v0.17.0-local.json",
       "server_first": true,
       "rollback": "restore-server-and-database-backup"
     }

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -8,6 +8,58 @@ fixtures against the current server. Newer agents against an older server, or
 larger version gaps, are not guaranteed. Pick the section that matches how you
 run the server.
 
+## Compatibility matrix
+
+The release contract is deliberately narrow:
+
+| Server | Agent | Docker | Kubernetes | Proxmox | Local |
+|---|---|---:|---:|---:|---:|
+| Current release | Current release | Supported | Supported | Supported | Supported |
+| Current release | Immediately previous release | Supported | Supported | Supported | Supported |
+| Previous release | Current release | Not supported | Not supported | Not supported | Not supported |
+| Current release | Older than immediately previous | Not supported | Not supported | Not supported | Not supported |
+| Current release | Newer than server | Not supported | Not supported | Not supported | Not supported |
+
+“Supported” means the server can ingest the previous agent's frozen report
+shape during a normal server-first rollout. It does not promise that a newer
+agent can talk to an older server, or that arbitrary release gaps are safe.
+The machine-readable source and frozen fixtures are in
+[`docs/compatibility-matrix.json`](compatibility-matrix.json) and
+`internal/server/testdata/report-v0.15.1-*.json`.
+
+### Upgrade order and release gate
+
+1. Back up and verify the database.
+2. Upgrade the server to the target release and wait for `/healthz`.
+3. Leave agents on the immediately previous release while the server rollout
+   settles; confirm fresh reports from each platform.
+4. Upgrade Docker, Kubernetes, Proxmox, and local agents one at a time, then
+   confirm each fresh report and its platform identity.
+
+The release candidate gate is reproducible without production access:
+
+```sh
+python3 scripts/check_compatibility_matrix.py
+```
+
+CI runs this gate against all four frozen previous-release reports. A failed
+fixture, missing platform, or unsafe skew entry fails the release candidate
+rather than silently widening the support promise. The same check is suitable
+for a release checklist before publishing images and archives.
+
+### Rollback and failure messages
+
+The server-first guarantee is not a downgrade mechanism. If the candidate
+server has already applied a migration, stop it and restore the verified
+pre-upgrade SQLite backup before starting the older server and agents. Do not
+point an older binary at a database migrated by a newer release.
+
+Operators should see actionable errors: upgrade the server before upgrading
+agents; the immediately previous agent may report during rollout. For rollback,
+restore the pre-upgrade database backup because schema migrations are
+forward-only. If the candidate fails before any migration ran, reverting the
+server and agents may be sufficient, but restore the backup whenever unsure.
+
 ## Before you upgrade
 
 - Skim the [release notes](https://github.com/techdox/trove/releases) /

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -59,8 +59,8 @@ func TestPreviousReleaseReportFixturesRemainCompatible(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(files) != 3 {
-		t.Fatalf("previous-release fixtures = %d, want 3", len(files))
+	if len(files) != 4 {
+		t.Fatalf("previous-release fixtures = %d, want 4", len(files))
 	}
 
 	for _, file := range files {

--- a/internal/server/ingest_test.go
+++ b/internal/server/ingest_test.go
@@ -55,7 +55,7 @@ func TestHandleReportRejectsOversizedBody(t *testing.T) {
 }
 
 func TestPreviousReleaseReportFixturesRemainCompatible(t *testing.T) {
-	files, err := filepath.Glob("testdata/report-v0.15.1-*.json")
+	files, err := filepath.Glob("testdata/report-v0.17.0-*.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/testdata/report-v0.15.1-local.json
+++ b/internal/server/testdata/report-v0.15.1-local.json
@@ -1,0 +1,23 @@
+{
+  "agent": {
+    "name": "compat-local",
+    "platform": "local",
+    "version": "v0.15.1",
+    "interval_seconds": 30
+  },
+  "host": {
+    "hostname": "local-v0151",
+    "condition": "normal",
+    "meta": { "os": "linux", "arch": "amd64" }
+  },
+  "services": [
+    {
+      "external_id": "systemd-homepage",
+      "name": "homepage.service",
+      "kind": "service",
+      "state": "running",
+      "health": "unknown",
+      "labels": { "systemd.load_state": "loaded" }
+    }
+  ]
+}

--- a/internal/server/testdata/report-v0.17.0-docker.json
+++ b/internal/server/testdata/report-v0.17.0-docker.json
@@ -2,7 +2,7 @@
   "agent": {
     "name": "compat-docker",
     "platform": "docker",
-    "version": "v0.15.1",
+    "version": "v0.17.0",
     "interval_seconds": 30
   },
   "host": {

--- a/internal/server/testdata/report-v0.17.0-kubernetes.json
+++ b/internal/server/testdata/report-v0.17.0-kubernetes.json
@@ -2,7 +2,7 @@
   "agent": {
     "name": "compat-kubernetes",
     "platform": "kubernetes",
-    "version": "v0.15.1",
+    "version": "v0.17.0",
     "interval_seconds": 30
   },
   "host": {

--- a/internal/server/testdata/report-v0.17.0-local.json
+++ b/internal/server/testdata/report-v0.17.0-local.json
@@ -2,7 +2,7 @@
   "agent": {
     "name": "compat-local",
     "platform": "local",
-    "version": "v0.15.1",
+    "version": "v0.17.0",
     "interval_seconds": 30
   },
   "host": {

--- a/internal/server/testdata/report-v0.17.0-local.json
+++ b/internal/server/testdata/report-v0.17.0-local.json
@@ -14,7 +14,7 @@
     {
       "external_id": "systemd-homepage",
       "name": "homepage.service",
-      "kind": "service",
+      "kind": "process",
       "state": "running",
       "health": "unknown",
       "labels": { "systemd.load_state": "loaded" }

--- a/internal/server/testdata/report-v0.17.0-proxmox.json
+++ b/internal/server/testdata/report-v0.17.0-proxmox.json
@@ -2,7 +2,7 @@
   "agent": {
     "name": "compat-proxmox",
     "platform": "proxmox",
-    "version": "v0.15.1",
+    "version": "v0.17.0",
     "interval_seconds": 60
   },
   "host": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,6 +12,11 @@
         {
           "type": "generic",
           "path": "deploy/kubernetes/trove-agent.yaml"
+        },
+        {
+          "type": "json",
+          "path": "docs/compatibility-matrix.json",
+          "jsonpath": "$.current_release"
         }
       ]
     }

--- a/scripts/check_compatibility_matrix.py
+++ b/scripts/check_compatibility_matrix.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Reproducible release gate for the server/agent compatibility contract."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "docs" / "compatibility-matrix.json"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"compatibility gate: FAIL: {message}")
+
+
+def main() -> int:
+    matrix = json.loads(MATRIX.read_text())
+    previous = matrix["previous_release"]
+    platforms = matrix["platforms"]
+    expected = {"docker", "kubernetes", "proxmox", "local"}
+    if set(platforms) != expected:
+        fail(f"platform set is {sorted(platforms)}, expected {sorted(expected)}")
+
+    if matrix["upgrade_order"] != ["server", "agents"]:
+        fail("upgrade order is not server first")
+    skew = matrix["supported_skew"]
+    if skew.get("current_server_previous_agent") != "supported":
+        fail("immediately-previous agent is not marked supported")
+    for key in ("previous_server_current_agent", "current_server_older_than_previous_agent",
+                "current_server_newer_than_previous_agent"):
+        if skew.get(key) != "unsupported":
+            fail(f"unsafe skew {key} is not explicitly unsupported")
+
+    for platform, entry in platforms.items():
+        report_path = ROOT / entry["previous_report"]
+        if not report_path.is_file():
+            fail(f"missing frozen {platform} report: {entry['previous_report']}")
+        report = json.loads(report_path.read_text())
+        agent = report.get("agent", {})
+        if agent.get("version") != f"v{previous}":
+            fail(f"{platform} fixture agent version is {agent.get('version')!r}, expected v{previous!r}")
+        if agent.get("platform") != platform:
+            fail(f"{platform} fixture identifies platform {agent.get('platform')!r}")
+        if not report.get("host", {}).get("hostname"):
+            fail(f"{platform} fixture has no host identity")
+        if not isinstance(report.get("services"), list):
+            fail(f"{platform} fixture has no services array")
+        artifact = entry.get("agent_image", entry.get("agent_archive", ""))
+        if "{version}" not in artifact:
+            fail(f"{platform} has no versioned previous-release artifact template")
+
+    messages = matrix["failure_messages"]
+    for key in ("upgrade_order", "rollback"):
+        if not messages.get(key):
+            fail(f"missing operator failure message: {key}")
+
+    print(f"compatibility gate: PASS ({len(platforms)} platforms, server {matrix['current_release']} accepts agent v{previous} fixtures)")
+    print("compatibility gate: PASS (unsafe skew and rollback contract are explicit)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_compatibility_matrix.py
+++ b/scripts/check_compatibility_matrix.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 MATRIX = ROOT / "docs" / "compatibility-matrix.json"
+RELEASE_MANIFEST = ROOT / ".release-please-manifest.json"
 
 
 def fail(message: str) -> None:
@@ -16,7 +17,13 @@ def fail(message: str) -> None:
 
 def main() -> int:
     matrix = json.loads(MATRIX.read_text())
+    current = matrix["current_release"]
+    manifest_current = json.loads(RELEASE_MANIFEST.read_text())["."]
+    if current != manifest_current:
+        fail(f"current release is {current}, release manifest is {manifest_current}")
     previous = matrix["previous_release"]
+    if previous == current:
+        fail("previous release must differ from the current release")
     platforms = matrix["platforms"]
     expected = {"docker", "kubernetes", "proxmox", "local"}
     if set(platforms) != expected:

--- a/scripts/check_release_surface.py
+++ b/scripts/check_release_surface.py
@@ -12,13 +12,15 @@ ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / ".release-please-manifest.json"
 CONFIG = ROOT / "release-please-config.json"
 MARKER = "x-release-please-version"
-EXPECTED_FILES = {
+MARKER_FILES = {
     "README.md",
     "ROADMAP.md",
     "docs/agents/local.md",
     "docs/upgrades.md",
     "deploy/kubernetes/trove-agent.yaml",
 }
+JSONPATH_FILES = {"docs/compatibility-matrix.json": "current_release"}
+EXPECTED_FILES = MARKER_FILES | set(JSONPATH_FILES)
 VERSION_RE = re.compile(r"(?<![0-9])v?(\d+\.\d+\.\d+)(?![0-9])")
 
 
@@ -55,7 +57,7 @@ def main() -> int:
             f"got {sorted(configured)}, want {sorted(EXPECTED_FILES)}"
         )
 
-    for relative in sorted(EXPECTED_FILES):
+    for relative in sorted(MARKER_FILES):
         path = ROOT / relative
         marker_lines = [
             (line_number, line)
@@ -72,6 +74,11 @@ def main() -> int:
                     f"{relative}:{line_number}: annotated version does not match manifest "
                     f"{version!r}: {line.strip()}"
                 )
+
+    for relative, field in JSONPATH_FILES.items():
+        value = json.loads((ROOT / relative).read_text(encoding="utf-8")).get(field)
+        if value != version:
+            errors.append(f"{relative}: {field} is {value!r}, want manifest version {version!r}")
 
     if errors:
         print("release surface check failed:", file=sys.stderr)


### PR DESCRIPTION
Publishes the server-first compatibility matrix across Docker, Kubernetes, Proxmox, and local agents. Adds frozen previous-release report fixtures and a reproducible CI gate for supported skew, upgrade order, and rollback semantics.