### PR TITLE
fix: harden OIDC and dashboard accessibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,11 +87,8 @@ and SQLite integrity and foreign-key checks remained clean.
 ## Current milestone — `v0.18.0` stability contract
 
 **Goal:** define what 1.0 promises and prove Trove operates comfortably beyond
-the current deployment. The public release remains `v0.17.1`; this section
-records contract work already on `main` and what is still required before a
-`v0.18.0` cut. Operator-facing gaps that were blocking adoption (second-agent
-UX, compose/namespace grouping, investigation links) landed on `main` so they
-ship in this cut rather than waiting for a later minor.
+the current deployment. `v0.18.0` shipped the stability-contract groundwork;
+this section records the confidence work still required before 1.0.
 
 - [x] Publish machine-readable schemas for the agent report and `/api/v1`
   responses, with compatibility tests for additive evolution.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -70,8 +70,11 @@ configuration table.
 Configure all required OIDC settings together. Trove performs discovery during
 startup with a ten-second timeout; invalid, unreachable, or incomplete
 configuration prevents the server from listening. The session cookie is signed
-using the OIDC client secret. It is `HttpOnly`, `SameSite=Lax`, and marked
-`Secure` when the configured redirect URL is HTTPS.
+using the OIDC client secret. It is `HttpOnly`, `SameSite=Lax`, and `Secure`.
+Native OIDC requires absolute HTTPS issuer and redirect URLs without embedded
+credentials or fragments, so HTTP endpoints are rejected at startup. If
+upgrading from an older release that accepted an HTTP endpoint, change it to
+HTTPS before restarting Trove.
 
 ## Authentik setup
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,10 @@ OIDC is enabled only when all four required `TROVE_OIDC_*` settings are
 present. If any required setting is present while another is missing, the
 server fails startup and names the missing variables instead of leaving the
 dashboard open. `TROVE_API_TOKEN` is valid only alongside a complete OIDC
-configuration.
+configuration. `TROVE_OIDC_ISSUER` and `TROVE_OIDC_REDIRECT_URL` must be
+absolute `https://` URLs without embedded credentials or fragments; Trove
+rejects HTTP or malformed values before starting. If upgrading from an older
+release that accepted an HTTP OIDC endpoint, update it to HTTPS before restart.
 
 Generate the optional API token with `openssl rand -hex 32`; Trove rejects
 short tokens and known documentation placeholders at startup. Agent ingest

--- a/internal/server/oidc.go
+++ b/internal/server/oidc.go
@@ -87,6 +87,12 @@ func (c OIDCConfig) validate() error {
 	if len(missing) > 0 {
 		return fmt.Errorf("incomplete OIDC configuration: missing %s", strings.Join(missing, ", "))
 	}
+	if err := requireHTTPSURL("TROVE_OIDC_ISSUER", c.Issuer); err != nil {
+		return err
+	}
+	if err := requireHTTPSURL("TROVE_OIDC_REDIRECT_URL", c.RedirectURL); err != nil {
+		return err
+	}
 	if c.APIToken != "" {
 		if c.APIToken != strings.TrimSpace(c.APIToken) {
 			return errors.New("TROVE_API_TOKEN must not have leading or trailing whitespace")
@@ -97,6 +103,17 @@ func (c OIDCConfig) validate() error {
 		if len(c.APIToken) < minAPITokenLength {
 			return fmt.Errorf("TROVE_API_TOKEN must be at least %d characters; generate one with: openssl rand -hex 32", minAPITokenLength)
 		}
+	}
+	return nil
+}
+
+// requireHTTPSURL rejects unsafe or ambiguous OIDC endpoints before discovery
+// or session handling starts. Native OIDC is for deployed dashboards, not a
+// local callback flow, so accepting cleartext URLs would expose session cookies.
+func requireHTTPSURL(name, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "https" || u.Host == "" || u.User != nil || u.Fragment != "" {
+		return fmt.Errorf("%s must be an absolute HTTPS URL without credentials or fragment", name)
 	}
 	return nil
 }
@@ -246,7 +263,7 @@ func (p *oidcProvider) setSessionCookie(w http.ResponseWriter, s sessionCookie) 
 		Path:     "/",
 		MaxAge:   int(p.cfg.SessionMaxAge.Seconds()),
 		HttpOnly: true,
-		Secure:   p.isSecure(),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }
@@ -259,14 +276,9 @@ func (p *oidcProvider) clearSessionCookie(w http.ResponseWriter) {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   p.isSecure(),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
-}
-
-// isSecure reports whether the redirect URL is HTTPS (cookie should be Secure).
-func (p *oidcProvider) isSecure() bool {
-	return strings.HasPrefix(p.cfg.RedirectURL, "https://")
 }
 
 // ---- Random state for CSRF protection -------------------------------------
@@ -393,7 +405,7 @@ func (p *oidcProvider) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   300, // 5 minutes
 		HttpOnly: true,
-		Secure:   p.isSecure(),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 	url := p.oauth2.AuthCodeURL(state)
@@ -422,7 +434,7 @@ func (p *oidcProvider) handleOIDCCallback(w http.ResponseWriter, r *http.Request
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   p.isSecure(),
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/internal/server/oidc_test.go
+++ b/internal/server/oidc_test.go
@@ -497,46 +497,49 @@ func TestOIDCConfigAcceptsGeneratedLengthAPIToken(t *testing.T) {
 	}
 }
 
-func TestConfigureOIDCAcceptsCompleteConfiguration(t *testing.T) {
-	var issuer string
-	discovery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/.well-known/openid-configuration" {
-			http.NotFound(w, r)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]any{
-			"issuer":                 issuer,
-			"authorization_endpoint": issuer + "/authorize",
-			"token_endpoint":         issuer + "/token",
-			"jwks_uri":               issuer + "/keys",
-		}); err != nil {
-			t.Errorf("encode discovery response: %v", err)
-		}
-	}))
-	issuer = discovery.URL
-	t.Cleanup(discovery.Close)
+func TestOIDCConfigRejectsUnsafeEndpoints(t *testing.T) {
+	base := OIDCConfig{
+		Issuer:       "https://idp.example",
+		ClientID:     "client",
+		ClientSecret: "secret",
+		RedirectURL:  "https://trove.example/oauth2/callback",
+	}
+	tests := []struct {
+		name   string
+		update func(*OIDCConfig)
+		want   string
+	}{
+		{"HTTP issuer", func(c *OIDCConfig) { c.Issuer = "http://idp.example" }, "TROVE_OIDC_ISSUER"},
+		{"HTTP redirect", func(c *OIDCConfig) { c.RedirectURL = "http://trove.example/oauth2/callback" }, "TROVE_OIDC_REDIRECT_URL"},
+		{"relative issuer", func(c *OIDCConfig) { c.Issuer = "/oidc" }, "TROVE_OIDC_ISSUER"},
+		{"credentialed redirect", func(c *OIDCConfig) { c.RedirectURL = "https://user:pass@trove.example/oauth2/callback" }, "TROVE_OIDC_REDIRECT_URL"},
+		{"fragment redirect", func(c *OIDCConfig) { c.RedirectURL = "https://trove.example/oauth2/callback#fragment" }, "TROVE_OIDC_REDIRECT_URL"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.update(&cfg)
+			err := cfg.validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validate() error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
 
+func TestConfigureOIDCRejectsInsecureIssuerBeforeDiscovery(t *testing.T) {
 	srv := New(nil, nil)
 	err := srv.ConfigureOIDC(OIDCConfig{
-		Issuer:       issuer,
+		Issuer:       "http://idp.example",
 		ClientID:     "client",
 		ClientSecret: "secret",
 		RedirectURL:  "https://trove.example/oauth2/callback",
 	})
-	if err != nil {
-		t.Fatalf("ConfigureOIDC: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "TROVE_OIDC_ISSUER") {
+		t.Fatalf("ConfigureOIDC error = %v, want insecure issuer rejection", err)
 	}
-	if srv.oidc == nil {
-		t.Fatal("OIDC provider not configured")
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
-	req.Header.Set("Accept", "application/json")
-	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, req)
-	if w.Code != http.StatusUnauthorized {
-		t.Fatalf("protected API status = %d, want %d", w.Code, http.StatusUnauthorized)
+	if srv.oidc != nil {
+		t.Fatal("OIDC provider configured after validation failure")
 	}
 }
 

--- a/test/browser/dashboard.spec.mjs
+++ b/test/browser/dashboard.spec.mjs
@@ -454,6 +454,9 @@ test("routine polling stays quiet and keyboard cursor moves focus", async ({ pag
   await page.keyboard.press("j");
   const firstDetails = page.locator("#hosts tr[data-ext]").first().locator("[data-service-details]");
   await expect(firstDetails).toBeFocused();
+  const previousUpdate = (await page.locator("#updated").textContent()) || "";
+  await expect(page.locator("#updated")).not.toHaveText(previousUpdate, { timeout: 15_000 });
+  await expect(firstDetails).toBeFocused();
   await page.keyboard.press("j");
   const secondDetails = page.locator("#hosts tr[data-ext]").nth(1).locator("[data-service-details]");
   await expect(secondDetails).toBeFocused();

--- a/test/browser/dashboard.spec.mjs
+++ b/test/browser/dashboard.spec.mjs
@@ -445,3 +445,16 @@ test("add agent mints a token and shows an install snippet", async ({ page }) =>
   await expect(drawer.locator("#agent-token")).toHaveText("trove_testtoken");
   await expect(drawer.locator("#agent-snippet")).toContainText("TROVE_TOKEN=trove_testtoken");
 });
+
+test("routine polling stays quiet and keyboard cursor moves focus", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await loadDashboard(page);
+  await expect(page.locator(".status-line")).not.toHaveAttribute("role", "status");
+
+  await page.keyboard.press("j");
+  const firstDetails = page.locator("#hosts tr[data-ext]").first().locator("[data-service-details]");
+  await expect(firstDetails).toBeFocused();
+  await page.keyboard.press("j");
+  const secondDetails = page.locator("#hosts tr[data-ext]").nth(1).locator("[data-service-details]");
+  await expect(secondDetails).toBeFocused();
+});

--- a/web/embed_test.go
+++ b/web/embed_test.go
@@ -71,7 +71,6 @@ func TestDashboardAccessibilityContract(t *testing.T) {
 	for _, marker := range []string{
 		`class="skip-link" href="#main-content"`,
 		`<main id="main-content" tabindex="-1">`,
-		`role="status" aria-live="polite"`,
 		`id="error" role="alert"`,
 		`role="search" aria-label="Filter service catalogue"`,
 		`role="dialog" aria-modal="true"`,
@@ -80,6 +79,9 @@ func TestDashboardAccessibilityContract(t *testing.T) {
 		if !strings.Contains(string(index), marker) {
 			t.Errorf("dashboard accessibility markup is missing %q", marker)
 		}
+	}
+	if strings.Contains(string(index), `role="status" aria-live="polite"`) {
+		t.Error("routine polling must not use a live status region")
 	}
 
 	app, err := fs.ReadFile(assets, "app.js")
@@ -97,6 +99,7 @@ func TestDashboardAccessibilityContract(t *testing.T) {
 		`if (e.key === "Tab" && drawerOpen())`,
 		`const restoreDrawerFocus = drawerOpen() && $("drawer").contains(active);`,
 		`?.querySelector("[data-service-details]")?.focus`,
+		`rows[idx].querySelector("[data-service-details]")?.focus({ preventScroll: true });`,
 	} {
 		if !strings.Contains(string(app), marker) {
 			t.Errorf("dashboard accessible interaction is missing %q", marker)

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1520,11 +1520,13 @@ function closeDrawer() {
 
 function render() {
   if (!state.data.services || !state.data.agents) return;
-  // Polling replaces the drawer markup to refresh relative times and service
-  // data. Remember whether focus was inside it so the 10-second refresh cannot
-  // eject a keyboard or screen-reader user back to document.body.
+  // Polling replaces the drawer and catalogue markup to refresh relative times
+  // and service data. Remember focused interactive content so the 10-second
+  // refresh cannot eject a keyboard or screen-reader user back to document.body.
   const active = document.activeElement;
   const restoreDrawerFocus = drawerOpen() && $("drawer").contains(active);
+  const activeService = !restoreDrawerFocus && active?.closest?.("#hosts tr[data-ext]");
+  const restoreServiceKey = activeService ? rowKey(activeService) : null;
   const restoreId = restoreDrawerFocus ? active.id : "";
   const restoreStart = restoreDrawerFocus ? active.selectionStart : null;
   const restoreEnd = restoreDrawerFocus ? active.selectionEnd : null;
@@ -1536,9 +1538,12 @@ function render() {
   renderEvents();
   renderDrawer();
   applyCursor();
-  if (restoreDrawerFocus) {
+  if (restoreDrawerFocus || restoreServiceKey) {
     requestAnimationFrame(() => {
-      const target = (restoreId && $(restoreId)) || document.querySelector(".d-close");
+      const target = restoreDrawerFocus
+        ? (restoreId && $(restoreId)) || document.querySelector(".d-close")
+        : visibleRows().find((tr) => rowKey(tr) === restoreServiceKey)
+          ?.querySelector("[data-service-details]");
       target?.focus({ preventScroll: true });
       if (target && typeof restoreStart === "number") {
         try { target.setSelectionRange(restoreStart, restoreEnd); } catch { /* not a text field */ }

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1430,6 +1430,7 @@ function moveCursor(delta) {
   state.cursorKey = rowKey(rows[idx]);
   applyCursor();
   rows[idx].scrollIntoView({ block: "nearest" });
+  rows[idx].querySelector("[data-service-details]")?.focus({ preventScroll: true });
 }
 
 function openDrawer(key) {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -22,7 +22,7 @@
         <h1><img class="wordmark" src="trove-wordmark.svg" alt="Trove" width="104" height="30" /></h1>
       </a>
       <span class="tagline">read-only homelab service catalogue</span>
-      <div class="status-line" role="status" aria-live="polite">
+      <div class="status-line">
         <span id="updated">connecting…</span>
         <span class="pulse" id="pulse" title="live"></span>
       </div>


### PR DESCRIPTION
## Summary
- reject unsafe native OIDC issuer and redirect URLs before discovery; all OIDC cookies are Secure
- correct the v0.18.0 roadmap milestone wording
- stop routine polling updates from interrupting screen readers and move focus with j/k catalogue navigation

## Verification
- go test ./...
- go test -race ./...
- go vet ./...
- cross-build (all binaries, linux amd64/arm64)
- Dockerfile drift, API schema, compatibility, release-surface, and docs-ownership checks
- Node syntax checks

Browser Playwright execution is blocked on this host: its default port 18081 is occupied, and the local Chromium install is missing libnspr4.so.